### PR TITLE
TILA-1053: Expose cities in the GraphQL API

### DIFF
--- a/api/graphql/applications/application_types.py
+++ b/api/graphql/applications/application_types.py
@@ -1,0 +1,20 @@
+import graphene
+from django.conf import settings
+from graphene_permissions.mixins import AuthNode
+from graphene_permissions.permissions import AllowAny
+
+from api.graphql.base_type import PrimaryKeyObjectType
+from applications.models import City
+from permissions.api_permissions.graphene_permissions import CityPermission
+
+
+class CityType(AuthNode, PrimaryKeyObjectType):
+    permission_classes = (
+        (CityPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
+    )
+
+    class Meta:
+        model = City
+        fields = ["name"]
+        filter_fields = []
+        interfaces = (graphene.relay.Node,)

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -8,6 +8,7 @@ from graphene_permissions.mixins import AuthFilter
 from graphene_permissions.permissions import AllowAny, AllowAuthenticated
 from rest_framework.generics import get_object_or_404
 
+from api.graphql.applications.application_types import CityType
 from api.graphql.reservation_units.reservation_unit_filtersets import (
     ReservationUnitsFilterSet,
 )
@@ -71,6 +72,7 @@ from permissions.api_permissions.graphene_field_decorators import (
 )
 from permissions.api_permissions.graphene_permissions import (
     AgeGroupPermission,
+    CityPermission,
     EquipmentCategoryPermission,
     EquipmentPermission,
     KeywordPermission,
@@ -238,6 +240,12 @@ class AgeGroupFilter(AuthFilter):
     )
 
 
+class CityFilter(AuthFilter):
+    permission_classes = (
+        (CityPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
+    )
+
+
 class Query(graphene.ObjectType):
     reservations = ReservationsFilter(
         ReservationType, filterset_class=ReservationFilterSet
@@ -289,6 +297,7 @@ class Query(graphene.ObjectType):
     terms_of_use = TermsOfUseFilter(TermsOfUseType)
     tax_percentages = TaxPercentageFilter(TaxPercentageType)
     age_groups = AgeGroupFilter(AgeGroupType)
+    cities = CityFilter(CityType)
 
     @check_resolver_permission(ReservationPermission)
     def resolve_reservation_by_pk(self, info, **kwargs):

--- a/api/graphql/tests/snapshots/snap_test_cities.py
+++ b/api/graphql/tests/snapshots/snap_test_cities.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['CitiesGraphQLTestCase::test_getting_cities 1'] = {
+    'data': {
+        'cities': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'Helsinki'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_cities.py
+++ b/api/graphql/tests/test_cities.py
@@ -1,0 +1,34 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from applications.models import City
+
+
+class CitiesGraphQLTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.api_client = APIClient()
+
+    def test_getting_cities(self):
+        City.objects.create(name="Helsinki")
+        response = self.query(
+            """
+            query {
+                cities {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+            """
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -290,3 +290,13 @@ class TaxPercentagePermission(BasePermission):
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
         return False
+
+
+class CityPermission(BasePermission):
+    @classmethod
+    def has_permission(self, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False


### PR DESCRIPTION
Adds cities to the GraphQL API, so they can be queried like this:

```graphql
{
  cities {
    edges {
      node {
        name
      }
    }
  }
}
```

This is needed so that the frontend can show the city options in dropdown menus.

TILA-1053