### PR TITLE
TILA-279 | Document API endpoints as OpenAPI using DRF spectacular

### DIFF
--- a/api/application_period_api.py
+++ b/api/application_period_api.py
@@ -16,6 +16,29 @@ class ApplicationPeriodSerializer(serializers.ModelSerializer):
             "reservation_period_end",
             "purposes",
         ]
+        extra_kwargs = {
+            "name": {
+                "help_text": "Name that describes this event.",
+            },
+            "reservation_units": {
+                "help_text": "Ids of reservation units that can be applied during this period.",
+            },
+            "application_period_begin": {
+                "help_text": "Begin date and time of the period when applications can be sent.",
+            },
+            "application_period_end": {
+                "help_text": "End date and time of the period when applications can be sent.",
+            },
+            "reservation_period_begin": {
+                "help_text": "Begin date and time of the period where applied reservation are allocated.",
+            },
+            "reservation_period_end": {
+                "help_text": "End date and time of the period where applied reservation are allocated.",
+            },
+            "purposes": {
+                "help_text": "Ids of purposes that are allowed for events applied for this application period.",
+            },
+        }
 
 
 class ApplicationPeriodViewSet(viewsets.ReadOnlyModelViewSet):

--- a/api/applications_api.py
+++ b/api/applications_api.py
@@ -54,8 +54,18 @@ class OrganisationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Organisation
-
         fields = ["id", "name", "identifier", "year_established"]
+        extra_kwargs = {
+            "name": {
+                "help_text": "Official name of the organisation",
+            },
+            "identifier": {
+                "help_text": "Identifier of the organisation. Finnish y-tunnus.",
+            },
+            "year_established": {
+                "help_text": "Year when the organisation was established.",
+            },
+        }
 
 
 class PersonSerializer(serializers.ModelSerializer):
@@ -96,6 +106,18 @@ class ApplicationEventScheduleSerializer(serializers.ModelSerializer):
     class Meta:
         model = ApplicationEventSchedule
         fields = ["id", "day", "begin", "end"]
+        extra_kwargs = {
+            "day": {
+                "help_text": "Day of requested reservation allocation time slot for event represented as number. "
+                "0 = monday, 6 = sunday.",
+            },
+            "begin": {
+                "help_text": "Begin time of requested reservation allocation slot.",
+            },
+            "end": {
+                "help_text": "End time of requested reservation allocation slot.",
+            },
+        }
 
 
 class DateAwareRecurrenceReadSerializer(serializers.ModelSerializer):
@@ -130,6 +152,14 @@ class EventReservationUnitSerializer(serializers.ModelSerializer):
             "priority",
             "reservation_unit",
         ]
+        extra_kwargs = {
+            "priority": {
+                "help_text": "Priority of this reservation unit for the event. Lower the number, higher the priority.",
+            },
+            "reservation_unit": {
+                "help_text": "Id of the reservation unit requested for the event.",
+            },
+        }
 
 
 class ApplicationEventSerializer(serializers.ModelSerializer):
@@ -140,23 +170,37 @@ class ApplicationEventSerializer(serializers.ModelSerializer):
     )
 
     application_id = serializers.PrimaryKeyRelatedField(
-        queryset=Application.objects.all(), source="application"
+        queryset=Application.objects.all(),
+        source="application",
+        help_text="Id of the applications to which this single application event is targeted to.",
     )
 
     age_group_id = serializers.PrimaryKeyRelatedField(
-        queryset=AgeGroup.objects.all(), source="age_group", allow_null=True
+        queryset=AgeGroup.objects.all(),
+        source="age_group",
+        allow_null=True,
+        help_text="Id of the age group for this event.",
     )
 
     ability_group_id = serializers.PrimaryKeyRelatedField(
-        queryset=AbilityGroup.objects.all(), source="ability_group", allow_null=True
+        queryset=AbilityGroup.objects.all(),
+        source="ability_group",
+        allow_null=True,
+        help_text="Id of the ability group for this event.",
     )
 
     purpose_id = serializers.PrimaryKeyRelatedField(
-        queryset=Purpose.objects.all(), source="purpose", allow_null=True
+        queryset=Purpose.objects.all(),
+        source="purpose",
+        allow_null=True,
+        help_text="Id of the usa purpose for this event.",
     )
 
     event_reservation_units = EventReservationUnitSerializer(
-        many=True, read_only=False, required=False
+        many=True,
+        read_only=False,
+        required=False,
+        help_text="List of reservation units applied for this event with priority included.",
     )
 
     class Meta:
