### PR TITLE
TILA-895 | Use state enum in Reservation query 

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -24,7 +24,9 @@ DEFAULT_TIMEZONE = get_default_timezone()
 
 
 class ReservationCreateSerializer(PrimaryKeySerializer):
-    state = serializers.CharField()
+    state = serializers.CharField(
+        help_text="Read only string value for ReservationType's ReservationState enum."
+    )
     reservation_unit_pks = serializers.ListField(
         child=IntegerPrimaryKeyField(queryset=ReservationUnit.objects.all()),
         source="reservation_unit",
@@ -185,6 +187,9 @@ class ReservationUpdateSerializer(
         super().__init__(*args, **kwargs)
         self.fields["state"].read_only = False
         self.fields["state"].required = False
+        self.fields[
+            "state"
+        ].help_text = "String value for ReservationType's ReservationState enum."
         self.fields["reservee_first_name"].required = False
         self.fields["reservee_last_name"].required = False
         self.fields["reservee_phone"].required = False

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -123,7 +123,6 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     )
 
     recurring_reservation = graphene.Field(RecurringReservationType)
-    state = graphene.String()
     reservee_first_name = graphene.String()
     reservee_last_name = graphene.String()
     reservee_phone = graphene.String()

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -79,12 +79,12 @@ snapshots['ReservationUnitTestCase::test_filtering_by_multiple_reservation_state
                             {
                                 'begin': '2021-05-03T00:00:00+00:00',
                                 'end': '2021-05-03T01:00:00+00:00',
-                                'state': 'created'
+                                'state': 'CREATED'
                             },
                             {
                                 'begin': '2021-05-03T01:00:00+00:00',
                                 'end': '2021-05-03T02:00:00+00:00',
-                                'state': 'confirmed'
+                                'state': 'CONFIRMED'
                             }
                         ]
                     }
@@ -124,7 +124,7 @@ snapshots['ReservationUnitTestCase::test_filtering_by_reservation_state 1'] = {
                             {
                                 'begin': '2021-05-03T00:00:00+00:00',
                                 'end': '2021-05-03T01:00:00+00:00',
-                                'state': 'created'
+                                'state': 'CREATED'
                             }
                         ]
                     }
@@ -145,7 +145,7 @@ snapshots['ReservationUnitTestCase::test_filtering_by_reservation_timestamps 1']
                             {
                                 'begin': '2021-05-03T00:00:00+00:00',
                                 'end': '2021-05-03T01:00:00+00:00',
-                                'state': 'created'
+                                'state': 'CREATED'
                             }
                         ]
                     }

--- a/api/graphql/tests/snapshots/snap_test_reservations.py
+++ b/api/graphql/tests/snapshots/snap_test_reservations.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'begin': '2021-10-12T12:00:00+00:00',
+                        'bufferTimeAfter': None,
+                        'bufferTimeBefore': None,
+                        'description': 'movies&popcorn',
+                        'end': '2021-10-12T13:00:00+00:00',
+                        'name': 'movies',
+                        'numPersons': None,
+                        'priority': 'A_100',
+                        'purpose': {
+                            'nameFi': 'purpose'
+                        },
+                        'recurringReservation': None,
+                        'reservationUnits': [
+                            {
+                                'nameFi': 'resunit'
+                            }
+                        ],
+                        'reserveeFirstName': 'Reser',
+                        'reserveeLastName': 'Vee',
+                        'reserveePhone': '',
+                        'state': 'CREATED',
+                        'user': 'joe.regularl@foo.com'
+                    }
+                }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
In `ReservationType` state had been defined as string type even though it is enum. This changes it to be enum instead of string.
In mutations though we are sticking with strings since there's a unsolved bug in gql+drf serializers with using enums and thus this adds some helping text for state field in mutations.

TILA-895
