### PR TITLE
TILA-1106: Copy entitlements and configs only if they exist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@ ARG BUILD_MODE
 RUN mkdir ./etc-pki-entitlement && mkdir ./rhsm-conf && mkdir ./rhsm-ca
 
 # Copy entitlements
-COPY ./etc-pki-entitlement /etc/pki/entitlement
+COPY *etc-pki-entitlement /etc/pki/entitlement
 
 # Copy subscription manager configurations if required
-COPY ./rhsm-conf /etc/rhsm
-COPY ./rhsm-ca /etc/rhsm/ca
+COPY *rhsm-conf /etc/rhsm
+COPY *rhsm-ca /etc/rhsm/ca
 
 RUN if [ "x$BUILD_MODE" = "xlocal" ]; \
     then \


### PR DESCRIPTION
Based on [this workaround](https://stackoverflow.com/a/65138098) -- copies the entitlement and configuration files only if they exist.

Tested this locally without any of the files existing, and then some of them existing (I verified this by logging into the container and checking whether those files exist). It should also work in the pipeline as before.

TILA-1106