### PR TITLE
TILA-1004: Add tests for additional instructions

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['ReservationUnitTestCase::test_filtering_by_active_application_rounds 1'] = {
@@ -430,6 +429,9 @@ snapshots['ReservationUnitTestCase::test_getting_reservation_units 1'] = {
                             'nameSv': 'sv'
                         },
                         'contactInformationFi': '',
+                        'additionalInstructionsFi': 'Lisäohjeita',
+                        'additionalInstructionsSv': 'Ytterligare instruktioner',
+                        'additionalInstructionsEn': 'Additional instructions',
                         'descriptionFi': '',
                         'equipment': [
                         ],


### PR DESCRIPTION
After adding additional instructions for reservation units to the model in #341, the fields were already usable in the GraphQL API. So the only thing remaining to do was to add tests.