### PR TITLE
TILA-1053: Expose age groups in GraphQL API

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -41,6 +41,8 @@ class AgeGroupType(AuthNode, PrimaryKeyObjectType):
     class Meta:
         model = AgeGroup
         fields = ["minimum", "maximum"]
+        filter_fields = []
+        interfaces = (graphene.relay.Node,)
 
 
 class AbilityGroupType(AuthNode, PrimaryKeyObjectType):

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -46,6 +46,7 @@ from api.graphql.reservations.reservation_mutations import (
     ReservationUpdateMutation,
 )
 from api.graphql.reservations.reservation_types import (
+    AgeGroupType,
     ReservationCancelReasonType,
     ReservationPurposeType,
     ReservationType,
@@ -69,6 +70,7 @@ from permissions.api_permissions.graphene_field_decorators import (
     check_resolver_permission,
 )
 from permissions.api_permissions.graphene_permissions import (
+    AgeGroupPermission,
     EquipmentCategoryPermission,
     EquipmentPermission,
     KeywordPermission,
@@ -230,6 +232,12 @@ class TaxPercentageFilter(AuthFilter):
     )
 
 
+class AgeGroupFilter(AuthFilter):
+    permission_classes = (
+        (AgeGroupPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
+    )
+
+
 class Query(graphene.ObjectType):
     reservations = ReservationsFilter(
         ReservationType, filterset_class=ReservationFilterSet
@@ -280,6 +288,7 @@ class Query(graphene.ObjectType):
 
     terms_of_use = TermsOfUseFilter(TermsOfUseType)
     tax_percentages = TaxPercentageFilter(TaxPercentageType)
+    age_groups = AgeGroupFilter(AgeGroupType)
 
     @check_resolver_permission(ReservationPermission)
     def resolve_reservation_by_pk(self, info, **kwargs):

--- a/api/graphql/tests/snapshots/snap_test_age_groups.py
+++ b/api/graphql/tests/snapshots/snap_test_age_groups.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['AgeGroupsGraphQLTestCase::test_getting_age_groups 1'] = {
+    'data': {
+        'ageGroups': {
+            'edges': [
+                {
+                    'node': {
+                        'maximum': 30,
+                        'minimum': 18
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_age_groups.py
+++ b/api/graphql/tests/test_age_groups.py
@@ -1,0 +1,35 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from reservations.models import AgeGroup
+
+
+class AgeGroupsGraphQLTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.api_client = APIClient()
+
+    def test_getting_age_groups(self):
+        AgeGroup.objects.create(minimum=18, maximum=30)
+        response = self.query(
+            """
+            query {
+                ageGroups {
+                    edges {
+                        node {
+                            minimum
+                            maximum
+                        }
+                    }
+                }
+            }
+            """
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)


### PR DESCRIPTION
Adds age groups to the GraphQL API, so they can be queried like this:

```graphql
{
  ageGroups {
    edges {
      node {
        minimum
        maximum
      }
    }
  }
}
```

This is needed so that the frontend can show age group options in dropdown menus.

TILA-1053