### PR TITLE
Make declined reservation units not required

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -770,6 +770,7 @@ class ApplicationEvent(models.Model):
     declined_reservation_units = models.ManyToManyField(
         ReservationUnit,
         verbose_name=_("Declined reservation units"),
+        blank=True,
     )
 
     @property


### PR DESCRIPTION
Its manytomany field and its not required so blank=True to make it work in admin.