### PR TITLE
TILA-877: Fix primary key type for terms

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -129,19 +129,19 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         source="cancellation_rule",
         required=False,
     )
-    payment_terms_pk = IntegerPrimaryKeyField(
+    payment_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(terms_type=TermsOfUse.TERMS_TYPE_PAYMENT),
         source="payment_terms",
         required=False,
     )
-    cancellation_terms_pk = IntegerPrimaryKeyField(
+    cancellation_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(
             terms_type=TermsOfUse.TERMS_TYPE_CANCELLATION
         ),
         source="cancellation_terms",
         required=False,
     )
-    service_specific_terms_pk = IntegerPrimaryKeyField(
+    service_specific_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(terms_type=TermsOfUse.TERMS_TYPE_SERVICE),
         source="service_specific_terms",
         required=False,

--- a/terms_of_use/tests/factories.py
+++ b/terms_of_use/tests/factories.py
@@ -9,7 +9,7 @@ class TermsOfUseFactory(DjangoModelFactory):
     class Meta:
         model = "terms_of_use.TermsOfUse"
 
-    id = Sequence(lambda n: n)
+    id = Sequence(lambda n: f"terms-{n}")
     name = FuzzyText()
     text = FuzzyText()
     terms_type = FuzzyChoice([terms_type for terms_type, _ in TermsOfUse.TERMS_TYPES])


### PR DESCRIPTION
The PK fields for the different terms was mistakenly defined as integers even though the terms of use PKs are strings.

This PR fixes the reservation unit GraphQL type so that those PKs are the correct type.

TILA-877