### PR TITLE
Tila 546 | Allocation results API permission changes

### DIFF
--- a/api/allocation_results_api.py
+++ b/api/allocation_results_api.py
@@ -12,7 +12,7 @@ from applications.models import (
     Organisation,
     User,
 )
-from permissions.api_permissions import AllocationRequestPermission
+from permissions.api_permissions import AllocationResultsPermission
 from reservation_units.models import ReservationUnit
 
 
@@ -123,7 +123,7 @@ class AllocationResultsFilter(filters.FilterSet):
         )
 
 
-class AllocationResultViewSet(viewsets.ModelViewSet):
+class AllocationResultViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = ApplicationEventScheduleResult.objects.all().order_by(
         "application_event_schedule__application_event_id"
     )
@@ -131,7 +131,7 @@ class AllocationResultViewSet(viewsets.ModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = AllocationResultsFilter
     permission_classes = (
-        [AllocationRequestPermission]
+        [AllocationResultsPermission]
         if not settings.TMP_PERMISSIONS_DISABLED
         else [permissions.AllowAny]
     )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -799,3 +799,24 @@ def valid_unit_viewer_data(user, unit):
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
+
+
+@pytest.mark.django_db
+@pytest.fixture
+def staff_user():
+    user = get_user_model().objects.create(
+        username="gen_admin",
+        first_name="Amin",
+        last_name="General",
+        email="amin.general@foo.com",
+        is_staff=True,
+    )
+
+    return user
+
+
+@pytest.fixture
+def staff_user_api_client(staff_user):
+    api_client = APIClient()
+    api_client.force_authenticate(staff_user)
+    return api_client

--- a/api/tests/test_allocation_results_api_permission.py
+++ b/api/tests/test_allocation_results_api_permission.py
@@ -1,0 +1,108 @@
+from rest_framework.reverse import reverse
+
+
+def test_normal_user_cannot_access_results_without_service_sector(user_api_client):
+    response = user_api_client.get(
+        reverse("allocation_results-list"),
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_normal_user_cannot_access_results_with_service_sector(user_api_client):
+    response = user_api_client.get(
+        reverse("allocation_results-list"),
+        data={"service_sector_id": 1},
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_general_admin_user_cant_access_results_without_service_sector(
+    general_admin_api_client,
+):
+    response = general_admin_api_client.get(
+        reverse("allocation_results-list"),
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_general_admin_user_can_access_results_with_service_sector(
+    general_admin_api_client, service_sector
+):
+    response = general_admin_api_client.get(
+        reverse("allocation_results-list"),
+        data={"service_sector_id": service_sector.id},
+        format="json",
+    )
+
+    assert response.status_code == 200
+
+
+def test_staff_user_can_access_results(staff_user_api_client):
+    response = staff_user_api_client.get(
+        reverse("allocation_results-list"),
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_staff_cannot_post(staff_user_api_client):
+    response = staff_user_api_client.post(
+        reverse("allocation_results-list"),
+        data={},
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_normal_user_cannot_post(user_api_client):
+    response = user_api_client.post(
+        reverse("allocation_results-list"),
+        data={},
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_service_sector_admin_cant_access_results_without_service_sector_data(
+    service_sector_application_manager_api_client, service_sector
+):
+    response = service_sector_application_manager_api_client.get(
+        reverse("allocation_results-list"),
+        format="json",
+    )
+
+    assert response.status_code == 403
+
+
+def test_service_sector_admin_can_access_results(
+    service_sector_application_manager_api_client,
+    service_sector,
+):
+    response = service_sector_application_manager_api_client.get(
+        reverse("allocation_results-list"),
+        data={"service_sector_id": service_sector.id},
+        format="json",
+    )
+
+    assert response.status_code == 200
+
+
+def test_service_sector_admin_cant_post_results(
+    service_sector_application_manager_api_client, service_sector
+):
+    response = service_sector_application_manager_api_client.post(
+        reverse("allocation_results-list"),
+        data={},
+        format="json",
+    )
+
+    assert response.status_code == 403

--- a/permissions/api_permissions.py
+++ b/permissions/api_permissions.py
@@ -191,6 +191,26 @@ class AllocationRequestPermission(permissions.BasePermission):
             return False
 
 
+class AllocationResultsPermission(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        return False
+
+    def has_permission(self, request, view):
+        service_sector_id = request.data.get(
+            "service_sector_id"
+        ) or request.query_params.get("service_sector_id")
+        service_sector = ServiceSector.objects.filter(id=service_sector_id).first()
+        if not service_sector:
+            return False
+
+        if (
+            request.method in permissions.SAFE_METHODS
+            and can_allocate_service_sector_allocations(request.user, service_sector)
+        ):
+            return True
+        return False
+
+
 class ApplicationEventPermission(permissions.BasePermission):
     def has_object_permission(self, request, view, application_event):
         return can_modify_application(request.user, application_event.application)


### PR DESCRIPTION
First of all makes the allocation results api end point as readonly. 
Second, makes the allocation results viewable only for service sector and general admin. => service sector id is required parameter.