### PR TITLE
TILA-893 | Make openinghours client timezone aware

### DIFF
--- a/api/graphql/opening_hours/opening_hours_types.py
+++ b/api/graphql/opening_hours/opening_hours_types.py
@@ -1,7 +1,10 @@
 import graphene
 from django.conf import settings
+from django.utils.timezone import get_default_timezone
 
 from opening_hours.utils.opening_hours_client import OpeningHoursClient
+
+DEFAULT_TIMEZONE = get_default_timezone()
 
 
 class TimeSpanType(graphene.ObjectType):
@@ -16,6 +19,22 @@ class TimeSpanType(graphene.ObjectType):
     description_fi = graphene.String()
     description_en = graphene.String()
     description_sv = graphene.String()
+
+    def resolve_start_time(self, info):
+        if not self.start_time:
+            return None
+        tzinfo = self.start_time.tzinfo or DEFAULT_TIMEZONE
+        start = tzinfo.localize(self.start_time)
+
+        return start
+
+    def resolve_end_time(self, info):
+        if not self.end_time:
+            return None
+        tzinfo = self.start_time.tzinfo or DEFAULT_TIMEZONE
+        end = tzinfo.localize(self.end_time)
+
+        return end
 
 
 class PeriodType(graphene.ObjectType):
@@ -43,10 +62,20 @@ class OpeningTimesType(graphene.ObjectType):
         return self.date
 
     def resolve_start_time(self, info):
-        return self.start_time
+        if not self.start_time:
+            return None
+        tzinfo = self.start_time.tzinfo or DEFAULT_TIMEZONE
+        start = tzinfo.localize(self.start_time)
 
-    def resolve_end_Time(self, info):
-        return self.end_time
+        return start
+
+    def resolve_end_time(self, info):
+        if not self.end_time:
+            return None
+        tzinfo = self.start_time.tzinfo or DEFAULT_TIMEZONE
+        end = tzinfo.localize(self.end_time)
+
+        return end
 
     def resolve_periods(self, info, **kwargs):
         return self.periods

--- a/api/graphql/opening_hours/opening_hours_types.py
+++ b/api/graphql/opening_hours/opening_hours_types.py
@@ -96,8 +96,8 @@ class OpeningHoursMixin:
                 for time in times:
                     oh = OpeningTimesType(
                         date=date,
-                        start_time=time.start_time,
-                        end_time=time.end_time,
+                        start_time=time.start_time.time(),
+                        end_time=time.end_time.time(),
                         state=time.resource_state,
                         periods=time.periods,
                     )

