### PR TITLE
Refactor get_opening_hours resource_id parameter

### DIFF
--- a/allocation/allocation_data_builder.py
+++ b/allocation/allocation_data_builder.py
@@ -126,7 +126,7 @@ class AllocationDataBuilder(object):
             return self.set_mock_opening_hour_data(space)
 
         opening_hours = get_opening_hours(
-            f"{settings.HAUKI_ORIGIN_ID}:{unit.uuid}",
+            f"{unit.uuid}",
             self.application_round.reservation_period_begin,
             self.application_round.reservation_period_end,
         )

--- a/api/hauki_api.py
+++ b/api/hauki_api.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.datetime_safe import datetime
 from rest_framework import serializers, viewsets
 from rest_framework.response import Response
@@ -14,7 +13,7 @@ class OpeningHours(object):
 
     def get_hours(self, start_date: datetime, end_date: datetime):
         return get_opening_hours(
-            resource_id=f"{settings.HAUKI_ORIGIN_ID}:{self.id}",
+            resource_id=f"{self.id}",
             start_date=start_date,
             end_date=end_date,
         )

--- a/applications/tests/test_reservation_creation.py
+++ b/applications/tests/test_reservation_creation.py
@@ -148,7 +148,7 @@ class ReservationSchedulerTestCase(TestCase, DjangoTestCase):
         self, mock
     ):
         scheduler = ReservationScheduler(
-            self.res_unit.id, self.reservation_begin, self.reservation_end
+            self.res_unit, self.reservation_begin, self.reservation_end
         )
         start_dt, end_dt = scheduler.get_reservation_times_based_on_opening_hours()
 
@@ -160,7 +160,7 @@ class ReservationSchedulerTestCase(TestCase, DjangoTestCase):
     ):
         reservation_end = self.reservation_end + datetime.timedelta(hours=1)
         scheduler = ReservationScheduler(
-            self.res_unit.id, self.reservation_begin, reservation_end
+            self.res_unit, self.reservation_begin, reservation_end
         )
         start_dt, end_dt = scheduler.get_reservation_times_based_on_opening_hours()
 

--- a/applications/utils/reservation_creation.py
+++ b/applications/utils/reservation_creation.py
@@ -52,7 +52,7 @@ def create_reservation_from_schedule_result(result, application_event):
         )
 
         reservation_scheduler = ReservationScheduler(
-            result.allocated_reservation_unit.id, res_start, res_end
+            result.allocated_reservation_unit, res_start, res_end
         )
         (
             start,
@@ -83,8 +83,8 @@ def create_reservation_from_schedule_result(result, application_event):
 
 
 class ReservationScheduler:
-    def __init__(self, reservation_unit_id, begin, end):
-        self.reservation_unit_id = reservation_unit_id
+    def __init__(self, reservation_unit, begin, end):
+        self.reservation_unit = reservation_unit
         self.begin = begin
         self.end = end
         self.dates = []
@@ -152,7 +152,7 @@ class ReservationScheduler:
     def get_opening_hours(self):
         # TODO: Cache opening hours per unit.
         return get_opening_hours(
-            self.reservation_unit_id,
+            self.reservation_unit.uuid,
             start_date=self.begin.date(),
             end_date=self.end.date(),
         )

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -93,9 +93,14 @@ def get_opening_hours(
 ) -> List[dict]:
     """Get opening hours for Hauki resource"""
 
-    days_data_out = []
+    resource_prefix = f"{settings.HAUKI_ORIGIN_ID}"
     if isinstance(resource_id, list):
-        resource_id = ",".join(resource_id)
+        resource_id = "%s:%s" % (
+            resource_prefix,
+            f",{resource_prefix}:".join(resource_id),
+        )
+    else:
+        resource_id = f"{resource_prefix}:{resource_id}"
     if isinstance(start_date, datetime.date):
         start_date = start_date.isoformat()
     if isinstance(end_date, datetime.date):
@@ -108,6 +113,7 @@ def get_opening_hours(
     }
     days_data_in = make_hauki_request(resource_opening_hours_url, query_params)
 
+    days_data_out = []
     for day_data_in in days_data_in["results"]:
         for opening_hours in day_data_in["opening_hours"]:
             day_data_out = {


### PR DESCRIPTION
Remove the need for giving HAUKI_ORIGIN_ID as part of the resource_id in
get_opening_hours function.
Moves the HAUKI_ORIGIN_ID to be added to resource_id when doing the
query to HAUKI