### PR TITLE
TILA-606 Configure celery for running backend tasks.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,6 @@ coverage.xml
 .pytest_cache/
 
 .mypy_cache/
+
+# Celery filesystem queue
+broker/

--- a/.env.example
+++ b/.env.example
@@ -209,3 +209,49 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 #by anything so you can subscribe to them from calendars,
 #we need to hash those, so you can't access those just by uuid
 #ICAL_HASH_SECRET=
+
+
+# CELERY
+
+# Set true if you want to use celery to run backend tasks. Otherwise they will be run synchronously.
+# Default is true
+#CELERY_ENABLED=True
+
+# What to use as celery result backend. Defaults to django db
+# For options see https://docs.celeryproject.org/en/stable/userguide/configuration.html#std-setting-result_backend
+#CELERY_RESULT_BACKEND=
+
+# Only needed if using django db as result backend. Defaults to django-cache
+#CELERY_CACHE_BACKEND=
+
+# Timezone for celery. Defaults to Europe/Helsinki
+#CELERY_TIMEZONE=
+
+# Set true to track started tasks. If set to false, only pending, finished and waiting to be retried
+# Tasks are reported. Useful if there are long running tasks, debugging or you need to report
+# what tasks are currently running.
+# Defaults to false
+# CELERY_TASK_TRACK_STARTED=
+
+# Time limit for celery tasks. Defaults to 5 minutes.
+#CELERY_TASK_TIME_LIMIT=
+
+# Broker url for celery.
+# URL in the form of: transport://userid:password@hostname:port/virtual_host
+# defaults to filesystem broker filesystem://
+#CELERY_BROKER_URL=
+
+# Celery filesystem backend
+# Set true to use filesystem backend. If set to true the following environment variables must be set.
+# If set to false, no need to set following celery variables.
+# Defaults to true
+#CELERY_FILESYSTEM_BACKEND=(bool, True),
+
+# Folder to use for celery queue out. Defaults to ./broker/queue/
+#CELERY_QUEUE_FOLDER_OUT=
+
+# Folder to use for celery queue in. Defaults to ./broker/queue/
+#CELERY_QUEUE_FOLDER_IN=
+
+# Folder to use for storing processed tasks. Defaults to ./broker/processed/
+#CELERY_PROCESSED_FOLDER=

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ perf*csv
 .pytest_cache
 .DS_Store
 /staticroot/
+/broker

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN useradd -ms /bin/bash -d /tvp tvp
 # Statics are kept inside container image for serving using whitenoise
 RUN mkdir -p /srv/static && chown tvp /srv/static && chown tvp /opt/app-root/bin
 
