### PR TITLE
Fix optional AgeGroupSerializer display option

### DIFF
--- a/api/reservations_api.py
+++ b/api/reservations_api.py
@@ -140,7 +140,7 @@ class AgeGroupSerializer(serializers.ModelSerializer):
             },
         }
 
-    def __init__(self, display=False, *args, **kwargs):
+    def __init__(self, *args, display=False, **kwargs):
         super(AgeGroupSerializer, self).__init__(*args, **kwargs)
         if display:
             self.fields.pop("id")


### PR DESCRIPTION
The display option was before *args so it was applied as first argument
not as kwarg => caused it to be display=True when it shouldn't