### PR TITLE
TILA-951: Expose metadata sets in GraphQL API

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -29,6 +29,7 @@ from reservations.models import (
     RecurringReservation,
     Reservation,
     ReservationCancelReason,
+    ReservationMetadataSet,
     ReservationPurpose,
 )
 
@@ -215,4 +216,25 @@ class ReservationCancelReasonType(AuthNode, PrimaryKeyObjectType):
         model = ReservationCancelReason
         fields = ["pk", "reason", "reason_fi", "reason_en", "reason_sv"]
         filter_fields = ["reason"]
+        interfaces = (graphene.relay.Node,)
+
+
+class ReservationMetadataSetType(AuthNode, PrimaryKeyObjectType):
+    permission_classes = (
+        (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
+    )
+
+    supported_fields = graphene.List(graphene.String)
+    required_fields = graphene.List(graphene.String)
+
+    def resolve_supported_fields(self, info: ResolveInfo):
+        return self.supported_fields.all()
+
+    def resolve_required_fields(self, info: ResolveInfo):
+        return self.required_fields.all()
+
+    class Meta:
+        model = ReservationMetadataSet
+        fields = ["pk", "name", "supported_fields", "required_fields"]
+        filter_fields = []
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -49,6 +49,7 @@ from api.graphql.reservations.reservation_mutations import (
 from api.graphql.reservations.reservation_types import (
     AgeGroupType,
     ReservationCancelReasonType,
+    ReservationMetadataSetType,
     ReservationPurposeType,
     ReservationType,
 )
@@ -77,6 +78,7 @@ from permissions.api_permissions.graphene_permissions import (
     EquipmentPermission,
     KeywordPermission,
     PurposePermission,
+    ReservationMetadataSetPermission,
     ReservationPermission,
     ReservationPurposePermission,
     ReservationUnitCancellationRulePermission,
@@ -246,6 +248,14 @@ class CityFilter(AuthFilter):
     )
 
 
+class ReservationMetadataSetFilter(AuthFilter):
+    permission_classes = (
+        (ReservationMetadataSetPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else (AllowAny,)
+    )
+
+
 class Query(graphene.ObjectType):
     reservations = ReservationsFilter(
         ReservationType, filterset_class=ReservationFilterSet
@@ -298,6 +308,7 @@ class Query(graphene.ObjectType):
     tax_percentages = TaxPercentageFilter(TaxPercentageType)
     age_groups = AgeGroupFilter(AgeGroupType)
     cities = CityFilter(CityType)
+    metadata_sets = ReservationMetadataSetFilter(ReservationMetadataSetType)
 
     @check_resolver_permission(ReservationPermission)
     def resolve_reservation_by_pk(self, info, **kwargs):

--- a/api/graphql/tests/snapshots/snap_test_metadata_sets.py
+++ b/api/graphql/tests/snapshots/snap_test_metadata_sets.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['MetadataSetsGraphQLTestCase::test_getting_metadata_sets 1'] = {
+    'data': {
+        'metadataSets': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'Test form',
+                        'requiredFields': [
+                            'reservee_first_name',
+                            'reservee_last_name'
+                        ],
+                        'supportedFields': [
+                            'reservee_first_name',
+                            'reservee_last_name',
+                            'reservee_phone'
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_metadata_sets.py
+++ b/api/graphql/tests/test_metadata_sets.py
@@ -1,0 +1,51 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from reservations.models import ReservationMetadataField, ReservationMetadataSet
+
+
+class MetadataSetsGraphQLTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.api_client = APIClient()
+
+    def test_getting_metadata_sets(self):
+        supported_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+                "reservee_phone",
+            ]
+        )
+        required_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+            ]
+        )
+        metadata_set = ReservationMetadataSet.objects.create(name="Test form")
+        metadata_set.supported_fields.set(supported_fields)
+        metadata_set.required_fields.set(required_fields)
+        response = self.query(
+            """
+            query {
+                metadataSets {
+                    edges {
+                        node {
+                            name
+                            supportedFields
+                            requiredFields
+                        }
+                    }
+                }
+            }
+            """
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -300,3 +300,13 @@ class CityPermission(BasePermission):
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
         return False
+
+
+class ReservationMetadataSetPermission(BasePermission):
+    @classmethod
+    def has_permission(self, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False


### PR DESCRIPTION
Adds ability to query metadata sets in GraphQL:

```graphql
{
  metadataSets {
    edges {
      node {
        pk
        name
        supportedFields
        requiredFields
      }
    }
  }
}
```
Example response:
```json
{
  "data": {
    "metadataSets": {
      "edges": [
        {
          "node": {
            "name": "Test form",
            "requiredFields": [
              "reservee_first_name",
              "reservee_last_name"
            ],
            "supportedFields": [
              "reservee_first_name",
              "reservee_last_name",
              "reservee_phone"
            ]
          }
        }
      ]
    }
  }
}
```

TILA-951