### PR TITLE
TILA-955: Add test for loading fixtures

### DIFF
--- a/tilavarauspalvelu/tests/test_fixtures.py
+++ b/tilavarauspalvelu/tests/test_fixtures.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+from django.core import management
+from pytest import mark
+
+
+@mark.django_db
+def test_fixtures_load_without_errors():
+    root_path = Path(__file__).parent.parent.parent
+    fixtures_path = root_path / "fixtures" / "cases.json"
+    management.call_command("loaddata", fixtures_path)


### PR DESCRIPTION
Added a new test that runs the `loaddata` management command with `fixtures/cases.json` as input, to make sure the fixtures get loaded successfully.