### PR TITLE
TILA-733: Add calendar URL for created reservations

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -1,7 +1,10 @@
 import graphene
 from graphene_permissions.mixins import AuthNode
+from graphql.execution.base import ResolveInfo
+from rest_framework.reverse import reverse
 
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.ical_api import hmac_signature
 from reservations.models import Reservation
 
 
@@ -10,3 +13,14 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
         model = Reservation
 
         interfaces = (graphene.relay.Node,)
+
+    calendar_url = graphene.String()
+
+    def resolve_calendar_url(self, info: ResolveInfo) -> str:
+        if self is None:
+            return ""
+        scheme = info.context.scheme
+        host = info.context.get_host()
+        calendar_url = reverse("reservation_calendar-detail", kwargs={"pk": self.pk})
+        signature = hmac_signature(f"reservation-{self.pk}")
+        return f"{scheme}://{host}{calendar_url}?hash={signature}"

--- a/api/graphql/tests/test_reservations.py
+++ b/api/graphql/tests/test_reservations.py
@@ -1,0 +1,51 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from django.contrib.auth import get_user_model
+from freezegun import freeze_time
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from reservation_units.tests.factories import ReservationUnitFactory
+
+
+@freeze_time("2021-09-24")
+class ReservationTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = get_user_model().objects.create()
+        cls.reservation_unit = ReservationUnitFactory()
+
+        cls.api_client = APIClient()
+
+    def test_creating_reservation(self):
+        self.maxDiff = None
+        response = self.query(
+            f"""
+            mutation {{
+              createReservation(input: {{
+                state: "created"
+                user: {self.user.pk}
+                priority: "100"
+                begin: "2020-01-01T00:00:00Z"
+                end: "2020-01-01T01:00:00Z"
+                reservationUnit: {self.reservation_unit.pk}
+              }}) {{
+                reservation {{
+                  id
+                  priority
+                  calendarUrl
+                }}
+                errors {{
+                  field
+                  messages
+                }}
+              }}
+            }}
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/api/ical_api.py
+++ b/api/ical_api.py
@@ -56,6 +56,40 @@ class ReservationUnitCalendarUrlSerializer(serializers.ModelSerializer):
         return f"{scheme}://{get_host(request)}{calendar_url}?hash={hmac_signature(instance.uuid)}"
 
 
+class ReservationIcalViewset(ViewSet):
+    queryset = Reservation.objects.all()
+
+    def get_object(self):
+        return Reservation.objects.get(pk=self.kwargs["pk"])
+
+    def retrieve(self, request, *args, **kwargs):
+        hash = request.query_params.get("hash", None)
+        if hash is None:
+            raise ValidationError("hash is required")
+
+        instance = self.get_object()
+        # We use a prefix for the value to sign, because using the plain integer PK
+        # could enable reusing the hashes for accessing other resources.
+        comparison_signature = hmac_signature(f"reservation-{instance.pk}")
+
+        if not hmac.compare_digest(comparison_signature, hash):
+            raise ValidationError("invalid hash signature")
+
+        buffer = io.BytesIO()
+        buffer.write(
+            export_reservation_events(
+                instance,
+                get_host(request),
+                reservation_unit_calendar(instance.reservation_unit),
+            ).to_ical()
+        )
+        buffer.seek(0)
+
+        return FileResponse(
+            buffer, as_attachment=True, filename="reservation_calendar.ics"
+        )
+
+
 class ReservationUnitCalendarUrlViewSet(
     viewsets.GenericViewSet,
     mixins.RetrieveModelMixin,
@@ -173,20 +207,25 @@ def export_reservation_unit_events(
 ):
     reservations = Reservation.objects.filter(reservation_unit=reserlation_unit)
     for reservation in reservations:
-        ical_event = Event()
-        ical_event.add(
-            "summary",
-            reservation.recurring_reservation.application_event.name
-            if reservation.recurring_reservation
-            else "",
-        )
-        ical_event.add("dtstart", reservation.begin)
-        ical_event.add("dtend", reservation.end)
-        ical_event.add("dtstamp", datetime.datetime.now())
-        ical_event.add("description", reservation.get_ical_description())
-        ical_event.add("location", reservation.get_location_string())
-        ical_event["uid"] = "%s.event.events.%s" % (reservation.id, site_name)
-        cal.add_component(ical_event)
+        export_reservation_events(reservation, site_name, cal)
+    return cal
+
+
+def export_reservation_events(reservation: Reservation, site_name: str, cal: Calendar):
+    ical_event = Event()
+    ical_event.add(
+        "summary",
+        reservation.recurring_reservation.application_event.name
+        if reservation.recurring_reservation
+        else "",
+    )
+    ical_event.add("dtstart", reservation.begin)
+    ical_event.add("dtend", reservation.end)
+    ical_event.add("dtstamp", datetime.datetime.now())
+    ical_event.add("description", reservation.get_ical_description())
+    ical_event.add("location", reservation.get_location_string())
+    ical_event["uid"] = f"{reservation.pk}.event.events.{site_name}"
+    cal.add_component(ical_event)
     return cal
 
 

--- a/api/tests/test_ical_api.py
+++ b/api/tests/test_ical_api.py
@@ -5,7 +5,7 @@ import pytest
 from assertpy import assert_that
 from rest_framework.reverse import reverse
 
-from api.ical_api import uuid_to_hmac_signature
+from api.ical_api import hmac_signature
 
 
 @pytest.mark.django_db
@@ -31,7 +31,7 @@ def test_unit_group_admin_can_get_calendar_url(
     assert response.status_code == 200
     assert response.data.get("calendar_url") == (
         f"http://testserver/v1/reservation_unit_calendar/{reservation_unit.id}"
-        f"/?hash={uuid_to_hmac_signature(reservation_unit.uuid)}"
+        f"/?hash={hmac_signature(reservation_unit.uuid)}"
     )
 
 
@@ -56,7 +56,7 @@ def test_getting_reservation_unit_calendar(
     base_url = reverse(
         "reservation_unit_calendar-detail", kwargs={"pk": reservation_unit.id}
     )
-    url = f"{base_url}?hash={uuid_to_hmac_signature(reservation_unit.uuid)}"
+    url = f"{base_url}?hash={hmac_signature(reservation_unit.uuid)}"
     response = user_api_client.get(url)
     assert response.status_code == 200
     zip_content = (
@@ -97,7 +97,7 @@ def test_getting_reservation_unit_calendar_with_invalid_hash(
     base_url = reverse(
         "reservation_unit_calendar-detail", kwargs={"pk": reservation_unit.id}
     )
-    url = f"{base_url}?hash={uuid_to_hmac_signature(uuid.uuid4())}"
+    url = f"{base_url}?hash={hmac_signature(uuid.uuid4())}"
     response = user_api_client.get(url)
     assert response.status_code == 400
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -18,6 +18,7 @@ from .declined_reservation_units_api import DeclinedReservationUnitViewSet
 from .hauki_api import OpeningHoursViewSet
 from .ical_api import (
     ApplicationEventIcalViewset,
+    ReservationIcalViewset,
     ReservationUnitCalendarUrlViewSet,
     ReservationUnitIcalViewset,
 )
@@ -90,6 +91,11 @@ router.register(
     r"reservation_unit_calendar",
     ReservationUnitIcalViewset,
     "reservation_unit_calendar",
+)
+router.register(
+    r"reservation_calendar",
+    ReservationIcalViewset,
+    "reservation_calendar",
 )
 
 


### PR DESCRIPTION
This PR adds calendar URL for created reservations.

For example, when creating a new reservation like this:

```graphql
mutation {
  createReservation(input: {
    state: "created"
    user: 1
    priority: "100"
    begin: "2020-01-01T00:00:00Z"
    end: "2020-01-01T00:00:00Z"
    reservationUnit: 1
  }) {
    reservation {
      id
      priority
      calendarUrl
    }
    errors {
      field
      messages
    }
  }
}
``` 
...the response will look like this:
```json
{
  "data": {
    "createReservation": {
      "reservation": {
        "id": "UmVzZXJ2YXRpb25UeXBlOjIw",
        "priority": "A_100",
        "calendarUrl": "http://0.0.0.0:8000/v1/reservation_calendar/20/?hash=fcc8548de047b5da4210453e089830f0889ec4cbe5ac83876f831e4185ac0df6"
      },
      "errors": []
    }
  }
}
```
For the HMAC signatures for reservations, I calculated the digest for `reservation-<PK>` instead of just `<PK>`, because signing the PK alone might enable the hash to be used for accessing other types of resources in the future, since it's not unique like a UUID.