### PR TITLE
TILA-1046: Validate reservation unit's price unit and interval fields

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -249,6 +249,14 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
                     f"Wrong type of id: {identifier} for {field_name}"
                 )
 
+    def validate_price_unit(self, value):
+        valid_values = [x[0] for x in ReservationUnit.PRICE_UNITS]
+        if value not in valid_values:
+            raise serializers.ValidationError(
+                f"Invalid price unit {value}. Valid values are {', '.join(valid_values)}"
+            )
+        return value
+
     def validate(self, data):
         is_draft = data.get("is_draft", getattr(self.instance, "is_draft", False))
 

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -257,6 +257,16 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             )
         return value
 
+    def validate_reservation_start_interval(self, value):
+        valid_values = [
+            x[0] for x in ReservationUnit.RESERVATION_START_INTERVAL_CHOICES
+        ]
+        if value not in valid_values:
+            raise serializers.ValidationError(
+                f"Invalid reservation start interval {value}. Valid values are {', '.join(valid_values)}"
+            )
+        return value
+
     def validate(self, data):
         is_draft = data.get("is_draft", getattr(self.instance, "is_draft", False))
 

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -2575,6 +2575,19 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
         assert_that(self.res_unit.highest_price).is_equal_to(expected_highest_price)
         assert_that(self.res_unit.price_unit).is_equal_to(expected_price_unit)
 
+    def test_price_unit_cannot_be_invalid(self):
+        invalid_price_unit = "invalid"
+        data = self.get_valid_update_data()
+        data["priceUnit"] = invalid_price_unit
+        response = self.query(self.get_update_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        res_unit_data = content.get("data").get("updateReservationUnit")
+        assert_that(res_unit_data.get("errors")).is_not_none()
+        self.res_unit.refresh_from_db()
+        assert_that(self.res_unit.price_unit).is_not_equal_to(invalid_price_unit)
+
     def test_errors_on_empty_name_translations(self):
         data = self.get_valid_update_data()
         data["nameEn"] = ""

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -2588,6 +2588,21 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
         self.res_unit.refresh_from_db()
         assert_that(self.res_unit.price_unit).is_not_equal_to(invalid_price_unit)
 
+    def test_reservation_start_interval_cannot_be_invalid(self):
+        invalid_interval = "invalid"
+        data = self.get_valid_update_data()
+        data["reservationStartInterval"] = invalid_interval
+        response = self.query(self.get_update_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        res_unit_data = content.get("data").get("updateReservationUnit")
+        assert_that(res_unit_data.get("errors")).is_not_none()
+        self.res_unit.refresh_from_db()
+        assert_that(self.res_unit.reservation_start_interval).is_not_equal_to(
+            invalid_interval
+        )
+
     def test_errors_on_empty_name_translations(self):
         data = self.get_valid_update_data()
         data["nameEn"] = ""


### PR DESCRIPTION
Added validation for enum fields:

* `ReservationUnit.price_unit`
* `ReservationUnit.reservation_start_interval`

I was only able to find these two fields with missing validation. The others seemed to be read-only (`Reservation.state`) or had validation already (`Resource.location_type`).