### PR TITLE
Upgrade Celery to version 5.2.2

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,6 +1,6 @@
 assertpy==1.1
 black==20.8b1
-celery
+celery==5.2.2
 Django==3.1.14
 django-auditlog==1.0a1
 django-celery-results

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ black==20.8b1
     # via -r requirements.in
 cachetools==4.2.2
     # via django-helusers
-celery==5.2.1
+celery==5.2.2
     # via
     #   -r requirements.in
     #   django-celery-results


### PR DESCRIPTION
Fixes CVE-2021-23727.