### PR TITLE
Bump django to 3.1.13 and pillow to 8.3.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 assertpy==1.1
 black==20.8b1
 celery
-Django==3.1.12
+Django==3.1.13
 django-auditlog==1.0a1
 django-celery-results
 django-cors-headers==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ click==7.1.2
     #   click-plugins
     #   click-repl
     #   pip-tools
-coverage==5.5
+coverage==6.0b1
     # via pytest-cov
 cryptography==3.4.7
     # via social-auth-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ django-recurrence==1.10.3
     # via -r requirements.in
 django-tinymce==3.2.0
     # via -r requirements.in
-django==3.1.12
+django==3.1.13
     # via
     #   -r requirements.in
     #   django-cors-headers
@@ -190,7 +190,7 @@ pathspec==0.8.1
     # via black
 pep517==0.10.0
     # via pip-tools
-pillow==8.2.0
+pillow==8.3.1
     # via easy-thumbnails
 pip-tools==6.1.0
     # via -r requirements.in


### PR DESCRIPTION
Security fixes.

also bumps coverage to 6.0b1 because safety.