### PR TITLE
TILA-959 | Use unit's department id in hauki url generation

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -38,6 +38,7 @@ from permissions.api_permissions.graphene_permissions import (
     SpacePermission,
     UnitPermission,
 )
+from permissions.helpers import can_manage_units
 from reservation_units.models import (
     Equipment,
     EquipmentCategory,
@@ -119,9 +120,13 @@ class ReservationUnitHaukiUrlType(AuthNode, DjangoObjectType):
         fields = ("url",)
 
     def resolve_url(self, info):
-        return generate_hauki_link(
-            self.uuid, info.context.user, self.unit.tprek_department_id
-        )
+        if can_manage_units(info.context.user, self.unit):
+            return generate_hauki_link(
+                self.uuid,
+                getattr(info.context.user, "email", ""),
+                self.unit.tprek_department_id,
+            )
+        return None
 
 
 class ReservationUnitImageType(DjangoObjectType):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -119,7 +119,9 @@ class ReservationUnitHaukiUrlType(AuthNode, DjangoObjectType):
         fields = ("url",)
 
     def resolve_url(self, info):
-        return generate_hauki_link(self.uuid, info.context.user)
+        return generate_hauki_link(
+            self.uuid, info.context.user, self.unit.tprek_department_id
+        )
 
 
 class ReservationUnitImageType(DjangoObjectType):

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['ReservationUnitQueryTestCase::test_filtering_by_active_application_rounds 1'] = {
@@ -306,11 +307,11 @@ snapshots['ReservationUnitQueryTestCase::test_filtering_by_unit 1'] = {
     }
 }
 
-snapshots['ReservationUnitQueryTestCase::test_getting_hauki_url 1'] = {
+snapshots['ReservationUnitQueryTestCase::test_getting_hauki_url_is_none_when_regular_user 1'] = {
     'data': {
         'reservationUnitByPk': {
             'haukiUrl': {
-                'url': 'https://test.com/resource/origin:3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=AnonymousUser&hsa_organization=ORGANISATION&hsa_created_at=2021-05-03 00:00:00+00:00&hsa_valid_until=2021-05-03 00:30:00+00:00&hsa_resource=origin:3774af34-9916-40f2-acc7-68db5a627710&hsa_signature=8df8cd01df388f8f1aad70e82035eaae3a27d33c2f3e3583bb7f9bb7aca966f1'
+                'url': None
             },
             'nameFi': 'test name fi'
         }
@@ -337,6 +338,9 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
             'edges': [
                 {
                     'node': {
+                        'additionalInstructionsEn': 'Additional instructions',
+                        'additionalInstructionsFi': 'Lisäohjeita',
+                        'additionalInstructionsSv': 'Ytterligare instruktioner',
                         'applicationRounds': [
                         ],
                         'cancellationRule': {
@@ -345,9 +349,6 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                             'nameSv': 'sv'
                         },
                         'contactInformationFi': '',
-                        'additionalInstructionsFi': 'Lisäohjeita',
-                        'additionalInstructionsSv': 'Ytterligare instruktioner',
-                        'additionalInstructionsEn': 'Additional instructions',
                         'descriptionFi': '',
                         'equipment': [
                         ],
@@ -403,6 +404,28 @@ snapshots['ReservationUnitQueryTestCase::test_getting_terms 1'] = {
                     }
                 }
             ]
+        }
+    }
+}
+
+snapshots['ReservationUnitQueryTestCase::test_hauki_url_for_admin 1'] = {
+    'data': {
+        'reservationUnitByPk': {
+            'haukiUrl': {
+                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.general%40foo.com&hsa_organization=ORGANISATION&hsa_created_at=2021-05-03T00%3A00%3A00%2B00%3A00&hsa_valid_until=2021-05-03T00%3A30%3A00%2B00%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=33d060cef23cf643241390af20ff12fee22b71d9d0c65c86e7ae5617d429df97'
+            },
+            'nameFi': 'test name fi'
+        }
+    }
+}
+
+snapshots['ReservationUnitQueryTestCase::test_hauki_url_for_unit_manager 1'] = {
+    'data': {
+        'reservationUnitByPk': {
+            'haukiUrl': {
+                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=unit.admin%40foo.com&hsa_organization=ORGANISATION&hsa_created_at=2021-05-03T00%3A00%3A00%2B00%3A00&hsa_valid_until=2021-05-03T00%3A30%3A00%2B00%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=4fc177546e1d20a59564a088600053cd89afe6d992ffcc2cce2d6affeb19b10e'
+            },
+            'nameFi': 'test name fi'
         }
     }
 }

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -182,7 +182,8 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
         settings.HAUKI_SECRET = "HAUKISECRET"
         settings.HAUKI_ADMIN_UI_URL = "https://test.com"
         settings.HAUKI_ORIGIN_ID = "origin"
-        settings.HAUKI_ORGANISATION_ID = "ORGANISATION"
+        self.reservation_unit.unit.tprek_department_id = "ORGANISATION"
+        self.reservation_unit.unit.save()
         self.maxDiff = None
         query = (
             f"{{\n"

--- a/opening_hours/hauki_link_generator.py
+++ b/opening_hours/hauki_link_generator.py
@@ -10,12 +10,13 @@ from django.conf import settings
 from django.utils.timezone import get_default_timezone
 
 
-def generate_hauki_link(uuid: UUID, username: str) -> Union[None, str]:
+def generate_hauki_link(
+    uuid: UUID, username: str, organization_id: str
+) -> Union[None, str]:
     if not (
         settings.HAUKI_ADMIN_UI_URL
         and settings.HAUKI_SECRET
         and settings.HAUKI_ORIGIN_ID
-        and settings.HAUKI_ORGANISATION_ID
         and username
     ):
         return None
@@ -26,7 +27,7 @@ def generate_hauki_link(uuid: UUID, username: str) -> Union[None, str]:
 
     get_parameters_string = (
         f"hsa_source={settings.HAUKI_ORIGIN_ID}&hsa_username={username}"
-        f"&hsa_organization={settings.HAUKI_ORGANISATION_ID}"
+        f"&hsa_organization={organization_id}"
         f"&hsa_created_at={now}&hsa_valid_until={now + timedelta(minutes=HAUKI_EXPIRACY_TIME_MINUTES)}"
         f"&hsa_resource={settings.HAUKI_ORIGIN_ID}:{uuid}"
     )

--- a/opening_hours/tests/test_hauki_link_generator.py
+++ b/opening_hours/tests/test_hauki_link_generator.py
@@ -9,18 +9,24 @@ from freezegun import freeze_time
 from opening_hours.hauki_link_generator import generate_hauki_link
 
 valid_signature = "3a8841996f4635970cc5a1d5dda58aaad4e2dd3cbb2857720939362792905b31"
+VALID_SIGNATURE = "b73b5d0a92326c74151d07a9e84c9906734b39aa81f44843116ce4a3c9ee3110"
+ORGANIZATION = "parent-organisation"
 
 
 @freeze_time("2021-01-01 12:00:00", tz_offset=2)
 def test_hauki_link_generation_signature(enable_hauki_admin_ui):
-    link = generate_hauki_link(uuid="123", username="foo@bar.com")
+    link = generate_hauki_link(
+        uuid="123", username="foo@bar.com", organization_id=ORGANIZATION
+    )
     params = dict(parse.parse_qsl(link))
-    assert_that(hmac.compare_digest(valid_signature, params["hsa_signature"])).is_true()
+    assert_that(hmac.compare_digest(VALID_SIGNATURE, params["hsa_signature"])).is_true()
 
 
 @freeze_time("2021-01-01 14:00:00", tz_offset=2)
 def test_comparing_signature_with_different_date(enable_hauki_admin_ui):
-    link = generate_hauki_link(uuid="123", username="foo@bar.com")
+    link = generate_hauki_link(
+        uuid="123", username="foo@bar.com", organization_id=ORGANIZATION
+    )
     params = dict(parse.parse_qsl(link))
     assert_that(
         hmac.compare_digest(valid_signature, params["hsa_signature"])
@@ -29,7 +35,9 @@ def test_comparing_signature_with_different_date(enable_hauki_admin_ui):
 
 @freeze_time("2021-01-01 12:00:00", tz_offset=2)
 def test_hauki_link_params(enable_hauki_admin_ui):
-    link = generate_hauki_link(uuid="123", username="foo@bar.com")
+    link = generate_hauki_link(
+        uuid="123", username="foo@bar.com", organization_id=ORGANIZATION
+    )
     params = dict(parse.parse_qsl(link))
     assert_that(params["hsa_organization"]).is_equal_to(settings.HAUKI_ORGANISATION_ID)
     assert_that(params["hsa_resource"]).is_equal_to(f"{settings.HAUKI_ORIGIN_ID}:123")
@@ -40,10 +48,12 @@ def test_hauki_link_params(enable_hauki_admin_ui):
 @freeze_time("2021-01-01 12:00:00", tz_offset=2)
 @pytest.mark.parametrize(
     "setting",
-    ["HAUKI_ADMIN_UI_URL", "HAUKI_SECRET", "HAUKI_ORIGIN_ID", "HAUKI_ORGANISATION_ID"],
+    ["HAUKI_ADMIN_UI_URL", "HAUKI_SECRET", "HAUKI_ORIGIN_ID"],
 )
 def test_hauki_link_with_missing_settings(setting, enable_hauki_admin_ui):
     setattr(settings, setting, None)
-    link = generate_hauki_link(uuid="123", username="foo@bar.com")
+    link = generate_hauki_link(
+        uuid="123", username="foo@bar.com", organization_id=ORGANIZATION
+    )
 
     assert_that(link).is_none()

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -25,14 +25,15 @@ from spaces.models import Unit
 
 
 class ReservationUnitHaukiUrlPermission(BasePermission):
+    """Check permissions in resolver level. Cannot figure out the permissions without knowing unit."""
+
     @classmethod
     def has_permission(cls, info: ResolveInfo) -> bool:
         return False
 
     @classmethod
     def has_node_permission(cls, info: ResolveInfo, id: str) -> bool:
-        # FIXME: needs a fix for permissions, not called currently TILA-777
-        return True
+        return False
 
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:


### PR DESCRIPTION
Three things related to hauki admin url generation here:
  - Read the unit's tprek_department id as the organization id. 
  - Refactors hauki link generator to be urlencoded.
  - Adds permission checks for displaying the link through api.

TILA-959 TILA-989