### PR TITLE
TILA-211 | Take space hierachy in account for reservation overlap checks

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -54,8 +54,28 @@ def resource():
 
 
 @pytest.fixture
-def space(location):
-    return Space.objects.create(name="Space", location=location)
+def parent_space(location):
+    return Space.objects.create(name="Parent space", location=location)
+
+
+@pytest.fixture
+def space(location, parent_space):
+    return Space.objects.create(name="Space", location=location, parent=parent_space)
+
+
+@pytest.fixture
+def child_space(location, space):
+    return Space.objects.create(name="Child space", location=location, parent=space)
+
+
+@pytest.fixture
+def reservation_unit_with_parent_space(resource, parent_space):
+    reservation_unit = ReservationUnit.objects.create(
+        name="Parent space test reservation unit", require_introduction=False
+    )
+    reservation_unit.resources.set([resource])
+    reservation_unit.spaces.set([parent_space])
+    return reservation_unit
 
 
 @pytest.fixture
@@ -65,6 +85,24 @@ def reservation_unit(resource, space):
     )
     reservation_unit.resources.set([resource])
     reservation_unit.spaces.set([space])
+    return reservation_unit
+
+
+@pytest.fixture
+def reservation_unit_with_child_space(resource, child_space):
+    reservation_unit = ReservationUnit.objects.create(
+        name="Child space test reservation unit", require_introduction=False
+    )
+    reservation_unit.spaces.set([child_space])
+    return reservation_unit
+
+
+@pytest.fixture
+def reservation_unit_with_resource(resource, space):
+    reservation_unit = ReservationUnit.objects.create(
+        name="Test reservation unit with resource", require_introduction=False
+    )
+    reservation_unit.resources.set([resource])
     return reservation_unit
 
 

--- a/api/tests/test_reservation_api.py
+++ b/api/tests/test_reservation_api.py
@@ -31,6 +31,78 @@ def test_reservation_overlapping(user_api_client, reservation, valid_reservation
 
 
 @pytest.mark.django_db
+def test_reservation_overlapping_with_child_space(
+    user_api_client,
+    confirmed_reservation,
+    valid_reservation_data,
+    reservation_unit_with_child_space,
+):
+    """
+    Reservation begins 5 minutes before the initial reservation ends,
+    so this should return an error
+    """
+    valid_reservation_data["begin"] = confirmed_reservation.end - datetime.timedelta(
+        minutes=5
+    )
+    valid_reservation_data["end"] = confirmed_reservation.end + datetime.timedelta(
+        hours=1
+    )
+    valid_reservation_data["reservation_unit"] = [reservation_unit_with_child_space.pk]
+    response = user_api_client.post(
+        reverse("reservation-list"), data=valid_reservation_data, format="json"
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_reservation_overlapping_with_parent_space(
+    user_api_client,
+    confirmed_reservation,
+    valid_reservation_data,
+    reservation_unit_with_parent_space,
+):
+    """
+    Reservation begins 5 minutes before the initial reservation ends,
+    so this should return an error
+    """
+    valid_reservation_data["begin"] = confirmed_reservation.end - datetime.timedelta(
+        minutes=5
+    )
+    valid_reservation_data["end"] = confirmed_reservation.end + datetime.timedelta(
+        hours=1
+    )
+    valid_reservation_data["reservation_unit"] = [reservation_unit_with_parent_space.pk]
+    response = user_api_client.post(
+        reverse("reservation-list"), data=valid_reservation_data, format="json"
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
+def test_reservation_overlapping_with_same_resource(
+    user_api_client,
+    confirmed_reservation,
+    valid_reservation_data,
+    reservation_unit_with_resource,
+):
+    """
+    Reservation begins 5 minutes before the initial reservation ends,
+    so this should return an error
+    """
+    valid_reservation_data["begin"] = confirmed_reservation.end - datetime.timedelta(
+        minutes=5
+    )
+    valid_reservation_data["end"] = confirmed_reservation.end + datetime.timedelta(
+        hours=1
+    )
+    valid_reservation_data["reservation_unit"] = [reservation_unit_with_resource.pk]
+    response = user_api_client.post(
+        reverse("reservation-list"), data=valid_reservation_data, format="json"
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.django_db
 def test_reservation_fetch_should_filter_by_status(user_api_client, reservation):
 
     url = f"{reverse('reservation-list')}?state=created&state=cancelled"


### PR DESCRIPTION
This  makes reservation overlap checks to check whole hierarchy family of space objects so for example you cant reserve a whole house if one room of it is already reserved or vice versa. Also added tests.