### PR TITLE
TILA-1050: Add ability to set/query metadata set for a reservation unit in the GraphQL API

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -23,6 +23,7 @@ from reservation_units.models import (
     ReservationUnitType,
     TaxPercentage,
 )
+from reservations.models import ReservationMetadataSet
 from resources.models import Resource
 from services.models import Service
 from spaces.models import Space, Unit
@@ -184,6 +185,11 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         source="tax_percentage",
         required=False,
     )
+    metadata_set_pk = IntegerPrimaryKeyField(
+        queryset=ReservationMetadataSet.objects.all(),
+        source="metadata_set",
+        required=False,
+    )
 
     translation_fields = get_all_translatable_fields(ReservationUnit)
 
@@ -227,6 +233,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "reservation_ends",
             "publish_begins",
             "publish_ends",
+            "metadata_set_pk",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):
@@ -240,6 +247,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         self.fields["cancellation_terms_pk"].write_only = True
         self.fields["service_specific_terms_pk"].write_only = True
         self.fields["tax_percentage_pk"].write_only = True
+        self.fields["metadata_set_pk"].write_only = True
 
     def _check_pk_list(self, id_list, field_name):
         for identifier in id_list:

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -12,7 +12,10 @@ from graphene_permissions.permissions import AllowAny
 
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.graphql.opening_hours.opening_hours_types import OpeningHoursMixin
-from api.graphql.reservations.reservation_types import ReservationType
+from api.graphql.reservations.reservation_types import (
+    ReservationMetadataSetType,
+    ReservationType,
+)
 from api.graphql.resources.resource_types import ResourceType
 from api.graphql.services.service_types import ServiceType
 from api.graphql.spaces.space_types import LocationType, SpaceType
@@ -308,6 +311,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     tax_percentage = graphene.Field(TaxPercentageType)
     buffer_time_before = graphene.Time()
     buffer_time_after = graphene.Time()
+    metadata_set = graphene.Field(ReservationMetadataSetType)
 
     permission_classes = (
         (ReservationUnitPermission,)
@@ -350,6 +354,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "reservation_ends",
             "publish_begins",
             "publish_ends",
+            "metadata_set",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],
@@ -508,6 +513,7 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "reservation_start_interval",
             "buffer_time_before",
             "buffer_time_after",
+            "metadata_set",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['ReservationUnitQueryTestCase::test_filtering_by_active_application_rounds 1'] = {
@@ -360,6 +359,11 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'location': None,
                         'lowestPrice': '0.00',
                         'maxPersons': 110,
+                        'metadataSet': {
+                            'name': 'Test form',
+                            'requiredFields': [],
+                            'supportedFields': [],
+                        },
                         'nameFi': 'test name fi',
                         'priceUnit': 'PER_HOUR',
                         'publishBegins': '2021-05-03T00:00:00+00:00',

--- a/reservations/tests/factories.py
+++ b/reservations/tests/factories.py
@@ -26,6 +26,13 @@ class ReservationPurposeFactory(DjangoModelFactory):
     name = FuzzyText()
 
 
+class ReservationMetadataSetFactory(DjangoModelFactory):
+    class Meta:
+        model = "reservations.ReservationMetadataSet"
+
+    name = FuzzyText()
+
+
 class ReservationFactory(DjangoModelFactory):
     class Meta:
         model = "reservations.Reservation"


### PR DESCRIPTION
Allows setting the metadata set by PK in reservation unit's create and update mutations, e.g.:

```graphql
mutation {
  updateReservationUnit(input: {
    pk: 123
    metadataSetPk: 567
  } {
    ...
  }
}
```

Also querying the metadata set is possible via the `metadataSet` field:

```graphql
{
  reservationUnitByPk(pk: 123) {
    metadataSet {
      name
      supportedFields
      requiredFields
    }
  }
}
```

TILA-1050