### PR TITLE
TILA-975 | Set FILE_UPLOAD_PERMISSIONS to None

### DIFF
--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -400,6 +400,11 @@ THUMBNAIL_ALIASES = {
     },
 }
 
+# Do not try to chmod when uploading images.
+# Our environments uses persistent storage for media and operation will not be permitted.
+# https://dev.azure.com/City-of-Helsinki/devops-guides/_git/devops-handbook?path=/storage.md&_a=preview&anchor=operation-not-permitted
+FILE_UPLOAD_PERMISSIONS = None
+
 CELERY_ENABLED = env("CELERY_ENABLED")
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND")
 


### PR DESCRIPTION
We use azure persistent storage for /media and it does not allow chmod any kind of permission changes for the folders and files. By default storage has this setting on and by setting this to None should skip the chmod  when uploading files.

TILA-975
