### PR TITLE
Remove beta repos from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN if [ "x$BUILD_MODE" = "xlocal" ] ;\
     fi
 
 RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-RUN subscription-manager repos --disable rhel-8-for-x86_64-baseos-beta-rpms
-RUN subscription-manager repos --disable rhel-8-for-x86_64-appstream-beta-rpms
 RUN yum -y update
 
 RUN rpm -Uvh https://download.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm


### PR DESCRIPTION
This should hopefully resolve the build error:

    2021-12-10T12:03:14.9444100Z STEP 10: RUN subscription-manager repos --disable rhel-8-for-x86_64-baseos-beta-rpms
    2021-12-10T12:03:34.8932008Z Error: 'rhel-8-for-x86_64-baseos-beta-rpms' does not match a valid repository ID. Use "subscription-manager repos --list" to see valid repositories.