### PR TITLE
Change reservation state to ChoiceField in serializer

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -29,8 +29,9 @@ DEFAULT_TIMEZONE = get_default_timezone()
 
 
 class ReservationCreateSerializer(PrimaryKeySerializer):
-    state = serializers.CharField(
-        help_text="Read only string value for ReservationType's ReservationState enum."
+    state = ChoiceCharField(
+        help_text="Read only string value for ReservationType's ReservationState enum.",
+        choices=STATE_CHOICES.STATE_CHOICES,
     )
     reservation_unit_pks = serializers.ListField(
         child=IntegerPrimaryKeyField(queryset=ReservationUnit.objects.all()),
@@ -326,9 +327,10 @@ class ReservationUpdateSerializer(
         super().__init__(*args, **kwargs)
         self.fields["state"].read_only = False
         self.fields["state"].required = False
-        self.fields[
-            "state"
-        ].help_text = "String value for ReservationType's ReservationState enum."
+        self.fields["state"].help_text = (
+            "String value for ReservationType's ReservationState enum. "
+            + f"Possible values are {', '.join(value[0].upper() for value in STATE_CHOICES.STATE_CHOICES)}."
+        )
         self.fields["reservee_first_name"].required = False
         self.fields["reservee_last_name"].required = False
         self.fields["reservee_phone"].required = False

--- a/api/graphql/tests/test_reservations/test_reservation_confirm.py
+++ b/api/graphql/tests/test_reservations/test_reservation_confirm.py
@@ -58,7 +58,9 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         confirm_data = content.get("data").get("confirmReservation")
         assert_that(confirm_data.get("errors")).is_none()
-        assert_that(confirm_data.get("state")).is_equal_to(STATE_CHOICES.CONFIRMED)
+        assert_that(confirm_data.get("state")).is_equal_to(
+            STATE_CHOICES.CONFIRMED.upper()
+        )
         self.reservation.refresh_from_db()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
 

--- a/api/graphql/tests/test_reservations/test_reservation_update.py
+++ b/api/graphql/tests/test_reservations/test_reservation_update.py
@@ -438,7 +438,7 @@ class ReservationUpdateTestCase(ReservationTestCaseBase):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
 
         input_data = self.get_valid_update_data()
-        input_data["state"] = STATE_CHOICES.CANCELLED
+        input_data["state"] = STATE_CHOICES.CANCELLED.upper()
         self.client.force_login(self.regular_joe)
         response = self.query(self.get_update_query(), input_data=input_data)
         content = json.loads(response.content)


### PR DESCRIPTION
This way we can enable taking in the enum value as uppercase. Also as uppercase it will be inline with other choice / enum based fields