### PR TITLE
Use ModelMultipleChoiceFilter instead of ModelInFilter for consistency and Graphene-Django 2.15+ compatibility

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_filtersets.py
+++ b/api/graphql/reservation_units/reservation_unit_filtersets.py
@@ -5,7 +5,6 @@ import django_filters
 from django.db.models import Q, Sum
 from django_filters import CharFilter
 
-from api.common_filters import ModelInFilter
 from reservation_units.models import (
     KeywordGroup,
     Purpose,
@@ -16,8 +15,10 @@ from spaces.models import Unit
 
 
 class ReservationUnitsFilterSet(django_filters.FilterSet):
-    unit = ModelInFilter(field_name="unit", queryset=Unit.objects.all())
-    reservation_unit_type = ModelInFilter(
+    unit = django_filters.ModelMultipleChoiceFilter(
+        field_name="unit", queryset=Unit.objects.all()
+    )
+    reservation_unit_type = django_filters.ModelMultipleChoiceFilter(
         field_name="reservation_unit_type", queryset=ReservationUnitType.objects.all()
     )
     max_persons_gte = django_filters.NumberFilter(
@@ -29,11 +30,13 @@ class ReservationUnitsFilterSet(django_filters.FilterSet):
 
     text_search = CharFilter(method="get_text_search")
 
-    keyword_groups = ModelInFilter(
+    keyword_groups = django_filters.ModelMultipleChoiceFilter(
         field_name="keyword_groups", queryset=KeywordGroup.objects.all()
     )
 
-    purposes = ModelInFilter(field_name="purposes", queryset=Purpose.objects.all())
+    purposes = django_filters.ModelMultipleChoiceFilter(
+        field_name="purposes", queryset=Purpose.objects.all()
+    )
 
     is_draft = django_filters.BooleanFilter(field_name="is_draft")
 

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['ReservationUnitTestCase::test_filtering_by_active_application_rounds 1'] = {
@@ -98,6 +97,44 @@ snapshots['ReservationUnitTestCase::test_filtering_by_max_persons_not_found 1'] 
     }
 }
 
+snapshots['ReservationUnitTestCase::test_filtering_by_multiple_keyword_groups 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'keywordGroups': [
+                            {
+                                'nameFi': 'Test group'
+                            }
+                        ],
+                        'nameFi': 'Test name'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitTestCase::test_filtering_by_multiple_purposes 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test name',
+                        'purposes': [
+                            {
+                                'nameFi': 'Test purpose'
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['ReservationUnitTestCase::test_filtering_by_multiple_reservation_states 1'] = {
     'data': {
         'reservationUnits': {
@@ -117,6 +154,56 @@ snapshots['ReservationUnitTestCase::test_filtering_by_multiple_reservation_state
                                 'state': 'CONFIRMED'
                             }
                         ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitTestCase::test_filtering_by_multiple_types 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test name',
+                        'reservationUnitType': {
+                            'nameFi': 'Test type'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Other reservation unit',
+                        'reservationUnitType': {
+                            'nameFi': 'Other type'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitTestCase::test_filtering_by_multiple_units 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test name',
+                        'unit': {
+                            'nameFi': 'Test unit'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Other reservation unit',
+                        'unit': {
+                            'nameFi': 'Other unit'
+                        }
                     }
                 }
             ]
@@ -278,6 +365,23 @@ snapshots['ReservationUnitTestCase::test_filtering_by_type_text 1'] = {
                         'nameFi': 'Test name',
                         'reservationUnitType': {
                             'nameFi': 'Test type'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitTestCase::test_filtering_by_unit 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test name',
+                        'unit': {
+                            'nameFi': 'Test unit'
                         }
                     }
                 }


### PR DESCRIPTION
The `ModelInFilter` from our `common_filters.py` causes problems with Graphene-Django 2.15 and above, because it inherits from both `BaseInFilter` and `ModelChoiceFilter`. Another problem with it is that it requires multiple PKs to be given as a string, like `"1,2,3"` instead of a list like `[1,2,3]`.

I noticed that for GraphQL APIs, we can actually skip `ModelInFilter` altogether and just use `ModelMultipleChoiceFilter` directly, which allows filtering by a single or multiple PKs given as a list. So instead of this:

```graphql
reservationUnits(reservationUnitType: "1,2,3") {
   ...
}
```
...we can do this:
```graphql
reservationUnits(reservationUnitType: [1,2,3]) {
   ...
}
```
And filtering by a single PK still works the same:
```graphql
reservationUnits(reservationUnitType: 1) {
   ...
}
```

This leaves all the filters in `common_filters.py` used only by our REST APIs.

This will also make the filters compatible with the latest version of Graphene-Django (2.15.0 and above), including the pre-releases which support Graphene 3.0.

Note, I also added tests for all of the reservation unit fields which used the `ModelInFilter` to make sure filtering by multiple PKs is possible.