@@ -178,6 +222,34 @@ class ApplicationEventSerializer(serializers.ModelSerializer):
             "purpose_id",
             "event_reservation_units",
         ]
+        extra_kwargs = {
+            "name": {
+                "help_text": "Name that describes this event.",
+            },
+            "num_persons": {
+                "help_text": "Number of persons that are excepted to attend this event.",
+            },
+            "min_duration": {
+                "help_text": "Minimum duration of reservations allocated for this event.",
+            },
+            "max_duration": {
+                "help_text": "Maximum duration of reservations allocated for this event.",
+            },
+            "events_per_week": {
+                "help_text": "Number of reservations requested for each week "
+                "(or every other week if biweekly is true).",
+            },
+            "biweekly": {
+                "help_text": "False if recurring reservations are wished for every week. "
+                "True if only every other week.",
+            },
+            "begin": {
+                "help_text": "Requested begin date of the recurring reservation for this event.",
+            },
+            "end": {
+                "help_text": "Requested end date of the recurring reservation for this event.",
+            },
+        }
 
     def validate(self, data):
         min_duration = data["min_duration"]
@@ -242,19 +314,31 @@ class ApplicationEventSerializer(serializers.ModelSerializer):
 
 class ApplicationSerializer(serializers.ModelSerializer):
 
-    contact_person = PersonSerializer(read_only=False, allow_null=True)
+    contact_person = PersonSerializer(
+        help_text="Contact person information for the application",
+        read_only=False,
+        allow_null=True,
+    )
 
-    organisation = OrganisationSerializer(read_only=False, allow_null=True)
+    organisation = OrganisationSerializer(
+        help_text="Organisation information for the application",
+        read_only=False,
+        allow_null=True,
+    )
 
     application_period_id = serializers.PrimaryKeyRelatedField(
-        queryset=ApplicationPeriod.objects.all(), source="application_period"
+        queryset=ApplicationPeriod.objects.all(),
+        source="application_period",
+        help_text="Id of the application period for which this application is targeted to",
     )
 
     user = serializers.HiddenField(default=NullableCurrentUserDefault())
 
-    application_events = ApplicationEventSerializer(many=True)
+    application_events = ApplicationEventSerializer(
+        help_text="List of applications events", many=True
+    )
 
-    status = serializers.CharField()
+    status = serializers.CharField(help_text="Status of this application")
 
     class Meta:
         model = Application

--- a/api/resources_api.py
+++ b/api/resources_api.py
@@ -15,6 +15,25 @@ class ResourceSerializer(TranslatedModelSerializer):
             "buffer_time_before",
             "buffer_time_after",
         ]
+        extra_kwargs = {
+            "name": {
+                "help_text": "State of the reservation. Default is 'created'.",
+            },
+            "location_type": {
+                "help_text": "Priority of this reservation. Higher priority reservations replaces lower ones.",
+            },
+            "space": {
+                "help_text": "Buffer time while reservation unit is unreservable before the reservation. "
+                "Dynamically calculated from spaces and resources.",
+            },
+            "buffer_time_before": {
+                "help_text": "Buffer time while reservation unit is unreservable after the reservation. "
+                "Dynamically calculated from spaces and resources.",
+            },
+            "buffer_time_after": {
+                "help_text": "Begin date and time of the reservation.",
+            },
+        }
 
 
 class ResourceViewSet(viewsets.ModelViewSet):

--- a/api/services_api.py
+++ b/api/services_api.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import mixins, serializers, viewsets
 
 from api.base import TranslatedModelSerializer
 from services.models import Service
@@ -14,8 +14,24 @@ class ServiceSerializer(TranslatedModelSerializer):
             "buffer_time_before",
             "buffer_time_after",
         ]
+        extra_kwargs = {
+            "name": {
+                "help_text": "Name of the service.",
+            },
+            "service_type": {
+                "help_text": "Type of the service.",
+            },
+            "buffer_time_before": {
+                "help_text": "Buffer time required before reservation if this service is used.",
+            },
+            "buffer_time_after": {
+                "help_text": "Buffer time required after reservation if this service is used.",
+            },
+        }
 
 
-class ServiceViewSet(viewsets.ModelViewSet):
+class ServiceViewSet(
+    viewsets.GenericViewSet, mixins.ListModelMixin, mixins.RetrieveModelMixin
+):
     serializer_class = ServiceSerializer
     queryset = Service.objects.all()

--- a/api/space_api.py
+++ b/api/space_api.py
@@ -14,12 +14,42 @@ class LocationSerializer(TranslatedModelSerializer):
     class Meta:
         model = Location
         fields = ["address_street", "address_zip", "address_city"]
