### PR TITLE
TILA-892 | Use custom opening hours end date in ReservationCreateSerializer 

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -60,7 +60,9 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
                     "Overlapping reservations are not allowed."
                 )
 
-            scheduler = ReservationUnitReservationScheduler(reservation_unit)
+            scheduler = ReservationUnitReservationScheduler(
+                reservation_unit, opening_hours_end=end.date()
+            )
             is_reservation_unit_open = scheduler.is_reservation_unit_open(begin, end)
             if not is_reservation_unit_open:
                 raise serializers.ValidationError(

--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -27,6 +27,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
     DATES = [
         datetime.datetime.strptime("2022-01-01", "%Y-%m-%d").date(),
         datetime.datetime.strptime("2022-01-02", "%Y-%m-%d").date(),
+        datetime.datetime.strptime("2023-07-01", "%Y-%m-%d").date(),
     ]
 
     @classmethod
@@ -50,7 +51,9 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
     @mock.patch("opening_hours.utils.opening_hours_client.get_opening_hours")
     def setUp(self, mock) -> None:
         mock.return_value = self.get_mocked_opening_hours()
-        self.scheduler = ReservationUnitReservationScheduler(self.reservation_unit)
+        self.scheduler = ReservationUnitReservationScheduler(
+            self.reservation_unit, opening_hours_end=self.DATES[2]
+        )
         self.app_round.set_status(ApplicationRoundStatus.APPROVED)
 
     def get_mocked_opening_hours(self):
@@ -72,6 +75,18 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
                 "resource_id": resource_id,
                 "origin_id": str(self.reservation_unit.uuid),
                 "date": self.DATES[1],
+                "times": [
+                    TimeElement(
+                        start_time=datetime.time(hour=10),
+                        end_time=datetime.time(hour=22),
+                        end_time_on_next_day=False,
+                    ),
+                ],
+            },
+            {
+                "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
+                "date": self.DATES[2],
                 "times": [
                     TimeElement(
                         start_time=datetime.time(hour=10),

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -8,7 +8,11 @@ from opening_hours.utils.opening_hours_client import OpeningHoursClient
 class ReservationUnitReservationScheduler:
     APRIL = 4
 
-    def __init__(self, reservation_unit):
+    def __init__(
+        self,
+        reservation_unit,
+        opening_hours_end: datetime.date = None,
+    ):
         self.reservation_unit = reservation_unit
 
         if self.reservation_unit.max_reservation_duration:
@@ -29,7 +33,7 @@ class ReservationUnitReservationScheduler:
         self.opening_hours_client = OpeningHoursClient(
             str(self.reservation_unit.uuid),
             self.start_time.date(),
-            self.reservation_date_end,
+            opening_hours_end or self.reservation_date_end,
             single=True,
         )
 


### PR DESCRIPTION
There was a situation that caused the reservation not to be created even it should've been when the reservation would occur after next spring. 
The reason was that the reservation creation validator uses `ReservationUnitReservationScheduler` class which were initially made for fetching next available opening times until next spring (Point when the recurring reservation applications start) and thus it loads opening hours only to that point of time.
This adds new optional date parameter to scheduler class which is used for fetching opening hours until specific date.