### PR TITLE
TILA-1105 | Add filter for getting reservation required handling

### DIFF
--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -1,6 +1,7 @@
 import django_filters
+from django.db.models import Q
 
-from reservations.models import Reservation
+from reservations.models import STATE_CHOICES, Reservation
 
 
 class ReservationFilterSet(django_filters.FilterSet):
@@ -8,6 +9,26 @@ class ReservationFilterSet(django_filters.FilterSet):
     end = django_filters.DateTimeFilter(field_name="end", lookup_expr="lte")
     state = django_filters.CharFilter(field_name="state", lookup_expr="iexact")
 
+    # Filter for displaying reservations which requires or had required handling.
+    requested = django_filters.BooleanFilter(method="get_requested")
+
+    order_by = django_filters.OrderingFilter(
+        fields=(
+            "state",
+            "begin",
+            "end",
+            "name",
+            "price",
+            "pk",
+        )
+    )
+
     class Meta:
         model = Reservation
         fields = ["begin", "end"]
+
+    def get_requested(self, qs, property, value: str):
+        query = Q(state=STATE_CHOICES.REQUIRES_HANDLING) | Q(handled_at__isnull=False)
+        if value:
+            return qs.filter(query)
+        return qs.exclude(query)

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -136,11 +136,14 @@ class ReservationsFilter(AuthFilter, django_filters.FilterSet):
             )
         elif user.is_anonymous:
             return queryset.none()
-        return queryset.filter(
+        qs = queryset.filter(
             Q(reservation_unit__unit__in=viewable_units)
             | Q(reservation_unit__unit__service_sectors__in=viewable_service_sectors)
             | Q(user=user)
-        ).order_by("begin")
+        ).distinct()
+        if not args.get("order_by", None):
+            qs = qs.order_by("begin")
+        return qs
 
 
 class ReservationUnitsFilter(AuthFilter, django_filters.FilterSet):

--- a/api/graphql/tests/test_reservations/snapshots/snap_base.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_base.py
@@ -43,6 +43,27 @@ snapshots['ReservationQueryTestCase::test_admin_can_read_working_memo 1'] = {
     }
 }
 
+snapshots['ReservationQueryTestCase::test_filter_requested 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'name': "I'm requesting this to be dealt with. Oh this is already dealt with, nice!",
+                        'state': 'CONFIRMED'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'This is requested',
+                        'state': 'REQUIRES_HANDLING'
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_filter_reservation_state_requires_handling 1'] = {
     'data': {
         'reservations': {

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -153,6 +153,43 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_filter_requested(self):
+        self.maxDiff = None
+        self.client.force_login(self.general_admin)
+        metadata = ReservationMetadataSetFactory()
+        res_unit = ReservationUnitFactory(metadata_set=metadata)
+        ReservationFactory(
+            state=STATE_CHOICES.REQUIRES_HANDLING,
+            reservation_unit=[res_unit],
+            recurring_reservation=None,
+            name="This is requested",
+        )
+        ReservationFactory(
+            state=STATE_CHOICES.CONFIRMED,
+            reservation_unit=[res_unit],
+            recurring_reservation=None,
+            name="I'm requesting this to be dealt with. Oh this is already dealt with, nice!",
+            handled_at=datetime.datetime.now(tz=get_default_timezone()),
+        )
+        response = self.query(
+            """
+            query {
+                reservations(requested: true orderBy: "state") {
+                    edges {
+                        node {
+                            state
+                            name
+                          }
+                        }
+                    }
+                }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
     def test_admin_can_read_working_memo(self):
         self.maxDiff = None
         self.client.force_login(self.general_admin)


### PR DESCRIPTION
We need to show reservations which have been in state REQUIRES_HANDLING
or are => so every "requested" or reservations needed to be handled are
shown with this.

TILA-1105