### PR TITLE
Tila 707 create update structure

### DIFF
--- a/api/graphql/base_serializers.py
+++ b/api/graphql/base_serializers.py
@@ -1,0 +1,15 @@
+from rest_framework import serializers
+
+
+class PrimaryKeySerializer(serializers.ModelSerializer):
+    pk = serializers.IntegerField(read_only=True)
+
+    def get_pk(self, instance):
+        return instance.id
+
+
+class PrimaryKeyUpdateSerializer(serializers.ModelSerializer):
+    pk = serializers.IntegerField(required=True)
+
+    def get_pk(self, instance):
+        return instance.id

--- a/api/graphql/reservation_units/reservation_unit_mutations.py
+++ b/api/graphql/reservation_units/reservation_unit_mutations.py
@@ -1,0 +1,41 @@
+import graphene
+from graphene_django.rest_framework.mutation import SerializerMutation
+from rest_framework.generics import get_object_or_404
+
+from api.graphql.reservation_units.reservation_unit_serializers import (
+    PurposeCreateSerializer,
+    PurposeUpdateSerializer,
+)
+from api.graphql.reservation_units.reservation_unit_types import PurposeType
+from reservation_units.models import Purpose
+
+
+class PurposeCreateMutation(SerializerMutation):
+    purpose = graphene.Field(PurposeType)
+
+    class Meta:
+        model_operations = ["create"]
+
+        serializer_class = PurposeCreateSerializer
+
+    @classmethod
+    def perform_mutate(cls, serializer, info):
+        purpose = serializer.create(serializer.validated_data)
+        return cls(errors=None, purpose=purpose)
+
+
+class PurposeUpdateMutation(SerializerMutation):
+    purpose = graphene.Field(PurposeType)
+
+    class Meta:
+        model_operations = ["update"]
+        lookup_field = "pk"
+        serializer_class = PurposeUpdateSerializer
+
+    @classmethod
+    def perform_mutate(cls, serializer, info):
+
+        validated_data = serializer.validated_data
+        pk = validated_data.get("pk")
+        purpose = serializer.update(get_object_or_404(Purpose, pk=pk), validated_data)
+        return cls(errors=None, purpose=purpose)

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -1,0 +1,14 @@
+from api.graphql.base_serializers import (
+    PrimaryKeySerializer,
+    PrimaryKeyUpdateSerializer,
+)
+from api.reservation_units_api import PurposeSerializer
+
+
+class PurposeCreateSerializer(PurposeSerializer, PrimaryKeySerializer):
+    pass
+
+
+class PurposeUpdateSerializer(PurposeSerializer, PrimaryKeyUpdateSerializer):
+    class Meta(PurposeSerializer.Meta):
+        fields = PurposeSerializer.Meta.fields + ["pk"]

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -22,10 +22,7 @@ from spaces.models import Space
 class PurposeType(PrimaryKeyObjectType):
     class Meta:
         model = Purpose
-        fields = (
-            "id",
-            "name",
-        )
+        fields = ("id", "name", "pk")
 
         interfaces = (graphene.relay.Node,)
 

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -6,6 +6,10 @@ from graphene_permissions.mixins import AuthFilter
 from graphene_permissions.permissions import AllowAuthenticated
 from rest_framework.generics import get_object_or_404
 
+from api.graphql.reservation_units.reservation_unit_mutations import (
+    PurposeCreateMutation,
+    PurposeUpdateMutation,
+)
 from api.graphql.reservation_units.reservation_unit_types import ReservationUnitType
 from api.graphql.reservations.reservation_types import ReservationType
 from api.graphql.resources.resource_types import ResourceType
@@ -44,6 +48,8 @@ class Query(graphene.ObjectType):
 
 class Mutation(graphene.ObjectType):
     create_reservation = ReservationMutation.Field()
+    create_purpose = PurposeCreateMutation.Field()
+    update_purpose = PurposeUpdateMutation.Field()
 
 
 schema = graphene.Schema(query=Query, mutation=Mutation)

--- a/api/graphql/spaces/space_types.py
+++ b/api/graphql/spaces/space_types.py
@@ -15,7 +15,7 @@ class DistrictType(PrimaryKeyObjectType):
 class RealEstateType(PrimaryKeyObjectType):
     class Meta:
         model = RealEstate
-        fields = ("id", "name", "district", "area")
+        fields = ("id", "name", "district", "surface_area")
 
         interfaces = (graphene.relay.Node,)
 

--- a/api/graphql/tests/snapshots/snap_test_purposes.py
+++ b/api/graphql/tests/snapshots/snap_test_purposes.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['PurposeTestCase::test_creating_purpose 1'] = {
+    'data': {
+        'createPurpose': {
+            'errors': None,
+            'purpose': {
+                'name': 'Created purpose'
+            }
+        }
+    }
+}
+
+snapshots['PurposeTestCase::test_updating_purpose 1'] = {
+    'updatePurpose': {
+        'errors': None,
+        'purpose': {
+            'name': 'Updated name'
+        }
+    }
+}

--- a/api/graphql/tests/test_purposes.py
+++ b/api/graphql/tests/test_purposes.py
@@ -1,0 +1,82 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from reservation_units.tests.factories import PurposeFactory
+
+
+class PurposeTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.purpose = PurposeFactory(name="Test purpose")
+
+        cls.api_client = APIClient()
+
+    def test_updating_purpose(self):
+        response = self.query(
+            f"mutation {{\n"
+            f'updatePurpose(input: {{pk: {self.purpose.id}, name: "Updated name"}}) {{\n'
+            f"purpose {{\n"
+            f"name\n"
+            f"pk\n"
+            f"}}\n"
+            f"errors {{\n"
+            f"messages\n"
+            f"field\n"
+            f"}}\n"
+            f"}}\n"
+            f"}}\n"
+        )
+
+        content = json.loads(response.content).get("data")
+
+        assert_that(content.get("errors")).is_none()
+        purpose_content = content.get("updatePurpose").get("purpose")
+        assert_that(purpose_content.get("pk")).is_equal_to(self.purpose.id)
+        content.get("updatePurpose").get("purpose").pop("pk")
+        self.assertMatchSnapshot(content)
+
+    def test_updading_should_error_when_not_found(self):
+        response = self.query(
+            f"mutation {{\n"
+            f'updatePurpose(input: {{pk: {self.purpose.id + 3782}, name: "Fail name"}}) {{\n'
+            f"purpose {{\n"
+            f"id\n"
+            f"name\n"
+            f"}}\n"
+            f"errors {{\n"
+            f"messages\n"
+            f"field\n"
+            f"}}\n"
+            f"}}\n"
+            f"}}\n"
+        )
+
+        content = json.loads(response.content)
+        errors = content.get("errors")
+        assert_that(len(errors)).is_equal_to(1)
+        assert_that(errors[0].get("message")).is_equal_to(
+            "No Purpose matches the given query."
+        )
+
+    def test_creating_purpose(self):
+        response = self.query(
+            "mutation {\n"
+            'createPurpose(input: {name: "Created purpose"}) {\n'
+            "purpose {\n"
+            "name\n"
+            "}\n"
+            "errors {\n"
+            "messages\n"
+            "field\n"
+            "}\n"
+            "}\n"
+            "}\n"
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)


### PR DESCRIPTION
Base classes for handling updating and creating objects with graphql while reusing drf serializers. Example usage with update and create of purposes. 