### PR TITLE
TILA-818: Add price-related fields to the GraphQL API

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -148,13 +148,30 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False,
     )
     lowest_price = serializers.DecimalField(
-        max_digits=10, decimal_places=2, required=False
+        max_digits=10,
+        decimal_places=2,
+        required=False,
+        help_text="Minimum price of the reservation unit",
     )
     highest_price = serializers.DecimalField(
-        max_digits=10, decimal_places=2, required=False
+        max_digits=10,
+        decimal_places=2,
+        required=False,
+        help_text="Maximum price of the reservation unit",
     )
-    price_unit = serializers.CharField(required=False)
-    price = serializers.DecimalField(max_digits=10, decimal_places=2, required=False)
+    price_unit = serializers.CharField(
+        required=False,
+        help_text=(
+            "Unit of the price. "
+            f"Possible values are {', '.join(value for value, _ in ReservationUnit.PRICE_UNITS)}."
+        ),
+    )
+    price = serializers.DecimalField(
+        max_digits=10,
+        decimal_places=2,
+        required=False,
+        help_text="The current list price for reservation units with a fixed price",
+    )
 
     translation_fields = get_all_translatable_fields(ReservationUnit)
 

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -147,6 +147,14 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         source="service_specific_terms",
         required=False,
     )
+    lowest_price = serializers.DecimalField(
+        max_digits=10, decimal_places=2, required=False
+    )
+    highest_price = serializers.DecimalField(
+        max_digits=10, decimal_places=2, required=False
+    )
+    price_unit = serializers.CharField(required=False)
+    price = serializers.DecimalField(max_digits=10, decimal_places=2, required=False)
 
     translation_fields = get_all_translatable_fields(ReservationUnit)
 
@@ -180,6 +188,10 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "payment_terms_pk",
             "cancellation_terms_pk",
             "service_specific_terms_pk",
+            "lowest_price",
+            "highest_price",
+            "price_unit",
+            "price",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -319,6 +319,10 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "payment_terms",
             "cancellation_terms",
             "service_specific_terms",
+            "lowest_price",
+            "highest_price",
+            "price_unit",
+            "price",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],
@@ -458,6 +462,10 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "next_available_slot",
             "hauki_url",
             "is_draft",
+            "lowest_price",
+            "highest_price",
+            "price_unit",
+            "price",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -54,6 +54,7 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
             "reservation_unit_pks",
             "purpose_pk",
             "confirmed_at",
+            "price",
         ]
 
     def __init__(self, *args, **kwargs):
@@ -62,6 +63,7 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
         self.fields["reservation_unit_pks"].write_only = True
         self.fields["purpose_pk"].required = False
         self.fields["confirmed_at"].read_only = True
+        self.fields["price"].read_only = True
 
     def validate(self, data):
         begin = data.get("begin", getattr(self.instance, "begin", None))

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -151,6 +151,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             "description",
             "purpose",
             "purpose_pk",
+            "price",
         ]
         filter_fields = {
             "state": ["exact"],

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -351,11 +351,15 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'descriptionFi': '',
                         'equipment': [
                         ],
+                        'highestPrice': '20.00',
                         'images': [
                         ],
                         'location': None,
+                        'lowestPrice': '0.00',
                         'maxPersons': 110,
                         'nameFi': 'test name fi',
+                        'price': '10.00',
+                        'priceUnit': 'PER_HOUR',
                         'purposes': [
                         ],
                         'requireIntroduction': False,

--- a/api/graphql/tests/snapshots/snap_test_reservations.py
+++ b/api/graphql/tests/snapshots/snap_test_reservations.py
@@ -29,28 +29,6 @@ snapshots['ReservationByPkTestCase::test_getting_reservation_of_another_user_by_
     }
 }
 
-snapshots['ReservationQueryTestCase::test_getting_reservation_by_pk 1'] = {
-    'data': {
-        'reservationByPk': {
-            'name': 'Test reservation',
-            'reserveeFirstName': 'Joe',
-            'reserveeLastName': 'Regular',
-            'reserveePhone': '+358123456789'
-        }
-    }
-}
-
-snapshots['ReservationQueryTestCase::test_getting_reservation_of_another_user_by_pk_does_not_reveal_reservee_name 1'] = {
-    'data': {
-        'reservationByPk': {
-            'name': 'Test reservation',
-            'reserveeFirstName': None,
-            'reserveeLastName': None,
-            'reserveePhone': None
-        }
-    }
-}
-
 snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
     'data': {
         'reservations': {
@@ -64,6 +42,7 @@ snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
                         'end': '2021-10-12T13:00:00+00:00',
                         'name': 'movies',
                         'numPersons': None,
+                        'price': '10.00',
                         'priority': 'A_100',
                         'purpose': {
                             'nameFi': 'purpose'


### PR DESCRIPTION
This PR adds price-related fields for reservation units and reservations to the GraphQL API.

## Reservation units

* `lowestPrice` (`Decimal`†)
  * This is the minimum price for the reservation unit, used when defining the price range in the management UI.
  * Optional, default value is 0.
* `highestPrice` (`Decimal`†)
  * This is the maximum price for the reservation unit, used when defining the price range in the management UI.
  * Optional, default value is 0.
* `priceUnit` (`String`‡)
  * The unit of the price. Possible values are `per_15_mins`, `per_30_mins`, `per_hour`, `per_half_day`, `per_day`, `per_week`, and `fixed`.
  * Optional, default value is `per_hour`.
* `price` (`Decimal`†)
  * The list price of the reservation unit. This is for cases where the price is fixed and this value will be copied to the reservation's price.
  * I'm not sure yet where the value for this will come from  (management UI? Django admin? Calculated based on lowest and highest?) because it's not shown in the UI mockups, but from previous discussions I understood that we need this field since the value must be copied from here to the reservation's `price` field.
  * Optional, default value is 0.

## Reservations

* `price` (`Decimal`†)
  * This is the final price of this particular reservation. It will be either decided by somebody based on the reservation unit's price range, or it will be copied directly from the reservation unit's `price` field (e.g. a reservation unit with a fixed price).
  * This field is *read-only` and will be filled by the backend when the reservation's final price is decided (not implemented yet since this part is still unknown).
  * Default value is 0.

### Notes:

† Graphene-Django [has a bug](https://github.com/graphql-python/graphene-django/blob/dd0d6ef28ffce33d30c4c8908f48a9d44a2b75ce/graphene_django/rest_framework/serializer_converter.py#L113) where it converts `DecimalField` into `Float` in mutations. There's no easy way to get around this. I'm planning to open a PR and hope they will fix it in the near future.

‡ This should actually be an `Enum`, but since we don't have a solution yet for handling enums in the GraphQL API, I have kept it as a `String` for consistency with other existing enums.

