### PR TITLE
TILA-1046: Allow uppercase enum values

### DIFF
--- a/api/graphql/choice_char_field.py
+++ b/api/graphql/choice_char_field.py
@@ -1,0 +1,42 @@
+from django.core.exceptions import ValidationError
+from django.utils.deconstruct import deconstructible
+from django.utils.translation import gettext_lazy as _
+from rest_framework import serializers
+
+
+@deconstructible
+class ChoiceValidator:
+    message = _(
+        'Choice "%(choice)s" is not allowed. '
+        "Allowed choices are: %(allowed_choices)s."
+    )
+    code = "invalid_choice"
+
+    def __init__(self, allowed_choices):
+        self.allowed_choices = [choice[0].upper() for choice in allowed_choices]
+
+    def __call__(self, value):
+        if value.upper() not in self.allowed_choices:
+            raise ValidationError(
+                self.message,
+                self.code,
+                {"choice": value, "allowed_choices": ", ".join(self.allowed_choices)},
+            )
+
+
+class ChoiceCharField(serializers.CharField):
+    def __init__(self, choices, **kwargs):
+        super().__init__(**kwargs)
+        choice_validator = ChoiceValidator(choices)
+        self.validators.append(choice_validator)
+
+    def to_internal_value(self, data):
+        if isinstance(data, str):
+            data = data.lower()
+        return super().to_internal_value(data)
+
+    def get_attribute(self, instance):
+        value = super().get_attribute(instance)
+        if isinstance(value, str):
+            return value.upper()
+        return value

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -6,6 +6,7 @@ from api.graphql.base_serializers import (
     PrimaryKeySerializer,
     PrimaryKeyUpdateSerializer,
 )
+from api.graphql.choice_char_field import ChoiceCharField
 from api.graphql.primary_key_fields import IntegerPrimaryKeyField
 from api.graphql.translate_fields import get_all_translatable_fields
 from api.reservation_units_api import (
@@ -164,20 +165,22 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False,
         help_text="Maximum price of the reservation unit",
     )
