### PR TITLE
Fix hauki resource update

### DIFF
--- a/opening_hours/resources.py
+++ b/opening_hours/resources.py
@@ -84,7 +84,7 @@ def send_resource_to_hauki(resource: Resource):
 def update_hauki_resource(resource: Resource):
     if not (settings.HAUKI_API_URL and settings.HAUKI_API_KEY):
         raise HaukiConfigurationError(
-            "Both hauki api url and hauki secret need to be configured"
+            "Both hauki api url and hauki api key need to be configured"
         )
     if not resource.id:
         raise ValueError("Resource id must be set when updating resource in hauki.")

--- a/reservation_units/utils/hauki_exporter.py
+++ b/reservation_units/utils/hauki_exporter.py
@@ -56,7 +56,7 @@ class ReservationUnitHaukiExporter:
         department_id = f"tprek:{department_id}"
 
         return Resource(
-            id=None,
+            id=self.reservation_unit.hauki_resource_id or None,
             name=self.reservation_unit.name,
             description=self.reservation_unit.description,
             address=None,


### PR DESCRIPTION
In update hauki resource the id was not set to Resource object to be updated.
This changes the Resource object to contain resource id if it is set to ReservationUnit.