### PR TITLE
TILA-1057: Add validation for required metadata fields

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -3,6 +3,7 @@ from typing import List
 
 from django.conf import settings
 from django.utils.timezone import get_default_timezone
+from graphene.utils.str_converters import to_camel_case
 from rest_framework import serializers
 
 from api.graphql.base_serializers import (
@@ -204,6 +205,7 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
 
             self.check_buffer_times(data, reservation_unit)
             self.check_reservation_start_time(begin, scheduler)
+            self.check_metadata_fields(data, reservation_unit)
 
         data["state"] = STATE_CHOICES.CREATED
         data[
@@ -294,6 +296,16 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
             raise serializers.ValidationError(
                 f"Reservation start time does not match the allowed interval of {interval_minutes} minutes."
             )
+
+    def check_metadata_fields(self, data, reservation_unit) -> None:
+        metadata_set = reservation_unit.metadata_set
+        required_fields = metadata_set.required_fields.all() if metadata_set else []
+        for required_field in required_fields:
+            internal_field_name = required_field.field_name
+            if not data.get(internal_field_name):
+                raise serializers.ValidationError(
+                    f"Value for required field {to_camel_case(internal_field_name)} is missing."
+                )
 
 
 class ReservationUpdateSerializer(

--- a/api/graphql/tests/test_reservations.py
+++ b/api/graphql/tests/test_reservations.py
@@ -20,7 +20,13 @@ from reservation_units.tests.factories import (
     ReservationUnitCancellationRuleFactory,
     ReservationUnitFactory,
 )
-from reservations.models import STATE_CHOICES, AgeGroup, Reservation
+from reservations.models import (
+    STATE_CHOICES,
+    AgeGroup,
+    Reservation,
+    ReservationMetadataField,
+    ReservationMetadataSet,
+)
 from reservations.tests.factories import (
     ReservationCancelReasonFactory,
     ReservationFactory,
@@ -839,6 +845,29 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             price=10,
         )
 
+    def _create_metadata_set(self):
+        supported_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+                "reservee_phone",
+                "home_city",
+                "age_group",
+            ]
+        )
+        required_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+                "home_city",
+                "age_group",
+            ]
+        )
+        metadata_set = ReservationMetadataSet.objects.create(name="Test form")
+        metadata_set.supported_fields.set(supported_fields)
+        metadata_set.required_fields.set(required_fields)
+        return metadata_set
+
     def get_update_query(self):
         return """
             mutation updateReservation($input: ReservationUpdateMutationInput!) {
@@ -1238,6 +1267,90 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         assert_that(
             content.get("data").get("updateReservation").get("errors")[0]["messages"][0]
         ).contains(err_msg)
+
+    def test_update_succeeds_when_reservation_unit_has_no_metadata_set(
+        self, mock_periods, mock_opening_hours
+    ):
+        self.reservation_unit.metadata_set = None
+        self.reservation_unit.save(update_fields=["metadata_set"])
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        input_data = self.get_valid_update_data()
+        input_data["reserveeFirstName"] = "John"
+        self.client.force_login(self.regular_joe)
+        response = self.query(self.get_update_query(), input_data=input_data)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("updateReservation").get("errors")
+        ).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.reservee_first_name).is_equal_to(
+            input_data["reserveeFirstName"]
+        )
+
+    def test_update_succeeds_when_all_required_fields_are_filled(
+        self, mock_periods, mock_opening_hours
+    ):
+        self.reservation_unit.metadata_set = self._create_metadata_set()
+        self.reservation_unit.save(update_fields=["metadata_set"])
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        home_city = City.objects.create(name="Helsinki")
+        age_group = AgeGroup.objects.create(minimum=18, maximum=30)
+        input_data = self.get_valid_update_data()
+        input_data["reserveeFirstName"] = "John"
+        input_data["reserveeLastName"] = "Doe"
+        input_data["reserveePhone"] = "+358123456789"
+        input_data["homeCityPk"] = home_city.pk
+        input_data["ageGroupPk"] = age_group.pk
+        self.client.force_login(self.regular_joe)
+        response = self.query(self.get_update_query(), input_data=input_data)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("updateReservation").get("errors")
+        ).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.reservee_first_name).is_equal_to(
+            input_data["reserveeFirstName"]
+        )
+        assert_that(self.reservation.reservee_last_name).is_equal_to(
+            input_data["reserveeLastName"]
+        )
+        assert_that(self.reservation.reservee_phone).is_equal_to(
+            input_data["reserveePhone"]
+        )
+        assert_that(self.reservation.home_city).is_equal_to(home_city)
+        assert_that(self.reservation.age_group).is_equal_to(age_group)
+
+    def test_update_fails_when_some_required_fields_are_missing(
+        self, mock_periods, mock_opening_hours
+    ):
+        self.reservation_unit.metadata_set = self._create_metadata_set()
+        self.reservation_unit.save(update_fields=["metadata_set"])
+        home_city = City.objects.create(name="Helsinki")
+        age_group = AgeGroup.objects.create(minimum=18, maximum=30)
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        input_data = self.get_valid_update_data()
+        input_data["reserveeLastName"] = "Doe"
+        input_data["reserveePhone"] = "+358123456789"
+        input_data["homeCityPk"] = home_city.pk
+        input_data["ageGroupPk"] = age_group.pk
+        self.client.force_login(self.regular_joe)
+        response = self.query(self.get_update_query(), input_data=input_data)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("updateReservation").get("errors")
+        ).is_not_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.reservee_last_name).is_not_equal_to(
+            input_data["reserveeLastName"]
+        )
+        assert_that(self.reservation.reservee_phone).is_not_equal_to(
+            input_data["reserveePhone"]
+        )
+        assert_that(self.reservation.home_city).is_not_equal_to(home_city)
+        assert_that(self.reservation.age_group).is_not_equal_to(age_group)
 
 
 @freezegun.freeze_time("2021-10-12T12:00:00Z")


### PR DESCRIPTION
This adds validation for required metadata fields.

When mutating a reservation, we go through each required field in the attached reservation unit's metadata set. If any of the required field is missing/empty, a validation error is raised.

TILA-1057