### PR TITLE
TILA-769 | Unit mutation enchancements

### DIFF
--- a/api/graphql/base_mutations.py
+++ b/api/graphql/base_mutations.py
@@ -1,5 +1,6 @@
 import graphene
 from graphene_permissions.mixins import AuthMutation
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import get_object_or_404
 
 
@@ -7,7 +8,7 @@ class AuthSerializerMutation(AuthMutation):
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
         if not cls.has_permission(root, info, input):
-            return None
+            raise PermissionDenied("No permission to mutate")
 
         return super().mutate_and_get_payload(root, info, **input)
 

--- a/api/graphql/tests/test_units.py
+++ b/api/graphql/tests/test_units.py
@@ -1,0 +1,69 @@
+import json
+
+from assertpy import assert_that
+from django.contrib.auth import get_user_model
+from graphene_django.utils import GraphQLTestCase
+
+from permissions.models import UnitRole, UnitRoleChoice, UnitRolePermission
+from spaces.models import Unit
+from spaces.tests.factories import UnitFactory
+
+
+class UnitsUpdateTestCase(GraphQLTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.unit = UnitFactory()
+
+        cls.unit_admin = get_user_model().objects.create(
+            username="gen_admin",
+            first_name="Admin",
+            last_name="General",
+            email="amin.general@foo.com",
+        )
+        unit_role_choice = UnitRoleChoice.objects.get(code="admin")
+        UnitRole.objects.create(
+            user=cls.unit_admin, role=unit_role_choice, unit=cls.unit
+        )
+        UnitRolePermission.objects.create(
+            role=unit_role_choice, permission="can_manage_units"
+        )
+
+        cls.regular_joe = get_user_model().objects.create(
+            username="regjoe",
+            first_name="joe",
+            last_name="regular",
+            email="joe.regularl@foo.com",
+        )
+
+    def get_update_query(self):
+        return "mutation updateUnit($input: UnitUpdateMutationInput!) {updateUnit(input: $input){pk}}"
+
+    def test_admin_can_update_unit(self):
+        self._client.force_login(self.unit_admin)
+        desc = "Awesomeunit"
+        response = self.query(
+            self.get_update_query(),
+            input_data={"pk": self.unit.pk, "description": desc},
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(Unit.objects.get(pk=self.unit.pk).description).is_equal_to(desc)
+
+    def test_normal_user_cannot_update_unit(self):
+        self._client.force_login(self.regular_joe)
+        desc = "Awesomeunit"
+        response = self.query(
+            self.get_update_query(),
+            input_data={"pk": self.unit.pk, "description": desc},
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")[0]["message"]).contains(
+            "No permission to mutate"
+        )
+        assert_that(Unit.objects.get(pk=self.unit.pk).description).is_empty()

--- a/api/graphql/units/unit_serializers.py
+++ b/api/graphql/units/unit_serializers.py
@@ -3,5 +3,15 @@ from api.units_api.serializers import UnitSerializer
 
 
 class UnitUpdateSerializer(UnitSerializer, PrimaryKeyUpdateSerializer):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["tprek_id"].required = False
+        self.fields["name"].required = False
+        self.fields["description"].required = False
+        self.fields["short_description"].required = False
+        self.fields["web_page"].required = False
+        self.fields["email"].required = False
+        self.fields["phone"].required = False
+
     class Meta(UnitSerializer.Meta):
         fields = UnitSerializer.Meta.fields + ["pk"]

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from django.shortcuts import get_object_or_404
 from graphene_permissions.permissions import BasePermission
 from graphql import ResolveInfo
 
@@ -83,4 +84,6 @@ class UnitPermission(BasePermission):
 
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
-        return can_manage_units(info.context.user)
+        pk = input.get("pk")
+        unit = get_object_or_404(Unit, pk=pk)
+        return can_manage_units(info.context.user, unit)


### PR DESCRIPTION
Also finetunes permissions checks for auth serializer mutations to raise permission error.