### PR TITLE
Graphene compatibility fixes

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -5,10 +5,10 @@ import graphene
 from django.conf import settings
 from django.db.models import Q, QuerySet, Sum
 from easy_thumbnails.files import get_thumbnailer
+from graphene import ResolveInfo
 from graphene_django import DjangoObjectType
 from graphene_permissions.mixins import AuthNode
 from graphene_permissions.permissions import AllowAny
-from graphql import ResolveInfo
 
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.graphql.opening_hours.opening_hours_types import OpeningHoursMixin

--- a/api/graphql/reservations/reservation_mutations.py
+++ b/api/graphql/reservations/reservation_mutations.py
@@ -1,7 +1,7 @@
 import graphene
+from graphene import ResolveInfo
 from graphene_django.rest_framework.mutation import SerializerMutation
 from graphene_permissions.permissions import AllowAny
-from graphql import ResolveInfo
 
 from api.graphql.base_mutations import AuthSerializerMutation
 from api.graphql.reservations.reservation_serializers import (

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -1,8 +1,8 @@
 import graphene
 from django.conf import settings
+from graphene import ResolveInfo
 from graphene_permissions.mixins import AuthNode
 from graphene_permissions.permissions import AllowAny, AllowAuthenticated
-from graphql.execution.base import ResolveInfo
 from rest_framework.reverse import reverse
 
 from api.graphql.base_type import PrimaryKeyObjectType

--- a/api/graphql/tests/test_equipments.py
+++ b/api/graphql/tests/test_equipments.py
@@ -92,7 +92,7 @@ class EquipmentUpdateTestCase(EquipmentBaseTestCase):
         assert_that(self.equipment.name).is_equal_to("Updated name")
 
     def test_updating_should_error_when_not_found(self):
-        data = {"pk": "1234", "nameFi": "Me errors", "categoryPk": self.category.id}
+        data = {"pk": 1234, "nameFi": "Me errors", "categoryPk": self.category.id}
         response = self.query(self.get_update_query(), input_data=data)
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
@@ -221,7 +221,7 @@ class EquipmentCategoryUpdateTestCase(EquipmentBaseTestCase):
         assert_that(self.equipment_category.name).is_equal_to("Updated name")
 
     def test_updating_should_error_when_not_found(self):
-        data = {"pk": "1234", "nameFi": "Me errors"}
+        data = {"pk": 1234, "nameFi": "Me errors"}
         response = self.query(self.get_update_query(), input_data=data)
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)

--- a/api/graphql/translate_fields.py
+++ b/api/graphql/translate_fields.py
@@ -3,7 +3,7 @@ from typing import List, Type
 from django.conf import settings
 from django.db import models
 from django.db.models import Model
-from graphql import ResolveInfo
+from graphene import ResolveInfo
 from modeltranslation.manager import get_translatable_fields_for_model
 
 LANGUAGE_CODES = [x[0] for x in settings.LANGUAGES]

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -1,8 +1,8 @@
 from typing import Any
 
 from django.shortcuts import get_object_or_404
+from graphene import ResolveInfo
 from graphene_permissions.permissions import BasePermission
-from graphql import ResolveInfo
 
 from permissions.helpers import (
     can_create_reservation,


### PR DESCRIPTION
This PR makes a couple of minor changes to the codebase to improve compatibility with future versions of Graphene:

* Fix some tests to use integer PKs instead of string PKs (new Graphene versions seem to be more strict about the types)
* Import `ResolveInfo` from the correct location (from the `graphene` package instead of the private `graphql` package)