### PR TITLE
TILA-999: Add reservation start interval to the GraphQL API

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -172,6 +172,15 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False,
         help_text="The current list price for reservation units with a fixed price",
     )
+    reservation_start_interval = serializers.CharField(
+        required=False,
+        help_text=(
+            "Determines the interval for the start time of the reservation. "
+            "For example an interval of 15 minutes means a reservation can "
+            "begin at minutes 0, 15, 30, or 45. Possible values are "
+            f"{', '.join(value[0] for value in ReservationUnit.RESERVATION_START_INTERVAL_CHOICES)}."
+        ),
+    )
 
     translation_fields = get_all_translatable_fields(ReservationUnit)
 
@@ -209,6 +218,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "highest_price",
             "price_unit",
             "price",
+            "reservation_start_interval",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -323,6 +323,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "highest_price",
             "price_unit",
             "price",
+            "reservation_start_interval",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -363,6 +363,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'purposes': [
                         ],
                         'requireIntroduction': False,
+                        'reservationStartInterval': 'INTERVAL_30_MINS',
                         'reservationUnitType': {
                             'nameFi': 'test type fi'
                         },

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -306,7 +306,8 @@ class ReservationUnit(models.Model):
         help_text=(
             "Determines the interval for the start time of the reservation. "
             "For example an interval of 15 minutes means a reservation can "
-            "begin at minutes 0, 15, 30, or 45."
+            "begin at minutes 0, 15, 30, or 45. Possible values are "
+            f"{', '.join(value[0] for value in RESERVATION_START_INTERVAL_CHOICES)}."
         ),
     )
 


### PR DESCRIPTION
Adds the new `reservationStartInterval` field for reservation units in the GraphQL API.