### PR TITLE
Upgrade to Django 3.1.14 for security fixes

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 assertpy==1.1
 black==20.8b1
 celery
-Django==3.1.13
+Django==3.1.14
 django-auditlog==1.0a1
 django-celery-results
 django-cors-headers==3.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -97,7 +97,7 @@ django-recurrence==1.10.3
     # via -r requirements.in
 django-tinymce==3.4.0
     # via -r requirements.in
-django==3.1.13
+django==3.1.14
     # via
     #   -r requirements.in
     #   django-cors-headers


### PR DESCRIPTION
This bumps Django from 3.1.13 to 3.1.14, which fixes  CVE-2021-44420.