### PR TITLE
Make all purpose fields editable in admin

### DIFF
--- a/reservation_units/admin.py
+++ b/reservation_units/admin.py
@@ -73,7 +73,6 @@ class DayPartAdmin(admin.ModelAdmin):
 @admin.register(Purpose)
 class PurposeAdmin(admin.ModelAdmin):
     model = Purpose
-    fields = ["name"]
 
 
 @admin.register(Equipment)


### PR DESCRIPTION
The translations for `Purpose` fields  were not modifiable in Django admin.

For some reason only the `name` field was specified in `PurposeAdmin`. This change fixes it so that all purpose fields can be edited.