-    price_unit = serializers.CharField(
+    price_unit = ChoiceCharField(
         required=False,
+        choices=ReservationUnit.PRICE_UNITS,
         help_text=(
             "Unit of the price. "
-            f"Possible values are {', '.join(value for value, _ in ReservationUnit.PRICE_UNITS)}."
+            f"Possible values are {', '.join(value[0].upper() for value in ReservationUnit.PRICE_UNITS)}."
         ),
     )
-    reservation_start_interval = serializers.CharField(
+    reservation_start_interval = ChoiceCharField(
         required=False,
+        choices=ReservationUnit.RESERVATION_START_INTERVAL_CHOICES,
         help_text=(
             "Determines the interval for the start time of the reservation. "
             "For example an interval of 15 minutes means a reservation can "
             "begin at minutes 0, 15, 30, or 45. Possible values are "
-            f"{', '.join(value[0] for value in ReservationUnit.RESERVATION_START_INTERVAL_CHOICES)}."
+            f"{', '.join(value[0].upper() for value in ReservationUnit.RESERVATION_START_INTERVAL_CHOICES)}."
         ),
     )
     tax_percentage_pk = IntegerPrimaryKeyField(
@@ -257,24 +260,6 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
                 raise serializers.ValidationError(
                     f"Wrong type of id: {identifier} for {field_name}"
                 )
-
-    def validate_price_unit(self, value):
-        valid_values = [x[0] for x in ReservationUnit.PRICE_UNITS]
-        if value not in valid_values:
-            raise serializers.ValidationError(
-                f"Invalid price unit {value}. Valid values are {', '.join(valid_values)}"
-            )
-        return value
-
-    def validate_reservation_start_interval(self, value):
-        valid_values = [
-            x[0] for x in ReservationUnit.RESERVATION_START_INTERVAL_CHOICES
-        ]
-        if value not in valid_values:
-            raise serializers.ValidationError(
-                f"Invalid reservation start interval {value}. Valid values are {', '.join(valid_values)}"
-            )
-        return value
 
     def validate(self, data):
         is_draft = data.get("is_draft", getattr(self.instance, "is_draft", False))

--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -10,6 +10,7 @@ from api.graphql.base_serializers import (
     PrimaryKeySerializer,
     PrimaryKeyUpdateSerializer,
 )
+from api.graphql.choice_char_field import ChoiceCharField
 from api.graphql.primary_key_fields import IntegerPrimaryKeyField
 from applications.models import CUSTOMER_TYPES, City
 from reservation_units.models import ReservationUnit
@@ -45,11 +46,12 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
     age_group_pk = IntegerPrimaryKeyField(
         queryset=AgeGroup.objects.all(), source="age_group", allow_null=True
     )
-    reservee_type = serializers.CharField(
+    reservee_type = ChoiceCharField(
+        choices=CUSTOMER_TYPES.CUSTOMER_TYPE_CHOICES,
         help_text=(
             "Type of the reservee. "
-            f"Possible values are {', '.join(value for value, _ in CUSTOMER_TYPES.CUSTOMER_TYPE_CHOICES)}."
-        )
+            f"Possible values are {', '.join(value[0].upper() for value in CUSTOMER_TYPES.CUSTOMER_TYPE_CHOICES)}."
+        ),
     )
 
     class Meta:

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -1714,8 +1714,8 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
             "cancellationRulePk": self.rule.pk,
             "lowestPrice": 0,
             "highestPrice": 20,
-            "priceUnit": "per_hour",
-            "reservationStartInterval": ReservationUnit.RESERVATION_START_INTERVAL_60_MINUTES,
+            "priceUnit": ReservationUnit.PRICE_UNIT_PER_HOUR.upper(),
+            "reservationStartInterval": ReservationUnit.RESERVATION_START_INTERVAL_60_MINUTES.upper(),
             "taxPercentagePk": TaxPercentage.objects.get(value=24).pk,
             "publishBegins": "2021-05-03T00:00:00+00:00",
             "publishEnds": "2021-05-03T00:00:00+00:00",
@@ -1758,8 +1758,8 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
         assert_that(res_unit.cancellation_rule).is_equal_to(self.rule)
         assert_that(res_unit.lowest_price).is_equal_to(data.get("lowestPrice"))
         assert_that(res_unit.highest_price).is_equal_to(data.get("highestPrice"))
-        assert_that(res_unit.price_unit).is_equal_to(data.get("priceUnit"))
-        assert_that(res_unit.reservation_start_interval).is_equal_to(
+        assert_that(res_unit.price_unit.upper()).is_equal_to(data.get("priceUnit"))
+        assert_that(res_unit.reservation_start_interval.upper()).is_equal_to(
             data.get("reservationStartInterval")
         )
         assert_that(res_unit.tax_percentage).is_equal_to(
@@ -2569,7 +2569,7 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
         data = self.get_valid_update_data()
         data["lowestPrice"] = float(expected_lowest_price)
         data["highestPrice"] = float(expected_highest_price)
-        data["priceUnit"] = expected_price_unit
+        data["priceUnit"] = expected_price_unit.upper()
         update_query = """
             mutation updateReservationUnit($input: ReservationUnitUpdateMutationInput!) {
                 updateReservationUnit(input: $input) {
@@ -2597,7 +2597,7 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
             float(expected_highest_price)
         )
         assert_that(res_unit_data.get("priceUnit")).is_equal_to(
-            ReservationUnit.PRICE_UNIT_PER_HOUR
+            expected_price_unit.upper()
         )
         self.res_unit.refresh_from_db()
         assert_that(self.res_unit.lowest_price).is_equal_to(expected_lowest_price)
@@ -2707,7 +2707,7 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
     def test_update_reservation_start_interval(self):
         expected_interval = ReservationUnit.RESERVATION_START_INTERVAL_60_MINUTES
         data = self.get_valid_update_data()
-        data["reservationStartInterval"] = expected_interval
+        data["reservationStartInterval"] = expected_interval.upper()
         update_query = """
             mutation updateReservationUnit($input: ReservationUnitUpdateMutationInput!) {
                 updateReservationUnit(input: $input) {
@@ -2727,7 +2727,7 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
         assert_that(content.get("errors")).is_none()
         assert_that(res_unit_data.get("errors")).is_none()
         assert_that(res_unit_data.get("reservationStartInterval")).is_equal_to(
-            expected_interval
+            expected_interval.upper()
         )
         self.res_unit.refresh_from_db()
         assert_that(self.res_unit.reservation_start_interval).is_equal_to(


### PR DESCRIPTION
This adds a new `ChoiceCharField` which can be used for enum fields with choices.

It takes the choices as an argument, and includes a validator which makes sure a given value is part of the choices. So no separate validations should be needed in mutation serializers, for example.

This means that:

* In queries, enum strings are returned in `UPPERCASE` (as before)
* In mutation inputs, enum strings can be given in `UPPERCASE` or `lowercase` (previously they had to be given in lowercase)
* In mutation payloads, enum strings are returned in `UPPERCASE` (previously they were returned in lowercase)

Maybe we will get true enums [some day](https://github.com/graphql-python/graphene-django/issues/1280).