### PR TITLE
Upgrade django-tinymce to fix a security vulnerability

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -15,7 +15,7 @@ django-helusers==0.6.0
 django-modeltranslation==0.16.1
 django-mptt==0.11.0
 django-recurrence==1.10.3
-django-tinymce==3.2.0
+django-tinymce==3.4.0
 djangorestframework==3.12.2
 drf-oidc-auth==0.10.0
 drf-spectacular==0.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -95,7 +95,7 @@ django-mptt==0.11.0
     # via -r requirements.in
 django-recurrence==1.10.3
     # via -r requirements.in
-django-tinymce==3.2.0
+django-tinymce==3.4.0
     # via -r requirements.in
 django==3.1.13
     # via


### PR DESCRIPTION
I have contacted the maintainers of [django-tinymce](https://github.com/jazzband/django-tinymce) regarding https://github.com/advisories/GHSA-r8hm-w5f7-wj39
and they have recently published a new version of the library which includes a patched version of TinyMCE (a bundled JS library).

Not super critical because it looks like we only use django-tinymce in the admin interface, but at least we can get rid of the Dependabot alert.