### PR TITLE
TILA-758: Add active application rounds to GraphQL API

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -4,7 +4,16 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
+
+snapshots["ReservationUnitTestCase::test_filtering_by_active_application_rounds 1"] = {
+    "data": {
+        "reservationUnits": {
+            "edges": [{"node": {"applicationRounds": [{"name": "Test Round"}]}}]
+        }
+    }
+}
 
 snapshots["ReservationUnitTestCase::test_filtering_by_keyword_group 1"] = {
     "data": {
@@ -154,6 +163,7 @@ snapshots["ReservationUnitTestCase::test_getting_reservation_units 1"] = {
             "edges": [
                 {
                     "node": {
+                        "applicationRounds": [],
                         "contactInformation": "",
                         "description": "",
                         "equipment": [],


### PR DESCRIPTION
This PR adds application rounds to the reservation unit GraphQL API.

I did this by adding a `applicationRounds` field to the reservation unit type. For example:

```graphql
{
  reservationUnits {
    edges {
      node {
        name
      	applicationRounds {
          name
          applicationPeriodBegin
          applicationPeriodEnd
          status
      	}
      }
    }
  }
}
```
The above returns reservation units with application rounds related to each:
```json
{
  "data": {
    "reservationUnits": {
      "edges": [
        {
          "node": {
            "name": "Test reservation unit",
            "applicationRounds": [
              {
                "name": "Test Round",
                "applicationPeriodBegin": "2021-09-27T08:37:14.153445+00:00",
                "applicationPeriodEnd": "2021-10-25T08:37:14.153464+00:00",
                "status": "DRAFT"
              }
            ]
          }
        }
      ]
    }
  }
}
```

To get only the *active* application rounds, the `active: true` filter can be used:

```graphql
{
  reservationUnits {
    edges {
      node {
        name
      	applicationRounds(active: true) {
          name
          applicationPeriodBegin
          applicationPeriodEnd
          status
      	}
      }
    }
  }
}
```
This returns application rounds where the current time falls between the application period begin/end timestamps.

**Note:** I have also updated `schema.json` by running `python manage.py graphql_schema`. It seemed to be out of date so the GraphiQL interface was not detecting the schema correctly.