### PR TITLE
Add read and write permissions to broker subdirectories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,9 +71,9 @@ RUN python manage.py collectstatic --noinput
 RUN chgrp -R 0 /tvp
 RUN chmod g=u -R /tvp
 
-RUN mkdir -p /broker/queue && chown tvp /broker/queue
+RUN mkdir -p /broker/queue && chown tvp /broker/queue && chmod g+rw /broker/queue
 
-RUN mkdir -p /broker/processed && chown tvp /broker/queue
+RUN mkdir -p /broker/processed && chown tvp /broker/processed && chmod g+rw /broker/processed
 
 ENTRYPOINT ["/tvp/deploy/entrypoint.sh"]
 


### PR DESCRIPTION
Celery queue is not working because of file permissions:

```
PermissionError
[Errno 13] Permission denied: '/broker/queue/3259677_fc2859e1-ea07-4661-8c02-40d6382431d2.celery.msg'
```

The problem seems to be that the Celery worker process can't write files to `/broker/queue`.

Using OpenShift terminal, I checked that adding read/write permissions for the group *should* fix it. But it's a bit difficult to test locally. So I'm not 100% sure if this solution works.