### PR TITLE
TILA-737: Modifications for reservations related to reservation units

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -239,8 +239,8 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     keyword_groups = graphene.List(KeywordGroupType)
     reservations = graphene.List(
         ReservationType,
-        from_=graphene.DateTime(name="from"),
-        to=graphene.DateTime(),
+        from_=graphene.Date(name="from"),
+        to=graphene.Date(),
         state=graphene.List(graphene.String),
     )
     application_rounds = graphene.List(ApplicationRoundType, active=graphene.Boolean())
@@ -347,8 +347,8 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     def resolve_reservations(
         self,
         info: ResolveInfo,
-        from_: Optional[datetime.datetime] = None,
-        to: Optional[datetime.datetime] = None,
+        from_: Optional[datetime.date] = None,
+        to: Optional[datetime.date] = None,
         state: Optional[List[str]] = None,
     ) -> QuerySet:
         reservations = self.reservation_set.all()

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import List, Optional
 
 import graphene
 from django.conf import settings
@@ -241,7 +241,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
         ReservationType,
         from_=graphene.DateTime(name="from"),
         to=graphene.DateTime(),
-        state=graphene.String(),
+        state=graphene.List(graphene.String),
     )
     application_rounds = graphene.List(ApplicationRoundType, active=graphene.Boolean())
 
@@ -349,7 +349,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
         info: ResolveInfo,
         from_: Optional[datetime.datetime] = None,
         to: Optional[datetime.datetime] = None,
-        state: Optional[str] = None,
+        state: Optional[List[str]] = None,
     ) -> QuerySet:
         reservations = self.reservation_set.all()
         if from_ is not None:
@@ -357,7 +357,8 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
         if to is not None:
             reservations = reservations.filter(end__lte=to)
         if state is not None:
-            reservations = reservations.filter(state=getattr(STATE_CHOICES, state))
+            states = [getattr(STATE_CHOICES, s) for s in state]
+            reservations = reservations.filter(state__in=states)
         return reservations
 
     def resolve_application_rounds(

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -11,7 +11,6 @@ from reservations.models import Reservation
 class ReservationType(AuthNode, PrimaryKeyObjectType):
     class Meta:
         model = Reservation
-        filter_types = ["state"]
         interfaces = (graphene.relay.Node,)
 
     class Input:

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -14,8 +14,8 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
         interfaces = (graphene.relay.Node,)
 
     class Input:
-        from_ = graphene.Field(graphene.DateTime, name="from")
-        to = graphene.Field(graphene.DateTime)
+        from_ = graphene.Field(graphene.Date, name="from")
+        to = graphene.Field(graphene.Date)
 
     calendar_url = graphene.String()
 

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -37,6 +37,34 @@ snapshots["ReservationUnitTestCase::test_filtering_by_max_persons_not_found 1"] 
     "data": {"reservationUnits": {"edges": []}}
 }
 
+snapshots[
+    "ReservationUnitTestCase::test_filtering_by_multiple_reservation_states 1"
+] = {
+    "data": {
+        "reservationUnits": {
+            "edges": [
+                {
+                    "node": {
+                        "name": "Test name",
+                        "reservations": [
+                            {
+                                "begin": "2021-05-03T00:00:00+00:00",
+                                "end": "2021-05-03T01:00:00+00:00",
+                                "state": "CREATED",
+                            },
+                            {
+                                "begin": "2021-05-03T01:00:00+00:00",
+                                "end": "2021-05-03T02:00:00+00:00",
+                                "state": "CONFIRMED",
+                            },
+                        ],
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots["ReservationUnitTestCase::test_filtering_by_reservation_state 1"] = {
     "data": {
         "reservationUnits": {

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -501,7 +501,7 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
                     edges {
                         node {
                             name
-                            reservations(from: "2021-05-03T00:00:00Z", to: "2021-05-04T00:00:00Z") {
+                            reservations(from: "2021-05-03", to: "2021-05-04") {
                                 begin
                                 end
                                 state

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -560,6 +560,52 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_filtering_by_multiple_reservation_states(self):
+        now = datetime.datetime.now().astimezone()
+        one_hour = datetime.timedelta(hours=1)
+        two_hours = datetime.timedelta(hours=2)
+        matching_reservations = [
+            ReservationFactory(
+                begin=now, end=now + one_hour, state=STATE_CHOICES.CREATED
+            ),
+            ReservationFactory(
+                begin=now + one_hour, end=now + two_hours, state=STATE_CHOICES.CONFIRMED
+            ),
+        ]
+        other_reservation = ReservationFactory(
+            begin=now + two_hours,
+            end=now + two_hours + one_hour,
+            state=STATE_CHOICES.CANCELLED,
+        )
+        self.reservation_unit.reservation_set.set(
+            matching_reservations + [other_reservation]
+        )
+        self.reservation_unit.save()
+
+        response = self.query(
+            """
+            query {
+                reservationUnits {
+                    edges {
+                        node {
+                            name
+                            reservations(state: ["CREATED", "CONFIRMED"]) {
+                                begin
+                                end
+                                state
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
     def test_filtering_by_active_application_rounds(self):
         now = datetime.datetime.now().astimezone()
         one_hour = datetime.timedelta(hours=1)


### PR DESCRIPTION
After discussing with frontend developers, we came up with a couple of some modifications for fetching the reservations:

* Ability to filter reservations by multiple states (e.g. `["CREATED", "CONFIRMED"]`)
* Use `date` instead of `datetime` for filtering between timestamps (we don't really have a need to filter more granularly)

After these, we can filter by either a single state:

```graphql
{
  reservationUnitByPk(pk: 1) {
    name
    reservations(state: "CREATED") {
      begin
      end
      state
    }
  }
}
```
...or by multiple states:
```graphql
{
  reservationUnitByPk(pk: 1) {
    name
    reservations(state: ["CREATED", "CONFIRMED"]) {
      begin
      end
      state
    }
  }
}
```
Also, dates without hours and minutes will be used to filter by dates:
```graphql
{
  reservationUnitByPk(pk: 1) {
    name
    reservations(from: "2020-01-01", to: "2020-01-02") {
      begin
      end
      state
    }
  }
}
```