### PR TITLE
TILA-999: Add missing reservationStartInterval to the reservationUnitByPk type

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -472,6 +472,7 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "lowest_price",
             "highest_price",
             "price_unit",
+            "reservation_start_interval",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)


### PR DESCRIPTION
Add missing `reservation_start_interval` field to the `reservationUnitByPk` type.

TILA-999