### PR TITLE
Fix outdated reservation cancellation reason snapshot

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_reservation_cancel_reason.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_cancel_reason.py
@@ -7,22 +7,6 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['ReservationCancelReasonsQueryTestCase::test_getting_reservation_cancel_reasons 1'] = {
-    'data': {
-        'reservationCancelReasons': {
-            'edges': [
-                {
-                    'node': {
-                        'reasonEn': 'en',
-                        'reasonFi': 'fi',
-                        'reasonSv': 'sv'
-                    }
-                }
-            ]
-        }
-    }
-}
-
 snapshots['ReservationCancelReasonsQueryTestCase::test_getting_reservation_cancel_reasons_for_logged_in_user 1'] = {
     'data': {
         'reservationCancelReasons': {


### PR DESCRIPTION
The snapshot for `test_getting_reservation_cancel_reasons` was outdated (test has been renamed / removed), which was giving warnings when running tests.

I updated the snapshot to make the warning go away.