### PR TITLE
TILA-777 | Add check_resolver permission check decorator and use it in resolvers

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -21,12 +21,20 @@ from api.graphql.units.unit_types import UnitType
 from applications.models import ApplicationRound
 from opening_hours.hauki_link_generator import generate_hauki_link
 from permissions.api_permissions.drf_permissions import ApplicationRoundPermission
+from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
+)
 from permissions.api_permissions.graphene_permissions import (
     EquipmentCategoryPermission,
     EquipmentPermission,
     PurposePermission,
+    ReservationPermission,
     ReservationUnitHaukiUrlPermission,
     ReservationUnitPermission,
+    ResourcePermission,
+    ServicePermission,
+    SpacePermission,
+    UnitPermission,
 )
 from reservation_units.models import (
     Equipment,
@@ -294,31 +302,37 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     def resolve_location(self, info):
         return self.get_location()
 
+    @check_resolver_permission(SpacePermission)
     def resolve_spaces(self, info):
         return Space.objects.filter(reservation_units=self.id).select_related(
             "parent", "building"
         )
 
+    @check_resolver_permission(ServicePermission)
     def resolve_services(self, info):
         return self.services.all()
 
+    @check_resolver_permission(PurposePermission)
     def resolve_purposes(self, info):
         return Purpose.objects.filter(reservation_units=self.id)
 
     def resolve_images(self, info):
         return ReservationUnitImage.objects.filter(reservation_unit_id=self.id)
 
+    @check_resolver_permission(ResourcePermission)
     def resolve_resources(self, info):
         return Resource.objects.filter(reservation_units=self.id)
 
     def resolve_reservation_unit_type(self, info):
         return self.reservation_unit_type
 
+    @check_resolver_permission(EquipmentPermission)
     def resolve_equipment(self, info):
         if self.equipments is None:
             return []
         return self.equipments.all()
 
+    @check_resolver_permission(UnitPermission)
     def resolve_unit(self, info):
         return self.unit
 
@@ -349,6 +363,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     def resolve_keyword_groups(self, info):
         return KeywordGroup.objects.filter(reservation_units=self.id)
 
+    @check_resolver_permission(ReservationPermission)
     def resolve_reservations(
         self,
         info: ResolveInfo,

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -8,6 +8,7 @@ from rest_framework.reverse import reverse
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.ical_api import hmac_signature
 from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
     recurring_reservation_non_public_field,
     reservation_non_public_field,
 )
@@ -16,6 +17,7 @@ from permissions.api_permissions.graphene_permissions import (
     AgeGroupPermission,
     RecurringReservationPermission,
     ReservationPermission,
+    ReservationUnitPermission,
 )
 from reservations.models import (
     AbilityGroup,
@@ -142,6 +144,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
 
     calendar_url = graphene.String()
 
+    @reservation_non_public_field
     def resolve_calendar_url(self, info: ResolveInfo) -> str:
         if self is None:
             return ""
@@ -157,5 +160,6 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             return None
         return self.user.email
 
+    @check_resolver_permission(ReservationUnitPermission)
     def resolve_reservation_units(self, info: ResolveInfo):
         return self.reservation_unit.all()

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -54,6 +54,9 @@ from api.graphql.spaces.space_mutations import (
 from api.graphql.spaces.space_types import SpaceType
 from api.graphql.units.unit_mutations import UnitUpdateMutation
 from api.graphql.units.unit_types import UnitByPkType, UnitType
+from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
+)
 from permissions.api_permissions.graphene_permissions import (
     EquipmentCategoryPermission,
     EquipmentPermission,
@@ -202,26 +205,32 @@ class Query(graphene.ObjectType):
 
     purposes = PurposeFilter(PurposeType)
 
+    @check_resolver_permission(ReservationUnitPermission)
     def resolve_reservation_unit_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(ReservationUnit, pk=pk)
 
+    @check_resolver_permission(ResourcePermission)
     def resolve_resource_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(Resource, pk=pk)
 
+    @check_resolver_permission(UnitPermission)
     def resolve_unit_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(Unit, pk=pk)
 
+    @check_resolver_permission(SpacePermission)
     def resolve_space_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(Space, pk=pk)
 
+    @check_resolver_permission(EquipmentPermission)
     def resolve_equipment_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(Equipment, pk=pk)
 
+    @check_resolver_permission(EquipmentCategoryPermission)
     def resolve_equipment_category_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(EquipmentCategory, pk=pk)

--- a/api/graphql/spaces/space_types.py
+++ b/api/graphql/spaces/space_types.py
@@ -5,7 +5,13 @@ from graphene_permissions.permissions import AllowAny
 
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.graphql.translate_fields import get_all_translatable_fields
-from permissions.api_permissions.graphene_permissions import SpacePermission
+from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
+)
+from permissions.api_permissions.graphene_permissions import (
+    ResourcePermission,
+    SpacePermission,
+)
 from spaces.models import Building, District, Location, RealEstate, Space
 
 
@@ -70,6 +76,7 @@ class SpaceType(AuthNode, PrimaryKeyObjectType):
     def resolve_children(self, info):
         return Space.objects.filter(parent=self)
 
+    @check_resolver_permission(ResourcePermission)
     def resolve_resources(self, info):
         return self.resource_set.all()
 

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -7,7 +7,6 @@ from assertpy import assert_that
 from django.conf import settings
 from django.test import override_settings
 from freezegun import freeze_time
-from graphene_django.utils import GraphQLTestCase
 from rest_framework.test import APIClient
 
 from api.graphql.tests.base import GrapheneTestCaseBase
@@ -31,9 +30,10 @@ from spaces.tests.factories import SpaceFactory, UnitFactory
 
 
 @freeze_time("2021-05-03")
-class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
+class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
     @classmethod
     def setUpTestData(cls):
+        super().setUpTestData()
         cls.type = ReservationUnitTypeFactory(name="Test type")
         large_space = SpaceFactory(
             max_persons=100, name="Large space", surface_area=100
@@ -50,6 +50,7 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
 
     def test_getting_reservation_units(self):
         self.maxDiff = None
+        self._client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -522,6 +523,7 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
         )
         self.reservation_unit.save()
 
+        self._client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -563,7 +565,7 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
             [matching_reservation, other_reservation]
         )
         self.reservation_unit.save()
-
+        self._client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -610,6 +612,7 @@ class ReservationUnitTestCase(GraphQLTestCase, snapshottest.TestCase):
         )
         self.reservation_unit.save()
 