--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.utils.timezone import get_default_timezone
 from rest_framework import serializers
 
 from api.graphql.base_serializers import (
@@ -11,6 +12,8 @@ from reservation_units.utils.reservation_unit_reservation_scheduler import (
     ReservationUnitReservationScheduler,
 )
 from reservations.models import STATE_CHOICES, Reservation
+
+DEFAULT_TIMEZONE = get_default_timezone()
 
 
 class ReservationCreateSerializer(PrimaryKeySerializer):
@@ -47,6 +50,9 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
     def validate(self, data):
         begin = data.get("begin", getattr(self.instance, "begin", None))
         end = data.get("end", getattr(self.instance, "end", None))
+        begin = begin.astimezone(DEFAULT_TIMEZONE)
+        end = end.astimezone(DEFAULT_TIMEZONE)
+
         duration = end - begin
         reservation_units = data.get(
             "reservation_unit", getattr(self.instance, "reservation_unit", None)

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -217,7 +217,13 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
             .get("reservationUnitByPk")
             .get("openingHours")
             .get("openingTimes")[0]["startTime"]
-        ).is_equal_to("10:00:00")
+        ).is_equal_to("10:00:00+00:00")
+        assert_that(
+            content.get("data")
+            .get("reservationUnitByPk")
+            .get("openingHours")
+            .get("openingTimes")[0]["endTime"]
+        ).is_equal_to("22:00:00+00:00")
 
     def test_filtering_by_type(self):
         response = self.query(

--- a/api/graphql/tests/test_reservations.py
+++ b/api/graphql/tests/test_reservations.py
@@ -20,6 +20,8 @@ from reservations.models import STATE_CHOICES, Reservation
 from reservations.tests.factories import ReservationFactory
 from spaces.tests.factories import SpaceFactory
 
+DEFAULT_TIMEZONE = get_default_timezone()
+
 
 @freezegun.freeze_time("2021-10-12T12:00:00Z")
 class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
@@ -33,6 +35,7 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
         resource_id = f"{settings.HAUKI_ORIGIN_ID}:{self.reservation_unit.uuid}"
         return [
             {
+                "timezone": DEFAULT_TIMEZONE,
                 "resource_id": resource_id,
                 "origin_id": str(self.reservation_unit.uuid),
                 "date": datetime.date.today(),

--- a/opening_hours/decorators.py
+++ b/opening_hours/decorators.py
@@ -1,0 +1,26 @@
+import datetime
+
+from django.utils.timezone import get_default_timezone
+
+TIMEZONE = get_default_timezone()
+
+
+def datetime_args_to_default_timezone(func: callable):
+    def convert_to_utc(*args, **kwargs):
+        converted_args = []
+        for arg in args:
+            if isinstance(arg, datetime.datetime):
+                arg = arg.astimezone(TIMEZONE)
+            elif isinstance(arg, datetime.time):
+                timezone = arg.tzinfo
+                if not timezone:
+                    timezone = TIMEZONE
+                dt = timezone.localize(
+                    datetime.datetime(1977, 1, 1, arg.hour, arg.minute, arg.second)
+                )
+                arg = dt.astimezone(TIMEZONE).time()
+            converted_args.append(arg)
+
+        return func(*converted_args, **kwargs)
+
+    return convert_to_utc

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -3,11 +3,16 @@ import logging
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Union
 
+import pytz
 from django.conf import settings
+from django.utils.timezone import get_default_timezone
 
 from opening_hours.enums import State
 from opening_hours.errors import HaukiConfigurationError
 from opening_hours.hauki_request import make_hauki_get_request
+
+REQUESTS_TIMEOUT = 15
+DEFAULT_TIMEZONE = get_default_timezone()
 
 logger = logging.getLogger(__name__)
 
@@ -125,8 +130,12 @@ def get_opening_hours(
 
     days_data_out = []
     for day_data_in in days_data_in["results"]:
+        timezone = pytz.timezone(
+            day_data_in.get("resource", {}).get("timezone", DEFAULT_TIMEZONE.zone)
+        )
         for opening_hours in day_data_in["opening_hours"]:
             day_data_out = {
+                "timezone": timezone,
                 "resource_id": day_data_in["resource"]["id"],
                 "origin_id": day_data_in["resource"]["origins"][0]["origin_id"],
                 "date": datetime.datetime.strptime(

--- a/opening_hours/utils/opening_hours_client.py
+++ b/opening_hours/utils/opening_hours_client.py
@@ -1,14 +1,74 @@
 import datetime
-from typing import Dict, List
+from typing import Dict, List, Union
 
+import pytz
 from django.conf import settings
+from django.utils.timezone import get_default_timezone
 
+from opening_hours.decorators import datetime_args_to_default_timezone
 from opening_hours.hours import (
     Period,
     TimeElement,
     get_opening_hours,
     get_periods_for_resource,
 )
+
+TIMEZONE = get_default_timezone()
+
+
+class OpeningHours:
+    start_time: datetime.datetime
+    end_time: datetime.datetime
+    resource_state: str
+    periods: List[int]
+
+    def __init__(
+        self,
+        start_time: datetime.datetime,
+        end_time: datetime.datetime,
+        resource_state: str,
+        periods: List[int],
+    ):
+        self.start_time = start_time
+        self.end_time = end_time
+        self.resource_state = resource_state
+        self.periods = periods
+
+    @classmethod
+    def get_opening_hours_class_from_time_element(
+        cls,
+        time_element: TimeElement,
+        date: datetime.date,
+        timezone: Union[
+            type(pytz.UTC), pytz.tzinfo.DstTzInfo, pytz.tzinfo.StaticTzInfo
+        ],
+    ):
+        start_time = timezone.localize(
+            datetime.datetime(
+                date.year,
+                date.month,
+                date.day,
+                time_element.start_time.hour,
+                time_element.end_time.minute,
+            )
+        )
+        if time_element.end_time_on_next_day:
+            date += datetime.timedelta(days=1)
+        end_time = timezone.localize(
+            datetime.datetime(
+                date.year,
+                date.month,
+                date.day,
+                time_element.end_time.hour,
+                time_element.end_time.minute,
+            )
+        )
+        return OpeningHours(
+            start_time=start_time.astimezone(TIMEZONE),
+            end_time=end_time.astimezone(TIMEZONE),
+            resource_state=time_element.resource_state,
+            periods=time_element.periods,
+        )
 
 
 class OpeningHoursClient:
@@ -53,10 +113,10 @@ class OpeningHoursClient:
         """Opening hours structure is:
         opening_hours = {
             resource_id: {
-                            datetime.date: [TimeElement, TimeElement, ...],
+                            datetime.date: [OpeningHours, OpeningHours, ...],
                             ....
                         },
-            resource_id: { datetime.date: [TimeElement, ...
+            resource_id: { datetime.date: [OpeningHours, ...
             ...
         }
         """
@@ -70,7 +130,16 @@ class OpeningHoursClient:
     def _fetch_opening_hours(self, start: datetime.date, end: datetime.date):
         for hour in get_opening_hours(self.resources, start, end, self.hauki_origin_id):
             res_id = hour["origin_id"]
-            self.opening_hours[res_id][hour["date"]].extend(hour["times"])
+            timezone = hour["timezone"]
+            date = hour["date"]
+            opening_hours = []
+            for time in hour["times"]:
+                opening_times = OpeningHours.get_opening_hours_class_from_time_element(
+                    time, date, timezone
+                )
+                opening_hours.append(opening_times)
+
+            self.opening_hours[res_id][date].extend(opening_hours)
 
     def refresh_opening_hours(self):
         self._init_opening_hours_structure()
@@ -94,22 +163,19 @@ class OpeningHoursClient:
     def get_resource_periods(self, resource) -> List[Period]:
         return self.periods.get(resource)
 
+    @datetime_args_to_default_timezone
     def is_resource_open(
         self, resource: str, start_time: datetime.datetime, end_time: datetime.datetime
     ) -> bool:
         times = self.get_opening_hours_for_resource(resource, start_time.date())
         for time in times:
-            if (
-                time.start_time <= start_time.time()
-                and time.end_time >= end_time.time()
-                and (time.end_time_on_next_day or end_time.date() == start_time.date())
-            ):
+            if time.start_time <= start_time and time.end_time >= end_time:
                 return True
         return False
 
     def next_opening_times(
         self, resource: str, date: datetime.date
-    ) -> (datetime.date, [TimeElement]):
+    ) -> (datetime.date, [OpeningHours]):
         times_for_resource = self.opening_hours.get(resource, {})
         times = times_for_resource.get(date)
 

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -4,6 +4,8 @@ from django.utils.timezone import get_default_timezone
 
 from opening_hours.utils.opening_hours_client import OpeningHoursClient
 
+DEFAULT_TIMEZONE = get_default_timezone()
+
 
 class ReservationUnitReservationScheduler:
     APRIL = 4
@@ -22,8 +24,8 @@ class ReservationUnitReservationScheduler:
         else:
             self.reservation_duration = 1
 
-        self.start_time = datetime.datetime.now(
-            tz=get_default_timezone()
+        self.start_time = DEFAULT_TIMEZONE.localize(
+            datetime.datetime.now()
         ) + datetime.timedelta(hours=2)
         self.end_time = self.start_time + datetime.timedelta(
             hours=self.reservation_duration
@@ -63,13 +65,14 @@ class ReservationUnitReservationScheduler:
                     open_application_round.reservation_period_end
                     + datetime.timedelta(days=1)
                 )
-                self.start_time = datetime.datetime(
-                    self.start_time.year,
-                    self.start_time.month,
-                    self.start_time.day,
-                    0,
-                    0,
-                    tzinfo=get_default_timezone(),
+                self.start_time = DEFAULT_TIMEZONE.localize(
+                    datetime.datetime(
+                        self.start_time.year,
+                        self.start_time.month,
+                        self.start_time.day,
+                        0,
+                        0,
+                    )
                 )
 
             else:
@@ -125,16 +128,11 @@ class ReservationUnitReservationScheduler:
             if not times:
                 break
             try:
-                opening_hours = sorted([time.start_time.hour for time in times])
-                for hour in [hour for hour in opening_hours if hour >= start.hour]:
-                    matching = datetime.datetime(
-                        open_date.year,
-                        open_date.month,
-                        open_date.day,
-                        hour,
-                        0,
-                        tzinfo=get_default_timezone(),
-                    )
+                opening_hours = sorted([time.start_time for time in times])
+                for start_time in [
+                    start_time for start_time in opening_hours if start_time >= start
+                ]:
+                    matching = start_time
             except ValueError:
                 continue
             start = datetime.timedelta(days=1)


### PR DESCRIPTION
Adds new class to represent opening hours with start and end times using datetimes for handier comparing and handling.
Reads timezone information from hauki for opening hours and uses that in the `OpeningHoursClient` class. 

Note that UI is now receiving opening hours as default timezone (currently UTC0)  