### PR TITLE
TILA-949 | Use HAUKI_API_KEY in post and put requests

### DIFF
--- a/opening_hours/hauki_request.py
+++ b/opening_hours/hauki_request.py
@@ -39,7 +39,7 @@ def make_hauki_post_request(url: str, data: dict):
             timeout=REQUESTS_TIMEOUT,
             headers={
                 "Content-Type": "application/json",
-                "Authorization": settings.HAUKI_SECRET,
+                "Authorization": f"APIToken {settings.HAUKI_API_KEY}",
             },
         )
     except Exception as e:
@@ -67,7 +67,7 @@ def make_hauki_put_request(url: str, data: dict):
             timeout=REQUESTS_TIMEOUT,
             headers={
                 "Content-Type": "application/json",
-                "Authorization": settings.HAUKI_SECRET,
+                "Authorization": f"APIToken {settings.HAUKI_API_KEY}",
             },
         )
     except Exception as e:


### PR DESCRIPTION
Previous PR related to this was missing these places. 

TILA-949 TILA-948