+
 RUN chown tvp /opt/app-root/lib/python3.8/site-packages
 RUN chown tvp /opt/app-root/lib/python3.8/site-packages/*
 RUN pip install --upgrade pip
@@ -67,6 +68,10 @@ RUN python manage.py collectstatic --noinput
 
 RUN chgrp -R 0 /tvp
 RUN chmod g=u -R /tvp
+
+RUN mkdir -p /broker/queue && chown tvp /broker/queue
+
+RUN mkdir -p /broker/processed && chown tvp /broker/queue
 
 ENTRYPOINT ["/tvp/deploy/entrypoint.sh"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,11 @@ services:
             - DEBUG=true
             - DATABASE_URL=postgis://tvp:tvp@db/tvp
             - WAIT_FOR_IT_ADDRESS=postgres:5432
+            - CELERY_ENABLED=true
+            - CELERY_FILESYSTEM_BACKEND=true
+            - CELERY_QUEUE_FOLDER_OUT=/broker/queue/
+            - CELERY_QUEUE_FOLDER_IN=/broker/queue/
+            - CELERY_PROCESSED_FOLDER=/broker/processed/
         command: ["start_django_development_server"]
         ports:
             - "127.0.0.1:8000:8000"

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,9 @@
 assertpy==1.1
 black==20.8b1
+celery
 Django==3.1.12
 django-auditlog==1.0a1
+django-celery-results
 django-cors-headers==3.6.0
 django-enumfields==2.0.0
 django-environ==0.4.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,8 @@
 #
 absl-py==0.12.0
     # via ortools
+amqp==5.0.6
+    # via kombu
 aniso8601==7.0.0
     # via graphene
 appdirs==1.4.4
@@ -18,10 +20,16 @@ attrs==21.2.0
     # via
     #   jsonschema
     #   pytest
+billiard==3.6.4.0
+    # via celery
 black==20.8b1
     # via -r requirements.in
 cachetools==4.2.2
     # via django-helusers
+celery==5.1.2
+    # via
+    #   -r requirements.in
+    #   django-celery-results
 certifi==2020.12.5
     # via
     #   elastic-apm
@@ -31,9 +39,19 @@ cffi==1.14.5
     # via cryptography
 chardet==4.0.0
     # via requests
-click==8.0.1
+click-didyoumean==0.0.3
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
+click==7.1.2
     # via
     #   black
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
     #   pip-tools
 coverage==5.5
     # via pytest-cov
@@ -46,6 +64,8 @@ defusedxml==0.7.1
 deprecation==2.1.0
     # via django-helusers
 django-auditlog==1.0a1
+    # via -r requirements.in
+django-celery-results==2.2.0
     # via -r requirements.in
 django-cors-headers==3.6.0
     # via -r requirements.in
@@ -150,6 +170,8 @@ isort==5.6.4
     # via -r requirements.in
 jsonschema==3.2.0
     # via drf-spectacular
+kombu==5.1.0
+    # via celery
 mccabe==0.6.1
     # via flake8
 mypy-extensions==0.4.3
@@ -179,6 +201,8 @@ promise==2.3
     #   graphene-django
     #   graphql-core
     #   graphql-relay
+prompt-toolkit==3.0.19
+    # via click-repl
 protobuf==3.17.0
     # via ortools
 psycopg2==2.8.6
@@ -229,6 +253,7 @@ python3-openid==3.2.0
     # via social-auth-core
 pytz==2021.1
     # via
+    #   celery
     #   django
     #   django-recurrence
     #   icalendar
@@ -255,6 +280,7 @@ singledispatch==3.6.1
 six==1.15.0
     # via
     #   absl-py
+    #   click-repl
     #   django-jsonfield
     #   django-modeltranslation
     #   ecdsa
@@ -304,10 +330,17 @@ urllib3==1.26.5
     #   sentry-sdk
 uwsgi==2.0.19.1
     # via -r requirements.in
+vine==5.0.0
+    # via
+    #   amqp
+    #   celery
+    #   kombu
 wasmer-compiler-cranelift==1.0.0
     # via fastdiff
 wasmer==1.0.0
     # via fastdiff
+wcwidth==0.2.5
+    # via prompt-toolkit
 whitenoise==5.2.0
     # via -r requirements.in
 

--- a/tilavarauspalvelu/__init__.py
+++ b/tilavarauspalvelu/__init__.py
@@ -1,1 +1,9 @@
+from __future__ import absolute_import
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ("celery_app",)
+
 __version__ = "0.4.0"

--- a/tilavarauspalvelu/celery.py
+++ b/tilavarauspalvelu/celery.py
@@ -1,0 +1,20 @@
+import os
+
+from celery import Celery
+
+# Set the default Django settings module for the 'celery' program.
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tilavarauspalvelu.settings")
+
+broker_url = os.getenv("CELERY_BROKER_URL", "filesystem://")
+broker_options = os.getenv("CELERY_BROKER_TRANSPORT_OPTIONS", {})
+
+app = Celery("tilavarauspalvelu")
+
+app.conf.update({"broker_url": broker_url, "broker_transport_options": broker_options})
+
+# All celery-related configuration keys
+# should have a `CELERY_` prefix.
+app.config_from_object("django.conf:settings", namespace="CELERY")
+
+# Load task modules from all registered Django apps.
+app.autodiscover_tasks()

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -91,6 +91,7 @@ INSTALLED_APPS = [
     "social_django",
     "tinymce",
     "easy_thumbnails",
+    "django_celery_results",
 ]
 
 MIDDLEWARE = [
@@ -170,6 +171,19 @@ env = environ.Env(
     CSRF_TRUSTED_ORIGINS=(list, []),
     MULTI_PROXY_HEADERS=(bool, False),
     ICAL_HASH_SECRET=(str, ""),
+    # Celery
+    CELERY_ENABLED=(bool, True),
+    CELERY_RESULT_BACKEND=(str, "django-db"),
+    CELERY_CACHE_BACKEND=(str, "django-cache"),
+    CELERY_TIMEZONE=(str, "Europe/Helsinki"),
+    CELERY_TASK_TRACK_STARTED=(bool, False),
+    CELERY_TASK_TIME_LIMIT=(int, 5 * 60),
+    CELERY_BROKER_URL=(str, "filesystem://"),
+    # Celery filesystem backend
+    CELERY_FILESYSTEM_BACKEND=(bool, True),
+    CELERY_QUEUE_FOLDER_OUT=(str, "./broker/queue/"),
+    CELERY_QUEUE_FOLDER_IN=(str, "./broker/queue/"),
+    CELERY_PROCESSED_FOLDER=(str, "./broker/processed/"),
 )
 
 environ.Env.read_env()
@@ -355,6 +369,31 @@ THUMBNAIL_ALIASES = {
         "medium": {"size": (384, 384), "crop": True},
     },
 }
+
+CELERY_ENABLED = env("CELERY_ENABLED")
+CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND")
+
+CELERY_CACHE_BACKEND = env("CELERY_CACHE_BACKEND")
+
+CELERY_TIMEZONE = env("CELERY_TIMEZONE")
+CELERY_TASK_TRACK_STARTED = env("CELERY_TASK_TRACK_STARTED")
+CELERY_TASK_TIME_LIMIT = env("CELERY_TASK_TIME_LIMIT")
+CELERY_BROKER_URL = env("CELERY_BROKER_URL")
+CELERY_FILESYSTEM_BACKEND = env("CELERY_FILESYSTEM_BACKEND")
+
+
+if CELERY_FILESYSTEM_BACKEND:
+
+    CELERY_QUEUE_FOLDER_OUT = env("CELERY_QUEUE_FOLDER_OUT")
+    CELERY_QUEUE_FOLDER_IN = env("CELERY_QUEUE_FOLDER_IN")
+    CELERY_PROCESSED_FOLDER = env("CELERY_PROCESSED_FOLDER")
+
+    CELERY_BROKER_TRANSPORT_OPTIONS = {
+        "data_folder_out": CELERY_QUEUE_FOLDER_OUT,
+        "data_folder_in": CELERY_QUEUE_FOLDER_IN,
+        "processed_folder": CELERY_PROCESSED_FOLDER,
+        "store_processed": True,
+    }
 
 
 # local_settings.py can be used to override environment-specific settings


### PR DESCRIPTION
Configures celery for running backend tasks. 

Note that this isn't production ready, specifically docker related stuff, since we are using filesystem backend. 

But this gives use a way to start implementing backend tasks with celery without doing changes to infrastructure, and configuration is done so that moving this to redis or similar message queue should be very simple. 