### PR TITLE
TILA-1054: Use a `Duration` scalar for duration fields

### DIFF
--- a/api/graphql/duration_field.py
+++ b/api/graphql/duration_field.py
@@ -1,0 +1,53 @@
+from datetime import timedelta
+from typing import Any, Optional
+
+from django.core.validators import MinValueValidator
+from django.utils.translation import gettext_lazy as _
+from graphene.types.scalars import Scalar
+from rest_framework import serializers
+
+
+class Duration(Scalar):
+    """
+    The `Duration` scalar type represents a duration value as an integer in seconds.
+    For example, a value of 900 means a duration of 15 minutes.
+    """
+
+    @staticmethod
+    def serialize(value: timedelta) -> int:
+        return int(value.total_seconds())
+
+    @staticmethod
+    def parse_value(value: Any) -> Optional[timedelta]:
+        try:
+            return timedelta(seconds=value)
+        except ValueError:
+            return None
+
+
+class MinDurationValidator(MinValueValidator):
+    def clean(self, x: timedelta) -> int:
+        return int(x.total_seconds())
+
+
+class DurationField(serializers.IntegerField):
+    default_error_messages = {"invalid": _("A valid integer is required.")}
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.validators.append(MinDurationValidator(0))
+
+    def to_internal_value(self, data) -> timedelta:
+        try:
+            return timedelta(seconds=int(data))
+        except ValueError:
+            self.fail("invalid")
+
+    def to_representation(self, value) -> int:
+        return int(value.total_seconds())
+
+    def get_attribute(self, instance: Any) -> Optional[int]:
+        value = super().get_attribute(instance)
+        if isinstance(value, timedelta):
+            return int(value.total_seconds())
+        return value

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -7,6 +7,7 @@ from api.graphql.base_serializers import (
     PrimaryKeyUpdateSerializer,
 )
 from api.graphql.choice_char_field import ChoiceCharField
