### PR TITLE
TILA-1010: Add validation for reservation start interval

### DIFF
--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -173,3 +173,22 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
         begin, end = self.scheduler.get_next_available_reservation_time()
         assert_that(begin).is_none()
         assert_that(end).is_none()
+
+    def test_get_reservation_unit_possible_start_times(self, mock):
+        start_date = datetime.date(2022, 1, 1)
+        interval = datetime.timedelta(minutes=90)
+        possible_start_times = self.scheduler.get_reservation_unit_possible_start_times(
+            start_date, interval
+        )
+        assert_that(possible_start_times).is_equal_to(
+            {
+                datetime.datetime(2022, 1, 1, 10, 0, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 11, 30, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 13, 00, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 14, 30, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 16, 00, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 17, 30, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 19, 00, tzinfo=DEFAULT_TIMEZONE),
+                datetime.datetime(2022, 1, 1, 20, 30, tzinfo=DEFAULT_TIMEZONE),
+            }
+        )

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -1,4 +1,5 @@
 import datetime
+from typing import Set
 
 from django.utils.timezone import get_default_timezone
 
@@ -145,3 +146,18 @@ class ReservationUnitReservationScheduler:
         return self.opening_hours_client.is_resource_open(
             str(self.reservation_unit.uuid), start, end
         )
+
+    def get_reservation_unit_possible_start_times(
+        self, date: datetime.date, interval: datetime.timedelta
+    ) -> Set[datetime.datetime]:
+        opening_hours = self.opening_hours_client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid),
+            datetime.date(date.year, date.month, date.day),
+        )
+        possible_start_times = set()
+        for opening_hour in opening_hours:
+            start_time = opening_hour.start_time
+            while start_time < opening_hour.end_time:
+                possible_start_times.add(start_time)
+                start_time += interval
+        return possible_start_times


### PR DESCRIPTION
Adds validation for reservation start interval.

Validations for only 15, 30, and 60 would've been very simple (just check that minutes are 0, 15, or 30), but 90 minutes makes it a bit trickier:

* If the reservation unit opens at 8:00, then valid reservation start times are 8:00, 9:30, 11:00, 12:30, etc.
* If the reservation unit opens at 9:00, then valid reservation start times are 9:00, 10:30, 12:00, 13:30, etc.

So I had to utilize the opening time of the reservation unit for the validation.

TILA-1010