### PR TITLE
TILA-1056: Add new form fields to reservation's GraphQL query and mutation APIs

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -135,6 +135,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     unit_price = graphene.Float()
     tax_percentage_value = graphene.Decimal()
     price = graphene.Float()
+    age_group = graphene.Field(AgeGroupType)
 
     class Meta:
         model = Reservation
@@ -152,6 +153,25 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             "reservee_first_name",
             "reservee_last_name",
             "reservee_phone",
+            "reservee_organisation_name",
+            "reservee_address_street",
+            "reservee_address_city",
+            "reservee_address_zip",
+            "reservee_email",
+            "reservee_type",
+            "reservee_id",
+            "reservee_is_unregistered_association",
+            "home_city",
+            "applying_for_free_of_charge",
+            "free_of_charge_reason",
+            "age_group",
+            "billing_first_name",
+            "billing_last_name",
+            "billing_address_street",
+            "billing_address_city",
+            "billing_address_zip",
+            "billing_phone",
+            "billing_email",
             "name",
             "description",
             "purpose",

--- a/api/graphql/tests/snapshots/snap_test_reservations.py
+++ b/api/graphql/tests/snapshots/snap_test_reservations.py
@@ -34,11 +34,27 @@ snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
             'edges': [
                 {
                     'node': {
+                        'applyingForFreeOfCharge': True,
+                        'ageGroup': {
+                            'maximum': 30,
+                            'minimum': 18
+                        },
                         'begin': '2021-10-12T12:00:00+00:00',
+                        'billingAddressCity': 'Turku',
+                        'billingAddressStreet': 'Aurakatu 12B',
+                        'billingAddressZip': '20100',
                         'bufferTimeAfter': None,
                         'bufferTimeBefore': None,
+                        'billingEmail': 'billing@example.com',
+                        'billingFirstName': 'Reser',
+                        'billingLastName': 'Vee',
+                        'billingPhone': '+358234567890',
                         'description': 'movies&popcorn',
                         'end': '2021-10-12T13:00:00+00:00',
+                        'freeOfChargeReason': 'This is some reason.',
+                        'homeCity': {
+                            'name': 'Test',
+                        },
                         'name': 'movies',
                         'numPersons': None,
                         'unitPrice': 10,
@@ -54,9 +70,17 @@ snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
                                 'nameFi': 'resunit'
                             }
                         ],
+                        'reserveeAddressCity': 'Helsinki',
+                        'reserveeAddressStreet': 'Mannerheimintie 2',
+                        'reserveeAddressZip': '00100',
+                        'reserveeEmail': 'reservee@example.com',
                         'reserveeFirstName': 'Reser',
+                        'reserveeId': '5727586-5',
+                        'reserveeIsUnregisteredAssociation': False,
                         'reserveeLastName': 'Vee',
-                        'reserveePhone': '',
+                        'reserveeOrganisationName': 'Test organisation',
+                        'reserveePhone': '+358123456789',
+                        'reserveeType': 'INDIVIDUAL',
                         'state': 'CREATED',
                         'user': 'joe.regularl@foo.com'
                     }

--- a/api/graphql/tests/test_reservations.py
+++ b/api/graphql/tests/test_reservations.py
@@ -10,7 +10,7 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.base import GrapheneTestCaseBase
-from applications.models import PRIORITY_CONST
+from applications.models import CUSTOMER_TYPES, PRIORITY_CONST, City
 from applications.tests.factories import ApplicationRoundFactory
 from opening_hours.enums import State
 from opening_hours.hours import TimeElement
@@ -20,7 +20,7 @@ from reservation_units.tests.factories import (
     ReservationUnitCancellationRuleFactory,
     ReservationUnitFactory,
 )
-from reservations.models import STATE_CHOICES, Reservation
+from reservations.models import STATE_CHOICES, AgeGroup, Reservation
 from reservations.tests.factories import (
     ReservationCancelReasonFactory,
     ReservationFactory,
@@ -76,6 +76,26 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         self.reservation = ReservationFactory(
             reservee_first_name="Reser",
             reservee_last_name="Vee",
+            reservee_type=CUSTOMER_TYPES.CUSTOMER_TYPE_INDIVIDUAL,
+            reservee_organisation_name="Test organisation",
+            reservee_address_street="Mannerheimintie 2",
+            reservee_address_city="Helsinki",
+            reservee_address_zip="00100",
+            reservee_phone="+358123456789",
+            reservee_email="reservee@example.com",
+            reservee_id="5727586-5",
+            reservee_is_unregistered_association=False,
+            home_city=City.objects.create(name="Test"),
+            applying_for_free_of_charge=True,
+            free_of_charge_reason="This is some reason.",
+            age_group=AgeGroup.objects.create(minimum=18, maximum=30),
+            billing_first_name="Reser",
+            billing_last_name="Vee",
+            billing_address_street="Aurakatu 12B",
+            billing_address_city="Turku",
+            billing_address_zip="20100",
+            billing_phone="+358234567890",
+            billing_email="billing@example.com",
             name="movies",
             description="movies&popcorn",
             reservation_unit=[self.reservation_unit],
@@ -111,7 +131,31 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
                             numPersons
                             reserveeFirstName
                             reserveeLastName
+                            reserveeType
+                            reserveeOrganisationName
+                            reserveeAddressStreet
+                            reserveeAddressCity
+                            reserveeAddressZip
                             reserveePhone
+                            reserveeEmail
+                            reserveeId
+                            reserveeIsUnregisteredAssociation
+                            homeCity {
+                                name
+                            }
+                            applyingForFreeOfCharge
+                            freeOfChargeReason
+                            ageGroup {
+                                minimum
+                                maximum
+                            }
+                            billingFirstName
+                            billingLastName
+                            billingAddressStreet
+                            billingAddressCity
+                            billingAddressZip
+                            billingPhone
+                            billingEmail
                             name
                             description
                             purpose {nameFi}


### PR DESCRIPTION
This adds the new reservation form fields introduced in #369 to the GraphQL API for reservations.

After this, the new form fields can be queried, e.g.:

```graphql
{
  reservationByPk(pk: 1) {
    reserveeType
    reserveeOrganisationName
    reserveeEmail
    reserveeId
    reserveeIsUnregisteredAssociation
    reserveeAddressStreet
    reserveeAddressCity
    reserveeAddressZip
    billingFirstName
    billingLastName
    billingPhone
    billingEmail
    billingAddressStreet
    billingAddressCity
    billingAddressZip
    homeCity {
      name
    }
    ageGroup {
      minimum
      maximum
    }
    applyingForFreeOfCharge
    freeOfChargeReason
    numPersons
  }
}
```

They can also be passed in create/update mutations, e.g.:

```graphql
mutation {
  updateReservation(input: {
    pk: 1
    billingAddressCity: "Test City"
  }) {
    billingAddressCity
  }
}
```

We don't check yet whether required fields are given or not -- this will be done in a separate PR. Normal validation for the fields is done however (e.g. checking the num `reserveeType`).