### PR TITLE
Fix deprecated test client in GraphQL tests

### DIFF
--- a/api/graphql/tests/test_equipments.py
+++ b/api/graphql/tests/test_equipments.py
@@ -15,7 +15,7 @@ class EquipmentBaseTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         cls.category = EquipmentCategoryFactory(name="Test Category")
 
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
 
 class EquipmentCreateTestCase(EquipmentBaseTestCase):
@@ -41,7 +41,7 @@ class EquipmentCreateTestCase(EquipmentBaseTestCase):
         assert_that(content.get("data").get("createEquipment").get("pk")).is_not_none()
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = {
             "nameFi": "Regular user created equipment",
             "categoryPk": self.category.id,
@@ -99,7 +99,7 @@ class EquipmentUpdateTestCase(EquipmentBaseTestCase):
         assert_that(content.get("errors")).is_not_none()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         name = self.equipment.name
         data = {
             "pk": self.equipment.pk,
@@ -175,7 +175,7 @@ class EquipmentCategoryCreateTestCase(EquipmentBaseTestCase):
         ).is_not_none()
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = {
             "nameFi": "Regular user created equipment category",
         }
@@ -228,7 +228,7 @@ class EquipmentCategoryUpdateTestCase(EquipmentBaseTestCase):
         assert_that(content.get("errors")).is_not_none()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         name = self.equipment_category.name
         data = {
             "pk": self.equipment_category.pk,

--- a/api/graphql/tests/test_purposes.py
+++ b/api/graphql/tests/test_purposes.py
@@ -16,7 +16,7 @@ class PurposeTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
 
     def setUp(self) -> None:
         super().setUp()
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_create_query(self):
         return """
@@ -85,7 +85,7 @@ class PurposeTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         self.assertMatchSnapshot(content)
 
     def test_normal_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(),
             input_data={"nameFi": "Created purpose"},
@@ -96,7 +96,7 @@ class PurposeTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         assert_that(Purpose.objects.exclude(id=self.purpose.id).exists()).is_false()
 
     def test_normal_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(),
             input_data={"pk": self.purpose.id, "nameFi": "Updated name"},

--- a/api/graphql/tests/test_reservation_cancel_reason.py
+++ b/api/graphql/tests/test_reservation_cancel_reason.py
@@ -18,7 +18,7 @@ class ReservationCancelReasonsQueryTestCase(
         )
 
     def test_getting_reservation_cancel_reasons_for_logged_in_user(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {

--- a/api/graphql/tests/test_reservation_unit_cancellation_rules.py
+++ b/api/graphql/tests/test_reservation_unit_cancellation_rules.py
@@ -18,7 +18,7 @@ class ReservationUnitCancellationRulesQueryTestCase(
         )
 
     def test_getting_reservation_unit_cancellation_rules_for_logged_in_user(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {

--- a/api/graphql/tests/test_reservation_unit_types.py
+++ b/api/graphql/tests/test_reservation_unit_types.py
@@ -15,7 +15,7 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
 
     def test_getting_reservation_unit_types(self):
         self.maxDiff = None
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -64,7 +64,7 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
 
     def test_getting_reservation_units(self):
         self.maxDiff = None
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -691,7 +691,7 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         )
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -733,7 +733,7 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
             [matching_reservation, other_reservation]
         )
         self.reservation_unit.save()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -780,7 +780,7 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         )
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -1052,7 +1052,7 @@ class ReservationUnitMutationsTestCaseBase(GrapheneTestCaseBase):
         )
 
     def setUp(self):
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
 
 class ReservationUnitCreateAsDraftTestCase(ReservationUnitMutationsTestCaseBase):
@@ -1163,7 +1163,7 @@ class ReservationUnitCreateAsDraftTestCase(ReservationUnitMutationsTestCaseBase)
         assert_that(res_unit_data.get("errors")).is_not_none()
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = {"isDraft": True, "nameFi": "Resunit name", "unitPk": self.unit.id}
         response = self.query(self.get_create_query(), input_data=data)
 
@@ -1609,7 +1609,7 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
         assert_that(content.get("errors")).is_not_none()
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = self.get_valid_data()
         response = self.query(self.get_create_query(), input_data=data)
 
@@ -1705,7 +1705,7 @@ class ReservationUnitUpdateDraftTestCase(ReservationUnitMutationsTestCaseBase):
         assert_that(self.res_unit.name_fi).is_not_empty()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = self.get_valid_update_data()
         data["nameFi"] = "Better name in my opinion."
         response = self.query(self.get_update_query(), input_data=data)
@@ -2009,7 +2009,7 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
         assert_that(self.res_unit.reservation_unit_type).is_not_none()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         data = self.get_valid_update_data()
         data["nameFi"] = "Better name in my opinion."
         response = self.query(self.get_update_query(), input_data=data)

--- a/api/graphql/tests/test_reservations.py
+++ b/api/graphql/tests/test_reservations.py
@@ -85,7 +85,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
 
     def test_reservation_query(self):
         self.maxDiff = None
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
@@ -160,7 +160,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
 
     def test_creating_reservation_succeed(self, mock_periods, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_input_data()
         response = self.query(self.get_create_query(), input_data=input_data)
         content = json.loads(response.content)
@@ -190,7 +190,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         self, mock_periods, mock_opening_hours
     ):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_input_data()
         optional_fields = [
             "reserveeFirstName",
@@ -209,7 +209,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
 
     def test_creating_reservation_with_pk_fails(self, mock_periods, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_input_data()
         input_data["pk"] = 9999
         response = self.query(self.get_create_query(), input_data=input_data)
@@ -229,7 +229,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -257,7 +257,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -285,7 +285,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -316,7 +316,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -349,7 +349,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -376,7 +376,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         input_data["begin"] = begin.strftime("%Y%m%dT%H%M%SZ")
         input_data["end"] = end.strftime("%Y%m%dT%H%M%SZ")
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_create_query(), input_data=input_data)
         content = json.loads(response.content)
 
@@ -398,7 +398,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             reservation_period_end=datetime.date.today() + datetime.timedelta(days=10),
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -419,7 +419,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         self.reservation_unit.max_reservation_duration = datetime.timedelta(minutes=30)
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -443,7 +443,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         self.reservation_unit.min_reservation_duration = datetime.timedelta(hours=2)
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(), input_data=self.get_valid_input_data()
         )
@@ -489,7 +489,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         valid_data["end"] = (res_start + datetime.timedelta(hours=1)).strftime(
             "%Y%m%dT%H%M%SZ"
         )
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_create_query(), input_data=valid_data)
         content = json.loads(response.content)
 
@@ -554,7 +554,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
 
     def test_updating_reservation_succeed(self, mock_periods, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -582,7 +582,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
     def test_updating_reservation_with_pk_fails(self, mock_periods, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
         new_pk = 9999
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_update_data()
         input_data["pk"] = new_pk
         response = self.query(self.get_update_query(), input_data=input_data)
@@ -602,7 +602,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -630,7 +630,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(),
             input_data={"pk": self.reservation.id, "priority": 200},
@@ -661,7 +661,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -692,7 +692,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_update_data()
         input_data.pop("begin")
         input_data.pop("end")
@@ -726,7 +726,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.CONFIRMED,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -753,7 +753,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         input_data["begin"] = begin.strftime("%Y%m%dT%H%M%SZ")
         input_data["end"] = end.strftime("%Y%m%dT%H%M%SZ")
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_update_query(), input_data=input_data)
         content = json.loads(response.content)
 
@@ -775,7 +775,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             reservation_period_end=datetime.date.today() + datetime.timedelta(days=10),
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -796,7 +796,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         self.reservation_unit.max_reservation_duration = datetime.timedelta(minutes=30)
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -820,7 +820,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         self.reservation_unit.min_reservation_duration = datetime.timedelta(hours=2)
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(), input_data=self.get_valid_update_data()
         )
@@ -853,7 +853,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         )
         input_data = self.get_valid_update_data()
         input_data["pk"] = res.pk
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_update_query(), input_data=input_data)
         content = json.loads(response.content)
 
@@ -867,7 +867,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
 
         input_data = self.get_valid_update_data()
         input_data["state"] = STATE_CHOICES.CANCELLED
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_update_query(), input_data=input_data)
         content = json.loads(response.content)
 
@@ -882,7 +882,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
 
         input_data = self.get_valid_update_data()
         input_data["state"] = STATE_CHOICES.CONFIRMED
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_update_query(), input_data=input_data)
         content = json.loads(response.content)
         assert_that(
@@ -932,7 +932,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
 
     def test_confirm_reservation_changes_state(self, mock_periods, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_confirm_data()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CREATED)
         response = self.query(self.get_confirm_query(), input_data=input_data)
@@ -948,7 +948,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         self, mock_periods, mock_opening_hours
     ):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         self.reservation.state = STATE_CHOICES.DENIED
         self.reservation.save()
         input_data = self.get_valid_confirm_data()
@@ -965,7 +965,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
     ):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
         unauthorized_user = get_user_model().objects.create()
-        self._client.force_login(unauthorized_user)
+        self.client.force_login(unauthorized_user)
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CREATED)
         input_data = self.get_valid_confirm_data()
         response = self.query(self.get_confirm_query(), input_data=input_data)
@@ -978,7 +978,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         self, mock_periods, mock_opening_hours
     ):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_confirm_data()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CREATED)
         self.query(self.get_confirm_query(), input_data=input_data)
@@ -1028,7 +1028,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         return {"pk": self.reservation.pk, "cancelReasonPk": self.cancel_reason.id}
 
     def test_cancel_reservation_changes_state(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1044,7 +1044,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CANCELLED)
 
     def test_cancel_reservation_adds_reason(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1060,7 +1060,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.cancel_reason).is_equal_to(self.cancel_reason)
 
     def test_cancel_reservation_adds_cancel_details(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         details = "wantitso"
         input_data["cancelDetails"] = details
@@ -1078,7 +1078,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.cancel_details).is_equal_to(details)
 
     def test_cancel_reservation_fails_if_state_is_not_confirmed(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         self.reservation.state = STATE_CHOICES.CREATED
         self.reservation.save()
         input_data = self.get_valid_cancel_data()
@@ -1092,7 +1092,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CREATED)
 
     def test_cancel_reservation_fails_if_cancel_reason_not_given(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         input_data.pop("cancelReasonPk")
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1104,7 +1104,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
 
     def test_cancel_reservation_fails_on_wrong_user(self):
         unauthorized_user = get_user_model().objects.create()
-        self._client.force_login(unauthorized_user)
+        self.client.force_login(unauthorized_user)
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
         input_data = self.get_valid_cancel_data()
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1121,7 +1121,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
         self.reservation_unit.cancellation_rule = rule
         self.reservation_unit.save()
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         response = self.query(self.get_cancel_query(), input_data=input_data)
 
@@ -1148,7 +1148,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
             user=self.regular_joe,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         input_data["pk"] = reservation.id
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1170,7 +1170,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
             user=self.regular_joe,
         )
 
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         input_data = self.get_valid_cancel_data()
         input_data["pk"] = reservation.id
         response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1186,7 +1186,7 @@ class ReservationCancellationTestCase(ReservationTestCaseBase):
             self.reservation_unit.cancellation_rule = None
             self.reservation_unit.save()
 
-            self._client.force_login(self.regular_joe)
+            self.client.force_login(self.regular_joe)
             assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
             input_data = self.get_valid_cancel_data()
             response = self.query(self.get_cancel_query(), input_data=input_data)
@@ -1223,7 +1223,7 @@ class ReservationByPkTestCase(ReservationTestCaseBase):
         """
 
     def test_getting_reservation_by_pk(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(self.get_query())
         content = json.loads(response.content)
         assert_that(content.get("errors")).is_none()
@@ -1233,7 +1233,7 @@ class ReservationByPkTestCase(ReservationTestCaseBase):
         self,
     ):
         unauthorized_user = get_user_model().objects.create()
-        self._client.force_login(unauthorized_user)
+        self.client.force_login(unauthorized_user)
         response = self.query(self.get_query())
         content = json.loads(response.content)
         assert_that(content.get("errors")).is_none()

--- a/api/graphql/tests/test_resources.py
+++ b/api/graphql/tests/test_resources.py
@@ -126,7 +126,7 @@ class ResourceGraphQLTestCase(ResourceGraphQLBase, snapshottest.TestCase):
 
 class ResourceCreateForPublishGraphQLTestCase(ResourceGraphQLBase):
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_create_query(self):
         return (
@@ -225,7 +225,7 @@ class ResourceCreateForPublishGraphQLTestCase(ResourceGraphQLBase):
         )
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(),
             input_data=self.get_valid_input_data(),
@@ -259,7 +259,7 @@ class ResourceCreateForPublishGraphQLTestCase(ResourceGraphQLBase):
 
 class ResourceCreateAsDraftGraphQLTestCase(ResourceGraphQLBase):
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_create_query(self):
         return (
@@ -347,7 +347,7 @@ class ResourceCreateAsDraftGraphQLTestCase(ResourceGraphQLBase):
         assert_that(Resource.objects.get(pk=res_pk))
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_create_query(),
             input_data=self.get_valid_input_data(),
@@ -362,7 +362,7 @@ class ResourceCreateAsDraftGraphQLTestCase(ResourceGraphQLBase):
 
 class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     @classmethod
     def setUpTestData(cls):
@@ -460,7 +460,7 @@ class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(self.resource.space).is_none()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(),
             input_data=self.get_valid_input_data(),
@@ -519,7 +519,7 @@ class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
 
 class ResourceUpdateAsDraftGraphQLTestCase(ResourceGraphQLBase):
     def setUp(self):
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     @classmethod
     def setUpTestData(cls):
@@ -574,7 +574,7 @@ class ResourceUpdateAsDraftGraphQLTestCase(ResourceGraphQLBase):
         assert_that(Resource.objects.get(id=self.resource.id).space).is_none()
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_update_query(),
             input_data=self.get_valid_input_data(),
@@ -598,7 +598,7 @@ class ResourceDeleteGraphQLTestCase(ResourceGraphQLBase):
         )
 
     def test_resource_deleted(self):
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
         response = self.query(
             self.get_delete_query(), input_data={"pk": self.resource.pk}
         )
@@ -613,7 +613,7 @@ class ResourceDeleteGraphQLTestCase(ResourceGraphQLBase):
         assert_that(Resource.objects.filter(pk=self.resource.pk).exists()).is_false()
 
     def test_regular_user_cannot_delete(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         response = self.query(
             self.get_delete_query(), input_data={"pk": self.resource.pk}
         )

--- a/api/graphql/tests/test_spaces.py
+++ b/api/graphql/tests/test_spaces.py
@@ -37,7 +37,7 @@ class SpaceMutationBaseTestCase(GraphQLTestCase):
 class DeleteSpaceTestCase(SpaceMutationBaseTestCase):
     def setUp(self) -> None:
         self.space = SpaceFactory(name="Test space")
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_delete_query(self):
         return (
@@ -76,7 +76,7 @@ class DeleteSpaceTestCase(SpaceMutationBaseTestCase):
         assert_that(Space.objects.filter(pk=self.space.pk).exists()).is_true()
 
     def test_space_not_deleted_when_no_credentials(self):
-        self._client.force_login(self.regular_user)
+        self.client.force_login(self.regular_user)
 
         app_round = ApplicationRoundFactory()
         resunit = ReservationUnitFactory(spaces=[self.space])
@@ -96,7 +96,7 @@ class DeleteSpaceTestCase(SpaceMutationBaseTestCase):
 
 class CreateSpaceTestCase(SpaceMutationBaseTestCase):
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_create_query(self):
         return """
@@ -148,7 +148,7 @@ class CreateSpaceTestCase(SpaceMutationBaseTestCase):
         ).contains("nameFi cannot be empty.")
 
     def test_regular_user_cannot_create(self):
-        self._client.force_login(self.regular_user)
+        self.client.force_login(self.regular_user)
         data = {"nameFi": "Woohoo I created a space!"}
         response = self.query(self.get_create_query(), input_data=data)
         assert_that(response.status_code).is_equal_to(200)
@@ -164,7 +164,7 @@ class UpdateSpaceTestCase(SpaceMutationBaseTestCase):
         cls.space = SpaceFactory(name="Space1")
 
     def setUp(self) -> None:
-        self._client.force_login(self.general_admin)
+        self.client.force_login(self.general_admin)
 
     def get_update_query(self):
         return """
@@ -211,7 +211,7 @@ class UpdateSpaceTestCase(SpaceMutationBaseTestCase):
         ).contains("nameFi cannot be empty.")
 
     def test_regular_user_cannot_update(self):
-        self._client.force_login(self.regular_user)
+        self.client.force_login(self.regular_user)
         data = {"pk": self.space.pk, "nameFi": "Woohoo I created a space!"}
         response = self.query(self.get_update_query(), input_data=data)
         assert_that(response.status_code).is_equal_to(200)

--- a/api/graphql/tests/test_units.py
+++ b/api/graphql/tests/test_units.py
@@ -39,7 +39,7 @@ class UnitsUpdateTestCase(GraphQLTestCase):
         return "mutation updateUnit($input: UnitUpdateMutationInput!) {updateUnit(input: $input){pk}}"
 
     def test_admin_can_update_unit(self):
-        self._client.force_login(self.unit_admin)
+        self.client.force_login(self.unit_admin)
         desc = "Awesomeunit"
         response = self.query(
             self.get_update_query(),
@@ -53,7 +53,7 @@ class UnitsUpdateTestCase(GraphQLTestCase):
         assert_that(Unit.objects.get(pk=self.unit.pk).description).is_equal_to(desc)
 
     def test_normal_user_cannot_update_unit(self):
-        self._client.force_login(self.regular_joe)
+        self.client.force_login(self.regular_joe)
         desc = "Awesomeunit"
         response = self.query(
             self.get_update_query(),


### PR DESCRIPTION
In Graphene 3.x, the test client `_client` in `GraphQLTestCase` has been renamed to `client`.

This PR fixes the related deprecation warnings caused by the Graphene upgrade.