### PR TITLE
TILA-989 | Require organization id for hauki admin url generation

### DIFF
--- a/fixtures/cases.json
+++ b/fixtures/cases.json
@@ -353,7 +353,7 @@
         "pk": 1,
         "fields": {
             "tprek_id": null,
-            "tprek_department_id": null,
+            "tprek_department_id": "1234",
             "name": "Töölön kirjasto",
             "name_fi": "Töölön kirjasto",
             "name_en": null,
@@ -377,7 +377,7 @@
         "pk": 2,
         "fields": {
             "tprek_id": null,
-            "tprek_department_id": null,
+            "tprek_department_id": "1234",
             "name": "Helsingin keskustakirjasto Oodi",
             "name_fi": "Helsingin keskustakirjasto Oodi",
             "name_en": null,
@@ -401,7 +401,7 @@
         "pk": 3,
         "fields": {
             "tprek_id": null,
-            "tprek_department_id": null,
+            "tprek_department_id": "1234",
             "name": "Fredriksbergin talo",
             "name_fi": "Fredriksbergin talo",
             "name_en": null,
@@ -425,7 +425,7 @@
         "pk": 4,
         "fields": {
             "tprek_id": null,
-            "tprek_department_id": null,
+            "tprek_department_id": "1234",
             "name": "Ympyrätalo",
             "name_fi": "Ympyrätalo",
             "name_en": null,

--- a/opening_hours/hauki_link_generator.py
+++ b/opening_hours/hauki_link_generator.py
@@ -18,6 +18,7 @@ def generate_hauki_link(
         and settings.HAUKI_SECRET
         and settings.HAUKI_ORIGIN_ID
         and username
+        and organization_id
     ):
         return None
 

--- a/opening_hours/tests/test_hauki_link_generator.py
+++ b/opening_hours/tests/test_hauki_link_generator.py
@@ -57,3 +57,9 @@ def test_hauki_link_with_missing_settings(setting, enable_hauki_admin_ui):
     )
 
     assert_that(link).is_none()
+
+
+@freeze_time("2021-01-01 12:00:00", tz_offset=2)
+def test_hauki_link_generation_when_organization_none(enable_hauki_admin_ui):
+    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=None)
+    assert_that(link).is_none()


### PR DESCRIPTION
Also update fixtures to have a value in unit's tprek_department_id. 

