### PR TITLE
Makes IntegerPrimaryKeyField displayable in mutation payload

### DIFF
--- a/api/graphql/primary_key_fields.py
+++ b/api/graphql/primary_key_fields.py
@@ -1,4 +1,5 @@
 from rest_framework import serializers
+from rest_framework.relations import PKOnlyObject
 
 
 class IntegerPrimaryKeyField(
@@ -6,3 +7,15 @@ class IntegerPrimaryKeyField(
     serializers.IntegerField,
 ):
     """A field that refers to foreign keys by an integer primary key."""
+
+    def get_attribute(self, instance):
+        attribute = super().get_attribute(instance)
+        if isinstance(attribute, PKOnlyObject) and attribute.pk:
+            attribute = IntCastablePkOnlyObject(pk=attribute.pk)
+            return attribute
+        return None
+
+
+class IntCastablePkOnlyObject(PKOnlyObject):
+    def __int__(self):
+        return self.pk


### PR DESCRIPTION
IntegerPrimaryKeyField was not displayable in mutation payloads.
Graphene tries to cast the field as int and it will fail so the field
must be int castable and also must be shown as null.
This adds override functions and casting to IntegerPrimaryKeyField to be
displayable in gql mutation payloads.