### PR TITLE
TILA-1057: Fix metadata field validation in confirm mutation

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -380,7 +380,8 @@ class ReservationUpdateSerializer(
         required_fields = metadata_set.required_fields.all() if metadata_set else []
         for required_field in required_fields:
             internal_field_name = required_field.field_name
-            if not data.get(internal_field_name):
+            existing_value = getattr(self.instance, internal_field_name, None)
+            if not data.get(internal_field_name, existing_value):
                 raise serializers.ValidationError(
                     f"Value for required field {to_camel_case(internal_field_name)} is missing."
                 )

--- a/api/graphql/tests/test_reservations/base.py
+++ b/api/graphql/tests/test_reservations/base.py
@@ -10,6 +10,7 @@ from opening_hours.enums import State
 from opening_hours.hours import TimeElement
 from reservation_units.models import ReservationUnit
 from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.models import ReservationMetadataField, ReservationMetadataSet
 from reservations.tests.factories import ReservationPurposeFactory
 from spaces.tests.factories import SpaceFactory
 
@@ -49,3 +50,26 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
                 ),
             ],
         }
+
+    def _create_metadata_set(self):
+        supported_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+                "reservee_phone",
+                "home_city",
+                "age_group",
+            ]
+        )
+        required_fields = ReservationMetadataField.objects.filter(
+            field_name__in=[
+                "reservee_first_name",
+                "reservee_last_name",
+                "home_city",
+                "age_group",
+            ]
+        )
+        metadata_set = ReservationMetadataSet.objects.create(name="Test form")
+        metadata_set.supported_fields.set(supported_fields)
+        metadata_set.required_fields.set(required_fields)
+        return metadata_set

--- a/api/graphql/tests/test_reservations/test_reservation_confirm.py
+++ b/api/graphql/tests/test_reservations/test_reservation_confirm.py
@@ -8,8 +8,9 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
+from applications.models import City
 from opening_hours.tests.test_get_periods import get_mocked_periods
-from reservations.models import STATE_CHOICES
+from reservations.models import STATE_CHOICES, AgeGroup
 from reservations.tests.factories import ReservationFactory
 
 
@@ -104,3 +105,39 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.confirmed_at).is_equal_to(
             datetime.datetime(2021, 10, 12, 12).astimezone()
         )
+
+    def test_confirm_reservation_succeeds_if_reservation_already_has_required_fields(
+        self, mock_periods, mock_opening_hours
+    ):
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        self.reservation_unit.metadata_set = self._create_metadata_set()
+        self.reservation_unit.save(update_fields=["metadata_set"])
+        self.reservation.reservee_first_name = "John"
+        self.reservation.reservee_last_name = "Doe"
+        self.reservation.home_city = City.objects.create(name="Helsinki")
+        self.reservation.age_group = AgeGroup.objects.create(minimum=18, maximum=30)
+        self.reservation.save()
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            self.get_confirm_query(), input_data=self.get_valid_confirm_data()
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        confirm_data = content.get("data").get("confirmReservation")
+        assert_that(confirm_data.get("errors")).is_none()
+
+    def test_confirm_reservation_fails_if_required_fields_are_not_filled(
+        self, mock_periods, mock_opening_hours
+    ):
+        self.reservation_unit.metadata_set = self._create_metadata_set()
+        self.reservation_unit.save(update_fields=["metadata_set"])
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        self.reservation.reservee_first_name = ""
+        self.reservation.save()
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            self.get_confirm_query(), input_data=self.get_valid_confirm_data()
+        )
+        content = json.loads(response.content)
+        confirm_data = content.get("data").get("confirmReservation")
+        assert_that(confirm_data.get("errors")).is_not_none()

--- a/api/graphql/tests/test_reservations/test_reservation_update.py
+++ b/api/graphql/tests/test_reservations/test_reservation_update.py
@@ -11,13 +11,7 @@ from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
 from applications.models import City
 from applications.tests.factories import ApplicationRoundFactory
 from opening_hours.tests.test_get_periods import get_mocked_periods
-from reservations.models import (
-    STATE_CHOICES,
-    AgeGroup,
-    Reservation,
-    ReservationMetadataField,
-    ReservationMetadataSet,
-)
+from reservations.models import STATE_CHOICES, AgeGroup, Reservation
 from reservations.tests.factories import ReservationFactory
 
 
@@ -44,29 +38,6 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
             tax_percentage_value=24,
             price=10,
         )
-
-    def _create_metadata_set(self):
-        supported_fields = ReservationMetadataField.objects.filter(
-            field_name__in=[
-                "reservee_first_name",
-                "reservee_last_name",
-                "reservee_phone",
-                "home_city",
-                "age_group",
-            ]
-        )
-        required_fields = ReservationMetadataField.objects.filter(
-            field_name__in=[
-                "reservee_first_name",
-                "reservee_last_name",
-                "home_city",
-                "age_group",
-            ]
-        )
-        metadata_set = ReservationMetadataSet.objects.create(name="Test form")
-        metadata_set.supported_fields.set(supported_fields)
-        metadata_set.required_fields.set(required_fields)
-        return metadata_set
 
     def get_update_query(self):
         return """
@@ -529,6 +500,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         age_group = AgeGroup.objects.create(minimum=18, maximum=30)
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
         input_data = self.get_valid_update_data()
+        input_data["reserveeFirstName"] = None
         input_data["reserveeLastName"] = "Doe"
         input_data["reserveePhone"] = "+358123456789"
         input_data["homeCityPk"] = home_city.pk


### PR DESCRIPTION
Fixes the `confirmReservation` mutation so that metadata fields are validated correctly based on possibly existing values in the reservation instance.

Added a test case to make sure confirming a reservation (without providing the required fields in the mutation input) will work in the future too.

TILA-1057