### PR TITLE
TILA-1063 | ReservationUnitImage update mutation

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_mutations.py
+++ b/api/graphql/reservation_units/reservation_unit_mutations.py
@@ -17,6 +17,7 @@ from api.graphql.reservation_units.reservation_unit_serializers import (
     PurposeUpdateSerializer,
     ReservationUnitCreateSerializer,
     ReservationUnitImageCreateSerializer,
+    ReservationUnitImageUpdateSerializer,
     ReservationUnitUpdateSerializer,
 )
 from api.graphql.reservation_units.reservation_unit_types import (
@@ -238,6 +239,21 @@ class ReservationUnitImageCreateMutation(AuthSerializerMutation, SerializerMutat
         if self.pk:
             return get_object_or_404(ReservationUnitImage, pk=self.pk)
         return None
+
+
+class ReservationUnitImageUpdateMutation(AuthSerializerMutation, SerializerMutation):
+    reservation_unit_image = graphene.Field(ReservationUnitImageType)
+
+    permission_classes = (
+        (ReservationUnitImagePermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else (AllowAny,)
+    )
+
+    class Meta:
+        model_operations = ["update"]
+        lookup_field = "pk"
+        serializer_class = ReservationUnitImageUpdateSerializer
 
 
 class ReservationUnitImageDeleteMutation(AuthDeleteMutation, ClientIDMutation):

--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -358,3 +358,22 @@ class ReservationUnitImageCreateSerializer(PrimaryKeySerializer):
         data["image"] = image
 
         return data
+
+
+class ReservationUnitImageUpdateSerializer(PrimaryKeyUpdateSerializer):
+    reservation_unit_pk = IntegerPrimaryKeyField(
+        source="reservation_unit",
+        read_only=True,
+    )
+    image_type = ChoiceCharField(
+        required=False,
+        choices=ReservationUnitImage.TYPES,
+        help_text=(
+            "Type of image. Value is one of image_type enum values: "
+            f"{', '.join(value[0].upper() for value in ReservationUnitImage.TYPES)}."
+        ),
+    )
+
+    class Meta:
+        model = ReservationUnitImage
+        fields = ["pk", "reservation_unit_pk", "image_type"]

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -143,14 +143,14 @@ class ReservationUnitHaukiUrlType(AuthNode, DjangoObjectType):
         return None
 
 
-class ReservationUnitImageType(DjangoObjectType):
+class ReservationUnitImageType(PrimaryKeyObjectType):
     image_url = graphene.String()
     medium_url = graphene.String()
     small_url = graphene.String()
 
     class Meta:
         model = ReservationUnitImage
-        fields = ("image_url", "medium_url", "small_url", "image_type")
+        fields = ("pk", "image_url", "medium_url", "small_url", "image_type")
 
     def resolve_image_url(self, info):
         if not self.image:

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -150,7 +150,7 @@ class ReservationUnitImageType(PrimaryKeyObjectType):
 
     class Meta:
         model = ReservationUnitImage
-        fields = ("pk", "image_url", "medium_url", "small_url", "image_type")
+        fields = ["pk", "image_url", "medium_url", "small_url", "image_type"]
 
     def resolve_image_url(self, info):
         if not self.image:

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -24,6 +24,7 @@ from api.graphql.reservation_units.reservation_unit_mutations import (
     ReservationUnitCreateMutation,
     ReservationUnitImageCreateMutation,
     ReservationUnitImageDeleteMutation,
+    ReservationUnitImageUpdateMutation,
     ReservationUnitUpdateMutation,
 )
 from api.graphql.reservation_units.reservation_unit_types import (
@@ -358,6 +359,7 @@ class Mutation(graphene.ObjectType):
     update_reservation_unit = ReservationUnitUpdateMutation.Field()
 
     create_reservation_unit_image = ReservationUnitImageCreateMutation.Field()
+    update_reservation_unit_image = ReservationUnitImageUpdateMutation.Field()
     delete_reservation_unit_image = ReservationUnitImageDeleteMutation.Field()
 
     create_purpose = PurposeCreateMutation.Field()


### PR DESCRIPTION
Adds update mutation for `ReservationUnitImage` - the mutation allows updating the reservation unit image's type.

Also add `pk` to `ReservationUnitImageType` to make deletion and update possible.

TILA-1058 TILA-1063