### PR TITLE
TILA-970 | Reservation unit image mutations

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -1,3 +1,4 @@
+from django.core import validators
 from rest_framework import serializers
 
 from api.graphql.base_serializers import (
@@ -17,6 +18,7 @@ from reservation_units.models import (
     Purpose,
     ReservationUnit,
     ReservationUnitCancellationRule,
+    ReservationUnitImage,
     ReservationUnitType,
 )
 from resources.models import Resource
@@ -289,3 +291,42 @@ class ReservationUnitUpdateSerializer(
 
     class Meta(ReservationUnitCreateSerializer.Meta):
         fields = ReservationUnitCreateSerializer.Meta.fields + ["pk"]
+
+
+class ReservationUnitImageCreateSerializer(PrimaryKeySerializer):
+    reservation_unit_pk = IntegerPrimaryKeyField(
+        queryset=ReservationUnit.objects.all(), source="reservation_unit"
+    )
+    image_type = serializers.CharField(
+        help_text="Type of image. Value is one of image_type enum values: "
+        f"{', '.join(value[0].upper() for value in ReservationUnitImage.TYPES)}.",
+        required=True,
+    )
+
+    class Meta:
+        model = ReservationUnitImage
+        fields = ["pk", "reservation_unit_pk", "image_type"]
+
+    def validate_image_field(self, image):
+        image_field = serializers.ImageField(
+            source="image",
+            required=True,
+            validators=[validators.validate_image_file_extension],
+        )
+        image_field.run_validators(image)
+
+    def validate_image_type(self, type):
+        return type.lower()
+
+    def validate(self, data):
+        image = self.context.get("request").FILES.get("image")
+        if not image:
+            raise serializers.ValidationError("No image file in request")
+        self.validate_image_field(image)
+
+        type_field = serializers.ChoiceField(choices=ReservationUnitImage.TYPES)
+        type_field.run_validation(data["image_type"])
+
+        data["image"] = image
+
+        return data

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -21,6 +21,8 @@ from api.graphql.reservation_units.reservation_unit_mutations import (
     PurposeCreateMutation,
     PurposeUpdateMutation,
     ReservationUnitCreateMutation,
+    ReservationUnitImageCreateMutation,
+    ReservationUnitImageDeleteMutation,
     ReservationUnitUpdateMutation,
 )
 from api.graphql.reservation_units.reservation_unit_types import (
@@ -312,6 +314,9 @@ class Mutation(graphene.ObjectType):
 
     create_reservation_unit = ReservationUnitCreateMutation.Field()
     update_reservation_unit = ReservationUnitUpdateMutation.Field()
+
+    create_reservation_unit_image = ReservationUnitImageCreateMutation.Field()
+    delete_reservation_unit_image = ReservationUnitImageDeleteMutation.Field()
 
     create_purpose = PurposeCreateMutation.Field()
     update_purpose = PurposeUpdateMutation.Field()

--- a/api/graphql/tests/snapshots/snap_test_reservation_unit_types.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_unit_types.py
@@ -16,7 +16,6 @@ snapshots['ReservationUnitTestCase::test_getting_reservation_unit_types 1'] = {
                         'nameEn': 'en',
                         'nameFi': 'fi',
                         'nameSv': 'sv',
-                        'pk': 1
                     }
                 }
             ]

--- a/api/graphql/tests/test_reservation_unit_image.py
+++ b/api/graphql/tests/test_reservation_unit_image.py
@@ -1,0 +1,187 @@
+import json
+
+from assertpy import assert_that
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from graphene_file_upload.django.testing import (
+    GraphQLFileUploadTestCase,
+    file_graphql_query,
+)
+
+from api.graphql.tests.base import GrapheneTestCaseBase
+from reservation_units.models import ReservationUnitImage
+from reservation_units.tests.factories import (
+    ReservationUnitFactory,
+    ReservationUnitImageFactory,
+)
+
+DEFAULT_GRAPHQL_URL = "/graphql/"
+
+
+class ReservationUnitImageCreateTestCase(
+    GrapheneTestCaseBase, GraphQLFileUploadTestCase
+):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.file_to_upload = SimpleUploadedFile(
+            name="eltest.png",
+            content="lostest".encode("utf-8"),
+            content_type="image/png",
+        )
+
+        cls.res_unit = ReservationUnitFactory()
+
+    def get_create_query(self):
+        return """
+        mutation createReservationUnitImage($input: ReservationUnitImageCreateMutationInput!) {
+            createReservationUnitImage(input: $input) {
+                pk
+                errors {
+                    messages field
+                }
+            }
+        }
+        """
+
+    def test_upload_image_success(self):
+        self.client.force_login(self.general_admin)
+        response = file_graphql_query(
+            self.get_create_query(),
+            op_name="createReservationUnitImage",
+            files={"image": self.file_to_upload},
+            variables={
+                "input": {
+                    "imageType": "MAIN",
+                    "reservationUnitPk": self.res_unit.id,
+                    "image": self.file_to_upload.name,
+                }
+            },
+            client=self.client,
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        image_data = content.get("data").get("createReservationUnitImage")
+        assert_that(image_data.get("errors")).is_none()
+
+        self.res_unit.refresh_from_db()
+        img = self.res_unit.images.first()
+        assert_that(img).is_not_none()
+        assert_that(img.image.name).starts_with(
+            f"{settings.RESERVATION_UNIT_IMAGES_ROOT}/eltest"
+        )
+        assert_that(img.image.name).ends_with(".png")
+        assert_that(img.image_type).is_equal_to("main")
+
+    def test_upload_file_not_an_image_fails(self):
+        file_to_upload = SimpleUploadedFile(
+            name="eltest.pdf",
+            content="lostest".encode("utf-8"),
+            content_type="application/pdf",
+        )
+
+        self.client.force_login(self.general_admin)
+        response = file_graphql_query(
+            self.get_create_query(),
+            op_name="createReservationUnitImage",
+            files={"image": file_to_upload},
+            variables={
+                "input": {
+                    "imageType": "image_type.MAIN",
+                    "reservationUnitPk": self.res_unit.id,
+                    "image": file_to_upload.name,
+                }
+            },
+            client=self.client,
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        image_data = content.get("data").get("createReservationUnitImage")
+        assert_that(image_data.get("errors")).is_not_none()
+
+        self.res_unit.refresh_from_db()
+        img = self.res_unit.images.first()
+        assert_that(img).is_none()
+
+    def test_upload_image_as_regular_user_fails(self):
+        self.client.force_login(self.regular_joe)
+        response = file_graphql_query(
+            self.get_create_query(),
+            op_name="createReservationUnitImage",
+            files={"image": self.file_to_upload},
+            variables={
+                "input": {
+                    "imageType": "MAIN",
+                    "reservationUnitPk": self.res_unit.id,
+                    "image": self.file_to_upload.name,
+                }
+            },
+            client=self.client,
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+
+        self.res_unit.refresh_from_db()
+        img = self.res_unit.images.first()
+        assert_that(img).is_none()
+
+
+class ReservationUnitImageDeleteGraphQLTestCase(GrapheneTestCaseBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        res_unit = ReservationUnitFactory()
+        cls.res_unit_image = ReservationUnitImageFactory(reservation_unit=res_unit)
+
+    def get_delete_query(self):
+        return """
+            mutation deleteReservationUnitImage($input: ReservationUnitImageDeleteMutationInput!) {
+                deleteReservationUnitImage(input: $input) {
+                    deleted
+                    errors
+                }
+            }
+            """
+
+    def test_reservation_unit_image_deleted(self):
+        self.client.force_login(self.general_admin)
+        response = self.query(
+            self.get_delete_query(), input_data={"pk": self.res_unit_image.pk}
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("deleteReservationUnitImage").get("errors")
+        ).is_none()
+        assert_that(
+            content.get("data").get("deleteReservationUnitImage").get("deleted")
+        ).is_true()
+
+        assert_that(
+            ReservationUnitImage.objects.filter(pk=self.res_unit_image.pk).exists()
+        ).is_false()
+
+    def test_regular_user_cannot_delete(self):
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            self.get_delete_query(), input_data={"pk": self.res_unit_image.pk}
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("deleteReservationUnitImage").get("errors")
+        ).contains("No permissions to perform delete.")
+        assert_that(
+            content.get("data").get("deleteReservationUnitImage").get("deleted")
+        ).is_false()
+
+        assert_that(
+            ReservationUnitImage.objects.filter(pk=self.res_unit_image.pk).exists()
+        ).is_true()

--- a/api/graphql/tests/test_reservation_unit_types.py
+++ b/api/graphql/tests/test_reservation_unit_types.py
@@ -22,7 +22,6 @@ class ReservationUnitTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
                 reservationUnitTypes {
                     edges {
                         node {
-                            pk
                             nameFi
                             nameEn
                             nameSv

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
-from graphene_django.views import GraphQLView
+from graphene_file_upload.django import FileUploadGraphQLView
 from rest_framework import routers
 
 from .allocation_api import AllocationRequestViewSet
@@ -124,5 +124,5 @@ router.register(r"parameters/city", CityViewSet, "city")
 
 
 urlpatterns = [
-    path("graphql/", csrf_exempt(GraphQLView.as_view(graphiql=True))),
+    path("graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))),
 ]

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -19,7 +19,7 @@ from permissions.helpers import (
     can_modify_reservation,
     can_view_recurring_reservation,
 )
-from reservation_units.models import ReservationUnit
+from reservation_units.models import ReservationUnit, ReservationUnitImage
 from reservations.models import RecurringReservation, Reservation
 from spaces.models import Unit
 
@@ -56,6 +56,30 @@ class ReservationUnitPermission(BasePermission):
         if not unit_pk:
             return False
         unit = Unit.objects.filter(id=unit_pk).first()
+        return can_manage_units_reservation_units(info.context.user, unit)
+
+
+class ReservationUnitImagePermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return False
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        if input.get("pk"):
+            reservation_unit_pk = (
+                ReservationUnitImage.objects.filter(id=input.get("pk"))
+                .values_list("reservation_unit_id", flat=True)
+                .first()
+            )
+        else:
+            reservation_unit_pk = input.get("reservation_unit_pk")
+        if not reservation_unit_pk:
+            return False
+
+        unit = Unit.objects.filter(reservationunit=reservation_unit_pk).first()
+        if not unit:
+            return False
         return can_manage_units_reservation_units(info.context.user, unit)
 
 

--- a/requirements.in
+++ b/requirements.in
@@ -39,3 +39,4 @@ social-auth-app-django==4.0.0
 uWSGI==2.0.19.1
 whitenoise==5.2.0
 pip-tools
+graphene-file-upload==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -147,6 +147,8 @@ graphene-django==3.0.0b7
     #   -r requirements.in
     #   django-graphql-jwt
     #   graphene-permissions
+graphene-file-upload==1.3.0
+    # via -r requirements.in
 graphene==3.0
     # via
     #   django-graphql-jwt
@@ -289,6 +291,7 @@ six==1.15.0
     #   django-modeltranslation
     #   ecdsa
     #   freezegun
+    #   graphene-file-upload
     #   jsonschema
     #   promise
     #   protobuf

--- a/reservation_units/tests/factories.py
+++ b/reservation_units/tests/factories.py
@@ -89,6 +89,11 @@ class ReservationUnitFactory(DjangoModelFactory):
             self.equipments.add(equipment)
 
 
+class ReservationUnitImageFactory(DjangoModelFactory):
+    class Meta:
+        model = "reservation_units.ReservationUnitImage"
+
+
 class KeywordCategoryFactory(DjangoModelFactory):
     class Meta:
         model = "reservation_units.KeywordCategory"


### PR DESCRIPTION
Introduces graphene file upload library which enables sending multipart request spec to be used in graphene by replacing the default graphqlview with the fileupload view.

Adds mutations for creating reservation unit image objects (with files [images]) 

https://github.com/jaydenseric/graphql-multipart-request-spec

TILA-970