### PR TITLE
Add specific third party warnings to filterwarnings to reduce noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This repository contains core of the new reservation platform for city of Helsin
 
 # Running tests and formatting
 
-Tests are run with pytest. You can just run pytest to run all the test. 
+Tests are run with pytest. Use `pytest` to run all tests. Use `pytest -W default` to show third party warnings ignored in `pytest.ini`.
 
 To run static code checks and tests with coverage:
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=tilavarauspalvelu.settings
 python_files = tests.py test_*.py *_tests.py
+filterwarnings =
+    ignore:.*collections.*:DeprecationWarning:graphene
+    ignore:.*ugettext_lazy.*::recurrence
+    ignore:.*No directory at.*:UserWarning:whitenoise

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -86,9 +86,9 @@ TEMPLATES = [
 WSGI_APPLICATION = "tilavarauspalvelu.wsgi.application"
 
 
-root = environ.Path(__file__)
+root = environ.Path(BASE_DIR)
 
-env = environ.Env(DEBUG=(bool, False), STATIC_ROOT=(environ.Path(), root("static")))
+env = environ.Env(DEBUG=(bool, False), STATIC_ROOT=(environ.Path(), root("staticroot")))
 environ.Env.read_env()
 
 # Database


### PR DESCRIPTION
This should make it easier to see and fix project level warnings.