### PR TITLE
TILA-295 | Filter reservation units with comma separated list of ids

### DIFF
--- a/api/reservation_units_api.py
+++ b/api/reservation_units_api.py
@@ -19,6 +19,10 @@ from reservation_units.models import (
 from spaces.models import District, Unit
 
 
+class NumberInFilter(filters.BaseInFilter, filters.NumberFilter):
+    pass
+
+
 class ReservationUnitFilter(filters.FilterSet):
     purpose = filters.ModelMultipleChoiceFilter(
         field_name="purposes", queryset=Purpose.objects.all()
@@ -38,6 +42,8 @@ class ReservationUnitFilter(filters.FilterSet):
         field_name="reservation_unit_type", queryset=ReservationUnitType.objects.all()
     )
     unit = filters.ModelChoiceFilter(field_name="unit", queryset=Unit.objects.all())
+
+    ids = NumberInFilter(field_name="id", lookup_expr="in")
 
 
 class ReservationUnitImageSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Very simple and is registered automatically by drf-spectacular. This allows you to filter reservation units by primary key like this: http://localhost:8000/v1/reservation_unit/?ids=4,9