+        extra_kwargs = {
+            "address_street": {
+                "help_text": "Street name and number for the location.",
+            },
+            "address_zip": {
+                "help_text": "Zip code of the location.",
+            },
+            "address_city": {
+                "help_text": "City of the location.",
+            },
+        }
 
 
 class SpaceSerializer(TranslatedModelSerializer):
     class Meta:
         model = Space
-        fields = ["id", "name", "parent", "building", "surface_area"]
+        fields = ["id", "name", "parent", "building", "surface_area", "district"]
+        extra_kwargs = {
+            "name": {
+                "help_text": "Name of the space.",
+            },
+            "parent": {
+                "help_text": "Id of parent space for this space. "
+                "Spaces are represented as a tree hierarchy in this system.",
+            },
+            "building": {
+                "help_text": "Buffer time while reservation unit is unreservable before the reservation. "
+                "Dynamically calculated from spaces and resources.",
+            },
+            "surface_area": {
+                "help_text": "Surface area of the space as square meters",
+            },
+            "district": {
+                "help_text": "Id of the district where this space is located.",
+            },
+        }
 
 
 class SpaceViewSet(viewsets.ModelViewSet):

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,11 +1,7 @@
 from rest_framework import routers
 
 from .application_period_api import ApplicationPeriodViewSet
-from .applications_api import (
-    AddressViewSet,
-    ApplicationEventViewSet,
-    ApplicationViewSet,
-)
+from .applications_api import ApplicationEventViewSet, ApplicationViewSet
 from .reservation_units_api import (
     EquipmentCategoryViewSet,
     EquipmentViewSet,
@@ -13,21 +9,16 @@ from .reservation_units_api import (
     ReservationUnitTypeViewSet,
     ReservationUnitViewSet,
 )
-from .reservations_api import AbilityGroupViewSet, AgeGroupViewSet, ReservationViewSet
 from .resources_api import ResourceViewSet
-from .services_api import ServiceViewSet
-from .space_api import SpaceViewSet
+from .reservations_api import AbilityGroupViewSet, AgeGroupViewSet, ReservationViewSet
 
 router = routers.DefaultRouter()
 
 router.register(r"reservation_unit", ReservationUnitViewSet, "reservationunit")
-router.register(r"space", SpaceViewSet, "space")
-router.register(r"service", ServiceViewSet, "service")
 router.register(r"resource", ResourceViewSet, "resource")
 router.register(r"reservation", ReservationViewSet, "reservation")
 router.register(r"application", ApplicationViewSet, "application")
 router.register(r"application_event", ApplicationEventViewSet, "application_event")
-router.register(r"address", AddressViewSet, "address")
 router.register(r"application_period", ApplicationPeriodViewSet, "application_period")
 router.register(r"parameters/purpose", PurposeViewSet, "purpose")
 router.register(r"parameters/age_group", AgeGroupViewSet, "age_group")

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -261,20 +261,17 @@ SPECTACULAR_SETTINGS = {
             "description": "",
         },
         {
-            "name": "address",
-            "description": "",
-        },
-        {
             "name": "application",
-            "description": "",
+            "description": "Applications for recurring reservations for individuals and organisations.",
         },
         {
             "name": "application_event",
-            "description": "",
+            "description": "Single recurring events related to a certain application.",
         },
         {
             "name": "application_period",
-            "description": "",
+            "description": "Information of past, current and future application periods "
+            "to where applications are targeted to.",
         },
         {
             "name": "parameters",
@@ -282,23 +279,12 @@ SPECTACULAR_SETTINGS = {
         },
         {
             "name": "reservation",
-            "description": "",
+            "description": "Reservation for single or multiple reservation units.",
         },
         {
             "name": "reservation_unit",
-            "description": "",
-        },
-        {
-            "name": "resource",
-            "description": "",
-        },
-        {
-            "name": "service",
-            "description": "",
-        },
-        {
-            "name": "space",
-            "description": "",
+            "description": "A single unit that can be reserved. "
+            "Wrapper for combinations of spaces, resources and services.",
         },
     ],
 }


### PR DESCRIPTION
I also disabled some endpoints that clearly aren't ready to be open, lacks tests etc. I think it's best to open endpoints as we need and use them and prevent making endpoints for every model if we don't know for sure that they are needed separately. It keeps documentation clean and makes understanding the API easier.

I hope review from as many developers as possible, because understanding who the API works is crucial for whole team. 