### PR TITLE
TILA-928 | Camelcase field names in errors

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -1,4 +1,5 @@
 from django.core import validators
+from graphene.utils.str_converters import to_camel_case
 from rest_framework import serializers
 
 from api.graphql.base_serializers import (
@@ -275,7 +276,8 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             value = data.get(field, getattr(self.instance, field, None))
             if field not in allowed_empty_fields and (not value or value.isspace()):
                 raise serializers.ValidationError(
-                    f"Not draft state reservation units must have a translations. Missing translation for {field}."
+                    f"Not draft state reservation units must have a translations. "
+                    f"Missing translation for {to_camel_case(field)}."
                 )
 
         spaces = data.get("spaces", getattr(self.instance, "spaces", None))

--- a/api/graphql/resources/resource_serializers.py
+++ b/api/graphql/resources/resource_serializers.py
@@ -1,3 +1,4 @@
+from graphene.utils.str_converters import to_camel_case
 from rest_framework import serializers
 
 from api.graphql.base_serializers import (
@@ -66,7 +67,8 @@ class ResourceCreateSerializer(ResourceSerializer, PrimaryKeySerializer):
             value = data.get(field)
             if not value or value.isspace():
                 validation_errors[field] = serializers.ValidationError(
-                    f"Not draft state resources must have a translations. Missing translation for {field}."
+                    f"Not draft state resources must have a translations. "
+                    f"Missing translation for {to_camel_case(field)}."
                 )
 
         if data.get("location_type") == Resource.LOCATION_FIXED and not data.get(
@@ -100,7 +102,8 @@ class ResourceUpdateSerializer(PrimaryKeyUpdateSerializer, ResourceCreateSeriali
                 if field in self.translation_fields:
                     if not value or value == "" or value.isspace():
                         raise serializers.ValidationError(
-                            f"Not draft state resources must have a translations. Missing translation for {field}."
+                            f"Not draft state resources must have a translations. "
+                            f"Missing translation for {to_camel_case(field)}."
                         )
 
                 if field == "space":

--- a/api/graphql/tests/test_resources.py
+++ b/api/graphql/tests/test_resources.py
@@ -168,7 +168,7 @@ class ResourceCreateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(
             content.get("data").get("createResource").get("errors")[0].get("messages")
         ).contains(
-            "Not draft state resources must have a translations. Missing translation for name_sv."
+            "Not draft state resources must have a translations. Missing translation for nameSv."
         )
         assert_that(Resource.objects.exclude(id=self.resource.id).count()).is_equal_to(
             0
@@ -186,7 +186,7 @@ class ResourceCreateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(
             content.get("data").get("createResource").get("errors")[0].get("messages")
         ).contains(
-            "Not draft state resources must have a translations. Missing translation for description_en."
+            "Not draft state resources must have a translations. Missing translation for descriptionEn."
         )
         assert_that(Resource.objects.exclude(id=self.resource.id).count()).is_equal_to(
             0
@@ -408,7 +408,7 @@ class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(
             content.get("data").get("updateResource").get("errors")[0].get("messages")
         ).contains(
-            "Not draft state resources must have a translations. Missing translation for name_sv."
+            "Not draft state resources must have a translations. Missing translation for nameSv."
         )
 
     def test_validation_error_when_empty_description_translation(self):
@@ -421,7 +421,7 @@ class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(
             content.get("data").get("updateResource").get("errors")[0].get("messages")
         ).contains(
-            "Not draft state resources must have a translations. Missing translation for description_fi."
+            "Not draft state resources must have a translations. Missing translation for descriptionFi."
         )
 
     def test_validation_error_when_try_to_null_space_and_fixed_location(self):
@@ -489,7 +489,7 @@ class ResourceUpdateForPublishGraphQLTestCase(ResourceGraphQLBase):
         assert_that(
             content.get("data").get("updateResource").get("errors")[0].get("messages")
         ).contains(
-            "Not draft state resources must have a translations. Missing translation for description_fi."
+            "Not draft state resources must have a translations. Missing translation for descriptionFi."
         )
 
     def test_partial_update_fails_when_removing_space_from_fixed_location(self):


### PR DESCRIPTION
By default graphene is camelcasing, but we're missing some custom validation messages to be camelcased

TILA-928