### PR TITLE
TILA-1008: Expose max reservations per user in the GraphQL API

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -234,6 +234,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "publish_begins",
             "publish_ends",
             "metadata_set_pk",
+            "max_reservations_per_user",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -355,6 +355,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "publish_begins",
             "publish_ends",
             "metadata_set",
+            "max_reservations_per_user",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],
@@ -518,6 +519,7 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "reservation_ends",
             "publish_begins",
             "publish_ends",
+            "max_reservations_per_user",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -359,6 +359,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'location': None,
                         'lowestPrice': '0.00',
                         'maxPersons': 110,
+                        'maxReservationsPerUser': 5,
                         'metadataSet': {
                             'name': 'Test form',
                             'requiredFields': [],


### PR DESCRIPTION
Adds `maxReservationsPerUser` for reservation units in the GraphQL API.

This allows the `maxReservationsPerUser` to be queried and also mutated in the create and update mutations.