+        self._client.force_login(self.regular_joe)
         response = self.query(
             """
             query {

--- a/api/graphql/units/unit_types.py
+++ b/api/graphql/units/unit_types.py
@@ -6,7 +6,14 @@ from graphene_permissions.permissions import AllowAny
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.graphql.opening_hours.opening_hours_types import OpeningHoursMixin
 from api.graphql.translate_fields import get_all_translatable_fields
-from permissions.api_permissions.graphene_permissions import UnitPermission
+from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
+)
+from permissions.api_permissions.graphene_permissions import (
+    ReservationUnitPermission,
+    SpacePermission,
+    UnitPermission,
+)
 from spaces.models import Unit
 
 
@@ -40,9 +47,11 @@ class UnitType(AuthNode, PrimaryKeyObjectType):
 
         interfaces = (graphene.relay.Node,)
 
+    @check_resolver_permission(ReservationUnitPermission)
     def resolve_reservation_units(self, info):
         return self.reservationunit_set.all()
 
+    @check_resolver_permission(SpacePermission)
     def resolve_spaces(self, info):
         return self.spaces.all()
 

--- a/permissions/api_permissions/graphene_field_decorators.py
+++ b/permissions/api_permissions/graphene_field_decorators.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from graphene_permissions.permissions import BasePermission
 
 from permissions.helpers import can_view_recurring_reservation, can_view_reservation
 
@@ -26,3 +27,19 @@ def recurring_reservation_non_public_field(func: callable):
         return func(*args, **kwargs)
 
     return permission_check
+
+
+def check_resolver_permission(permission_class: BasePermission):
+    def inner(func):
+        def permission_check(*args, **kwargs):
+            if (
+                not settings.TMP_PERMISSIONS_DISABLED
+                and not permission_class.has_permission(args[1])
+            ):
+                return None
+
+            return func(*args, **kwargs)
+
+        return permission_check
+
+    return inner

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -73,6 +73,14 @@ class ResourcePermission(BasePermission):
 
 class ReservationPermission(BasePermission):
     @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        """Authenticated users can see reservations.
+
+        The reservation fields has own permission checks.
+        """
+        return info.context.user.is_authenticated
+
+    @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
         pk = input.get("pk")
         if pk:
@@ -107,6 +115,10 @@ class RecurringReservationPermission(BasePermission):
 
 
 class PurposePermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return True
+
     @classmethod
     def has_filter_permission(cls, info: ResolveInfo) -> bool:
         return True
@@ -148,6 +160,20 @@ class SpacePermission(BasePermission):
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
         return can_manage_spaces(info.context.user)
+
+
+class ServicePermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_filter_permission(cls, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False
 
 
 class UnitPermission(BasePermission):


### PR DESCRIPTION
Decorator that is intended to be used with resolver functions for fields
and in schema for "byPk" fields

TILA-777