+from api.graphql.duration_field import DurationField
 from api.graphql.primary_key_fields import IntegerPrimaryKeyField
 from api.graphql.translate_fields import get_all_translatable_fields
 from api.reservation_units_api import (
@@ -96,8 +97,10 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
     name_fi = serializers.CharField(required=False, allow_blank=True)
     name_sv = serializers.CharField(required=False, allow_blank=True)
     name_en = serializers.CharField(required=False, allow_blank=True)
-    max_reservation_duration = serializers.DurationField(required=False)
-    min_reservation_duration = serializers.DurationField(required=False)
+    max_reservation_duration = DurationField(required=False)
+    min_reservation_duration = DurationField(required=False)
+    buffer_time_before = DurationField(required=False)
+    buffer_time_after = DurationField(required=False)
     max_persons = serializers.IntegerField(required=False)
     space_pks = serializers.ListField(
         child=IntegerPrimaryKeyField(queryset=Space.objects.all()),

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -11,6 +11,7 @@ from graphene_permissions.mixins import AuthNode
 from graphene_permissions.permissions import AllowAny
 
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.graphql.duration_field import Duration
 from api.graphql.opening_hours.opening_hours_types import OpeningHoursMixin
 from api.graphql.reservations.reservation_types import (
     ReservationMetadataSetType,
@@ -294,8 +295,8 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     unit = graphene.Field(UnitType)
     max_persons = graphene.Int()
     surface_area = graphene.Decimal()
-    max_reservation_duration = graphene.Time()
-    min_reservation_duration = graphene.Time()
+    max_reservation_duration = Duration()
+    min_reservation_duration = Duration()
     keyword_groups = graphene.List(KeywordGroupType)
     reservations = graphene.List(
         ReservationType,
@@ -309,8 +310,8 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     cancellation_terms = graphene.Field(TermsOfUseType)
     service_specific_terms = graphene.Field(TermsOfUseType)
     tax_percentage = graphene.Field(TaxPercentageType)
-    buffer_time_before = graphene.Time()
-    buffer_time_after = graphene.Time()
+    buffer_time_before = Duration()
+    buffer_time_after = Duration()
     metadata_set = graphene.Field(ReservationMetadataSetType)
 
     permission_classes = (
@@ -420,18 +421,6 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
         surface_area = self.spaces.aggregate(total_surface_area=Sum("surface_area"))
         return surface_area.get("total_surface_area")
 
-    def resolve_max_reservation_duration(self, info):
-        if not self.max_reservation_duration:
-            return None
-        duration = datetime.datetime(1, 1, 1) + self.max_reservation_duration
-        return duration.time()
-
-    def resolve_min_reservation_duration(self, info):
-        if not self.min_reservation_duration:
-            return None
-        duration = datetime.datetime(1, 1, 1) + self.min_reservation_duration
-        return duration.time()
-
     def resolve_keyword_groups(self, info):
         return KeywordGroup.objects.filter(reservation_units=self.id)
 
@@ -468,18 +457,6 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     @check_resolver_permission(ReservationUnitCancellationRulePermission)
     def resolve_cancellation_rule(self, info: ResolveInfo):
         return self.cancellation_rule
-
-    def resolve_buffer_time_before(self, info: ResolveInfo):
-        if not self.buffer_time_before:
-            return None
-        duration = datetime.datetime(1, 1, 1) + self.buffer_time_before
-        return duration.time()
-
-    def resolve_buffer_time_after(self, info: ResolveInfo):
-        if not self.buffer_time_after:
-            return None
-        duration = datetime.datetime(1, 1, 1) + self.buffer_time_after
-        return duration.time()
 
 
 class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):

--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -11,6 +11,7 @@ from api.graphql.base_serializers import (
     PrimaryKeyUpdateSerializer,
 )
 from api.graphql.choice_char_field import ChoiceCharField
+from api.graphql.duration_field import DurationField
 from api.graphql.primary_key_fields import IntegerPrimaryKeyField
 from applications.models import CUSTOMER_TYPES, City
 from reservation_units.models import ReservationUnit
@@ -55,6 +56,8 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
             f"Possible values are {', '.join(value[0].upper() for value in CUSTOMER_TYPES.CUSTOMER_TYPE_CHOICES)}."
         ),
     )
+    buffer_time_before = DurationField(required=False)
+    buffer_time_after = DurationField(required=False)
 
     class Meta:
         model = Reservation

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -8,6 +8,7 @@ from graphene_permissions.permissions import AllowAny, AllowAuthenticated
 from rest_framework.reverse import reverse
 
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.graphql.duration_field import Duration
 from api.graphql.translate_fields import get_all_translatable_fields
 from api.ical_api import hmac_signature
 from permissions.api_permissions.graphene_field_decorators import (
@@ -139,6 +140,8 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     tax_percentage_value = graphene.Decimal()
     price = graphene.Float()
     age_group = graphene.Field(AgeGroupType)
+    buffer_time_before = Duration()
+    buffer_time_after = Duration()
 
     class Meta:
         model = Reservation

--- a/api/graphql/resources/resource_serializers.py
+++ b/api/graphql/resources/resource_serializers.py
@@ -5,6 +5,7 @@ from api.graphql.base_serializers import (
     PrimaryKeySerializer,
     PrimaryKeyUpdateSerializer,
 )
+from api.graphql.duration_field import DurationField
 from api.graphql.primary_key_fields import IntegerPrimaryKeyField
 from api.graphql.translate_fields import get_all_translatable_fields
 from api.resources_api import ResourceSerializer
@@ -21,6 +22,20 @@ class ResourceCreateSerializer(ResourceSerializer, PrimaryKeySerializer):
     location_type = serializers.CharField(
         required=False
     )  # For some reason graphene blows up if this isn't defined here.
+    buffer_time_before = DurationField(
+        required=False,
+        help_text=(
+            "Buffer time while reservation unit is unreservable before the reservation. "
+            "Dynamically calculated from spaces and resources."
+        ),
+    )
+    buffer_time_after = DurationField(
+        required=False,
+        help_text=(
+            "Buffer time while reservation unit is unreservable after the reservation. "
+            "Dynamically calculated from spaces and resources."
+        ),
+    )
 
     class Meta(ResourceSerializer.Meta):
 

--- a/api/graphql/resources/resource_types.py
+++ b/api/graphql/resources/resource_types.py
@@ -4,6 +4,7 @@ from graphene_permissions.mixins import AuthNode
 from graphene_permissions.permissions import AllowAny
 
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.graphql.duration_field import Duration
 from api.graphql.spaces.space_types import BuildingType
 from api.graphql.translate_fields import get_all_translatable_fields
 from permissions.api_permissions.graphene_permissions import ResourcePermission
@@ -12,6 +13,8 @@ from resources.models import Resource
 
 class ResourceType(AuthNode, PrimaryKeyObjectType):
     building = graphene.List(BuildingType)
+    buffer_time_before = Duration()
+    buffer_time_after = Duration()
 
     permission_classes = (
         (ResourcePermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
@@ -35,13 +38,3 @@ class ResourceType(AuthNode, PrimaryKeyObjectType):
         }
 
         interfaces = (graphene.relay.Node,)
-
-    def resolve_buffer_time_before(self, info):
-        if self.buffer_time_before is None:
-            return None
-        return self.buffer_time_before.total_seconds()
-
-    def resolve_buffer_time_after(self, info):
-        if self.buffer_time_after is None:
-            return None
-        return self.buffer_time_after.total_seconds()

--- a/api/graphql/services/service_types.py
+++ b/api/graphql/services/service_types.py
@@ -1,13 +1,14 @@
 import graphene
 
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.graphql.duration_field import Duration
 from api.graphql.translate_fields import get_all_translatable_fields
 from services.models import Service
 
 
 class ServiceType(PrimaryKeyObjectType):
-    buffer_time_before = graphene.String()
-    buffer_time_after = graphene.String()
+    buffer_time_before = Duration()
+    buffer_time_after = Duration()
 
     class Meta:
         model = Service

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -368,8 +368,8 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'additionalInstructionsSv': 'Ytterligare instruktioner',
                         'applicationRounds': [
                         ],
-                        'bufferTimeAfter': '00:15:00',
-                        'bufferTimeBefore': '00:15:00',
+                        'bufferTimeAfter': 900,
+                        'bufferTimeBefore': 900,
                         'cancellationRule': {
                             'nameEn': 'en',
                             'nameFi': 'fi',
@@ -385,6 +385,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'location': None,
                         'lowestPrice': '0.00',
                         'maxPersons': 110,
+                        'maxReservationDuration': 86400,
                         'maxReservationsPerUser': 5,
                         'metadataSet': {
                             'name': 'Test form',
@@ -393,6 +394,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                             'supportedFields': [
                             ]
                         },
+                        'minReservationDuration': 600,
                         'nameFi': 'test name fi',
                         'priceUnit': 'PER_HOUR',
                         'publishBegins': '2021-05-03T00:00:00+00:00',
@@ -411,6 +413,11 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'resources': [
                         ],
                         'services': [
+                            {
+                                'bufferTimeAfter': 1800,
+                                'bufferTimeBefore': 900,
+                                'nameFi': 'Test Service'
+                            }
                         ],
                         'spaces': [
                             {

--- a/api/graphql/tests/snapshots/snap_test_resources.py
+++ b/api/graphql/tests/snapshots/snap_test_resources.py
@@ -30,8 +30,8 @@ snapshots['ResourceGraphQLTestCase::test_getting_resources_with_null_buffer_time
 snapshots['ResourceGraphQLTestCase::test_should_be_able_to_find_by_pk_with_buffer_times 1'] = {
     'data': {
         'resourceByPk': {
-            'bufferTimeAfter': 7200.0,
-            'bufferTimeBefore': 3600.0,
+            'bufferTimeAfter': 7200,
+            'bufferTimeBefore': 3600,
             'nameFi': 'Test resource'
         }
     }

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -59,6 +59,11 @@ class ReservationUnitQueryTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCa
             name_en="test type en",
             name_sv="test type sv",
         )
+        service = ServiceFactory(
+            name="Test Service",
+            buffer_time_before=datetime.timedelta(minutes=15),
+            buffer_time_after=datetime.timedelta(minutes=30),
+        )
         large_space = SpaceFactory(
             max_persons=100, name="Large space", surface_area=100
         )
@@ -80,6 +85,7 @@ class ReservationUnitQueryTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCa
             reservation_unit_type=cls.type,
             uuid="3774af34-9916-40f2-acc7-68db5a627710",
             spaces=[large_space, small_space],
+            services=[service],
             cancellation_rule=rule,
             additional_instructions_fi="Lisäohjeita",
             additional_instructions_sv="Ytterligare instruktioner",
@@ -97,6 +103,8 @@ class ReservationUnitQueryTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCa
             + datetime.timedelta(days=7),
             buffer_time_before=datetime.timedelta(minutes=15),
             buffer_time_after=datetime.timedelta(minutes=15),
+            min_reservation_duration=datetime.timedelta(minutes=10),
+            max_reservation_duration=datetime.timedelta(days=1),
             metadata_set=ReservationMetadataSetFactory(name="Test form"),
             max_reservations_per_user=5,
         )
@@ -128,6 +136,8 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
                             }
                             services {
                               nameFi
+                              bufferTimeBefore
+                              bufferTimeAfter
                             }
                             requireIntroduction
                             purposes {
@@ -190,6 +200,8 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
                             publishEnds
                             bufferTimeBefore
                             bufferTimeAfter
+                            minReservationDuration
+                            maxReservationDuration
                             metadataSet {
                               name
                               supportedFields
@@ -1752,8 +1764,8 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
             "reservationUnitTypePk": self.reservation_unit_type.id,
             "surfaceArea": 100,
             "maxPersons": 10,
-            "bufferTimeAfter": "1:00:00",
-            "bufferTimeBefore": "1:00:00",
+            "bufferTimeAfter": 3600,
+            "bufferTimeBefore": 3600,
             "cancellationRulePk": self.rule.pk,
             "lowestPrice": 0,
             "highestPrice": 20,

--- a/api/graphql/tests/test_reservations/snapshots/snap_base.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_base.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['ReservationByPkTestCase::test_getting_reservation_by_pk 1'] = {
@@ -91,8 +90,8 @@ snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
                         'billingFirstName': 'Reser',
                         'billingLastName': 'Vee',
                         'billingPhone': '+358234567890',
-                        'bufferTimeAfter': None,
-                        'bufferTimeBefore': None,
+                        'bufferTimeAfter': 1800,
+                        'bufferTimeBefore': 900,
                         'description': 'movies&popcorn',
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': 'This is some reason.',

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -58,6 +58,8 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             tax_percentage_value=24,
             price=10,
             working_memo="i'm visible to staff users",
+            buffer_time_before=datetime.timedelta(minutes=15),
+            buffer_time_after=datetime.timedelta(minutes=30),
         )
 
     def test_reservation_query(self):
@@ -112,6 +114,8 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
                             unitPrice
                             taxPercentageValue
                             price
+                            bufferTimeBefore
+                            bufferTimeAfter
                           }
                         }
                     }


### PR DESCRIPTION
This PR changes the GraphQL types for mutations and queries so that duration fields will use a new `Duration` scalar type instead of `String` for mutations and `Float` for query responses in the GraphQL schema.

After these changes, durations like `bufferTimeBefore` and `minDuration` should be set as integers in mutations:

```graphql
mutation {
  updateReservationUnit(input: {
    pk: 1
    bufferTimeBefore: 900
    maxReservationDuration: 1800
  }) {
    bufferTimeBefore
    maxReservationDuration
  }
}
```
Response:
```json
{
  "data": {
    "updateReservationUnit": {
      "bufferTimeBefore": 900,
      "maxReservationDuration": 1800
    }
  }
}
```
Queries will also return integers:
```graphql
{
  reservationUnits {
    edges {
      node {
        bufferTimeBefore
        maxReservationDuration
      }
    }
  }
}
```
Response:
```json
{
  "data": {
    "reservationUnits": {
      "edges": [
        {
          "node": {
            "bufferTimeBefore": 900,
            "maxReservationDuration": 1800
          }
        }
      ]
    }
  }
}
```

The schema will change like this:

* There will be a new scalar called `Duration`:
  * Acts like `Int`
  * Represents a duration in seconds
  * Accepts integer values parseable as `timedelta(seconds=<value>)`
* Reservations:
  * Queries:
    * `bufferTimeBefore`: `Float` → `Duration `
    * `bufferTimeAfter`: `Float` → `Duration `
  * Mutations:
    * `bufferTimeBefore`: `String` → `Duration `
    * `bufferTimeAfter`: `String` → `Duration `
* Resources:
  * Queries:
    * `bufferTimeBefore`: `Float` → `Duration `
    * `bufferTimeAfter`: `Float` → `Duration `
  * Mutations:
    * `bufferTimeBefore`: `String` → `Duration `
    * `bufferTimeAfter`: `String` → `Duration `
* Reservation units:
  * Queries:
    * `maxReservationDuration`: `Time` → `Duration`
    * `minReservationDuration`: `Time` → `Duration`
    * `bufferTimeBefore`: `Time` → `Duration`
    * `bufferTimeAfter`: `Time` → `Duration`
  * Mutations:
    * `maxReservationDuration`: `String` → `Duration`
    * `minReservationDuration`: `String` → `Duration`
    * `bufferTimeBefore`: `String` → `Duration`
    * `bufferTimeAfter`: `String` → `Duration`
