### PR TITLE
TILA-929: Upgrade Graphene-Django to the latest version

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -22,7 +22,7 @@ drf-spectacular==0.13.0
 easy-thumbnails==2.7.1
 flake8==3.8.4
 freezegun==0.3.14
-graphene-django==2.13.0
+graphene-django==3.0.0b7
 graphene_permissions==1.1.4
 icalendar==4.0.7
 isort==5.6.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ absl-py==0.12.0
     # via ortools
 amqp==5.0.6
     # via kombu
-aniso8601==7.0.0
+aniso8601==9.0.1
     # via graphene
 appdirs==1.4.4
     # via black
@@ -142,24 +142,24 @@ freezegun==0.3.14
     # via -r requirements.in
 future==0.18.2
     # via pyjwkest
-graphene-django==2.13.0
+graphene-django==3.0.0b7
     # via
     #   -r requirements.in
     #   django-graphql-jwt
     #   graphene-permissions
-graphene==2.1.8
+graphene==3.0
     # via
     #   django-graphql-jwt
     #   graphene-django
     #   graphene-permissions
 graphene_permissions==1.1.4
     # via -r requirements.in
-graphql-core==2.3.2
+graphql-core==3.1.6
     # via
     #   graphene
     #   graphene-django
     #   graphql-relay
-graphql-relay==2.0.1
+graphql-relay==3.1.0
     # via graphene
 icalendar==4.0.7
     # via -r requirements.in
@@ -202,10 +202,7 @@ pip-tools==6.1.0
 pluggy==0.13.1
     # via pytest
 promise==2.3
-    # via
-    #   graphene-django
-    #   graphql-core
-    #   graphql-relay
+    # via graphene-django
 prompt-toolkit==3.0.19
     # via click-repl
 protobuf==3.17.0
@@ -282,12 +279,8 @@ requests==2.25.1
     #   social-auth-core
 rsa==4.7.2
     # via python-jose
-rx==1.6.1
-    # via graphql-core
 sentry-sdk==0.19.5
     # via -r requirements.in
-singledispatch==3.6.1
-    # via graphene-django
 six==1.15.0
     # via
     #   absl-py
@@ -296,17 +289,12 @@ six==1.15.0
     #   django-modeltranslation
     #   ecdsa
     #   freezegun
-    #   graphene
-    #   graphene-django
-    #   graphql-core
-    #   graphql-relay
     #   jsonschema
     #   promise
     #   protobuf
     #   pyjwkest
     #   python-dateutil
     #   python-jose
-    #   singledispatch
     #   snapshottest
     #   social-auth-app-django
 snapshottest==0.6.0
@@ -320,7 +308,9 @@ sqlparse==0.4.2
 termcolor==1.1.0
     # via snapshottest
 text-unidecode==1.3
-    # via faker
+    # via
+    #   faker
+    #   graphene-django
 toml==0.10.2
     # via
     #   black
@@ -330,8 +320,6 @@ typed-ast==1.4.3
     # via black
 typing-extensions==3.10.0.0
     # via black
-unidecode==1.2.0
-    # via graphene-django
 uritemplate==3.0.1
     # via drf-spectacular
 urllib3==1.26.5

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -15,6 +15,7 @@ import os
 import subprocess  # nosec
 
 import environ
+import graphql
 import sentry_sdk
 from django.utils.translation import gettext_lazy as _
 from sentry_sdk.integrations.django import DjangoIntegration
@@ -22,6 +23,11 @@ from sentry_sdk.integrations.django import DjangoIntegration
 from tilavarauspalvelu.loggers import LOGGING_CONSOLE, LOGGING_ELASTIC
 
 logger = logging.getLogger("settings")
+
+
+# This is a temporary fix for graphene_permissions to avoid ImportError when importing ResolveInfo
+# This can be removed when graphene_permissions is updated to import ResolveInfo from the correct package.
+graphql.ResolveInfo = graphql.GraphQLResolveInfo
 
 
 def get_git_revision_hash() -> str:


### PR DESCRIPTION
This PR upgrades Graphene-Django to version 3.0.0b7, which is the latest version. Along with it, Graphene will be upgraded to version 3.0.

3.0.0b7 is a pre-release, but there hasn't been a new release for almost a year, so I'm not sure if there are any other options because the stable releases don't support Graphene 3.0. We need Graphene 3.0 for `null` value support for input fields (see https://github.com/graphql-python/graphene/issues/1362).

The Graphene-Permissions library has a small problem where it imports `ResolveInfo` from the wrong package, causing an `ImportError` with newer versions of Graphene. There is no fix for this yet, so the only way to avoid is to monkey patch it in `settings.py`. I will make a separate PR in the graphene-permissions project to have it fixed in a future version.