### PR TITLE
Upgrade Pillow

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -197,7 +197,7 @@ pathspec==0.8.1
     # via black
 pep517==0.10.0
     # via pip-tools
-pillow==8.3.2
+pillow==9.0.0
     # via easy-thumbnails
 pip-tools==6.1.0
     # via -r requirements.in


### PR DESCRIPTION
Bumps the Pillow version which is a dependency of `easy-thumbnails`.

Fixes Dependabot alerts.