### PR TITLE
TILA-750 | Read origin id from hauki

### DIFF
--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -177,6 +177,7 @@ def get_mocked_opening_hours(uuid):
     return [
         {
             "resource_id": resource_id,
+            "origin_id": str(uuid),
             "date": datetime.date(2020, 1, 1),
             "times": [
                 TimeElement(
@@ -190,6 +191,7 @@ def get_mocked_opening_hours(uuid):
         },
         {
             "resource_id": resource_id,
+            "origin_id": str(uuid),
             "date": datetime.date(2020, 1, 2),
             "times": [
                 TimeElement(

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -165,6 +165,7 @@ def get_opening_hours(
         for opening_hours in day_data_in["opening_hours"]:
             day_data_out = {
                 "resource_id": day_data_in["resource"]["id"],
+                "origin_id": day_data_in["resource"]["origins"]["origin_id"],
                 "date": datetime.datetime.strptime(
                     opening_hours["date"], "%Y-%m-%d"
                 ).date(),

--- a/opening_hours/tests/test_opening_hours_client.py
+++ b/opening_hours/tests/test_opening_hours_client.py
@@ -28,6 +28,7 @@ class OpeningHoursClientTestCase(TestCase):
         return [
             {
                 "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
                 "date": DATES[0],
                 "times": [
                     TimeElement(
@@ -39,6 +40,7 @@ class OpeningHoursClientTestCase(TestCase):
             },
             {
                 "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
                 "date": DATES[1],
                 "times": [
                     TimeElement(

--- a/opening_hours/utils/opening_hours_client.py
+++ b/opening_hours/utils/opening_hours_client.py
@@ -34,14 +34,11 @@ class OpeningHoursClient:
 
         self.resources = {}
 
-        self.resources = {
-            f"{self.hauki_origin_id}:{resource_id}": resource_id
-            for resource_id in resources
-        }
+        self.resources = resources
         self.opening_hours = {}
         if init_opening_hours:
             self._init_opening_hours_structure()
-            self._fetch_opening_hours(resources, start, end)
+            self._fetch_opening_hours(start, end)
 
         self.periods = {}
         for resource in resources:
@@ -63,24 +60,21 @@ class OpeningHoursClient:
             ...
         }
         """
-        self.opening_hours = {res_id: {} for k, res_id in self.resources.items()}
+        self.opening_hours = {res_id: {} for res_id in self.resources}
         running_date = self.start
         while running_date <= self.end:
-            for k, res_id in self.resources.items():
+            for res_id in self.resources:
                 self.opening_hours[res_id].update({running_date: []})
             running_date += datetime.timedelta(days=1)
 
-    def _fetch_opening_hours(
-        self, resources: [str], start: datetime.date, end: datetime.date
-    ):
-        for hour in get_opening_hours(resources, start, end, self.hauki_origin_id):
-            res_id = self.resources[hour["resource_id"]]
+    def _fetch_opening_hours(self, start: datetime.date, end: datetime.date):
+        for hour in get_opening_hours(self.resources, start, end, self.hauki_origin_id):
+            res_id = hour["origin_id"]
             self.opening_hours[res_id][hour["date"]].extend(hour["times"])
 
     def refresh_opening_hours(self):
         self._init_opening_hours_structure()
-        resources = [res_id for k, res_id in self.resources.items()]
-        self._fetch_opening_hours(resources, self.start, self.end)
+        self._fetch_opening_hours(self.start, self.end)
 
     def get_opening_hours_for_resource(self, resource, date) -> [TimeElement]:
         resource = self.opening_hours.get(resource, {})

--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -58,6 +58,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
         return [
             {
                 "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
                 "date": self.DATES[0],
                 "times": [
                     TimeElement(
@@ -69,6 +70,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
             },
             {
                 "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
                 "date": self.DATES[1],
                 "times": [
                     TimeElement(


### PR DESCRIPTION
Previously we were using the resource id from hauki as origin id from
hauki but those two are separate ids and that caused some problems in
OpeningHoursClient.
This fixes that so that the origin id is read which is the id that tvp
uses for resources.

TILA-750