### PR TITLE
Bump django to 3.1.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2
 coverage==5.3
-Django==3.0.10
+Django==3.1.7
 django-auditlog==0.4.7
 django-cors-headers==3.6.0
 django-environ==0.4.5


### PR DESCRIPTION
the version 3.0.x is to be deprecated in April