### PR TITLE
Allow null for certain reservation unit fields

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -91,17 +91,17 @@ class PurposeUpdateSerializer(PrimaryKeyUpdateSerializer, PurposeCreateSerialize
 
 
 class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySerializer):
-    terms_of_use_fi = serializers.CharField(required=False)
-    terms_of_use_sv = serializers.CharField(required=False)
-    terms_of_use_en = serializers.CharField(required=False)
-    name_fi = serializers.CharField(required=False, allow_blank=True)
-    name_sv = serializers.CharField(required=False, allow_blank=True)
-    name_en = serializers.CharField(required=False, allow_blank=True)
-    max_reservation_duration = DurationField(required=False)
-    min_reservation_duration = DurationField(required=False)
-    buffer_time_before = DurationField(required=False)
-    buffer_time_after = DurationField(required=False)
-    max_persons = serializers.IntegerField(required=False)
+    terms_of_use_fi = serializers.CharField(required=False, allow_null=True)
+    terms_of_use_sv = serializers.CharField(required=False, allow_null=True)
+    terms_of_use_en = serializers.CharField(required=False, allow_null=True)
+    name_fi = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    name_sv = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    name_en = serializers.CharField(required=False, allow_null=True, allow_blank=True)
+    max_reservation_duration = DurationField(required=False, allow_null=True)
+    min_reservation_duration = DurationField(required=False, allow_null=True)
+    buffer_time_before = DurationField(required=False, allow_null=True)
+    buffer_time_after = DurationField(required=False, allow_null=True)
+    max_persons = serializers.IntegerField(required=False, allow_null=True)
     space_pks = serializers.ListField(
         child=IntegerPrimaryKeyField(queryset=Space.objects.all()),
         source="spaces",
@@ -130,9 +130,15 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
     reservation_unit_type_pk = IntegerPrimaryKeyField(
         source="reservation_unit_type",
         required=False,
+        allow_null=True,
         queryset=ReservationUnitType.objects.all(),
     )
-    unit_pk = IntegerPrimaryKeyField(queryset=Unit.objects.all(), source="unit")
+    unit_pk = IntegerPrimaryKeyField(
+        queryset=Unit.objects.all(),
+        source="unit",
+        required=False,
+        allow_null=True,
+    )
     cancellation_rule_pk = IntegerPrimaryKeyField(
         queryset=ReservationUnitCancellationRule.objects.all(),
         source="cancellation_rule",
@@ -143,6 +149,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         queryset=TermsOfUse.objects.filter(terms_type=TermsOfUse.TERMS_TYPE_PAYMENT),
         source="payment_terms",
         required=False,
+        allow_null=True,
     )
     cancellation_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(
@@ -150,11 +157,13 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         ),
         source="cancellation_terms",
         required=False,
+        allow_null=True,
     )
     service_specific_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(terms_type=TermsOfUse.TERMS_TYPE_SERVICE),
         source="service_specific_terms",
         required=False,
+        allow_null=True,
     )
     lowest_price = serializers.DecimalField(
         max_digits=10,

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -1660,13 +1660,6 @@ class ReservationUnitCreateAsDraftTestCase(ReservationUnitMutationsTestCaseBase)
         assert_that(res_unit_data.get("errors")).is_none()
         assert_that(send_resource_mock.call_count).is_equal_to(0)
 
-    def test_create_errors_without_unit_pk(self):
-        data = {"isDraft": True, "nameFi": "Resunit name"}
-        response = self.query(self.get_create_query(), input_data=data)
-        assert_that(response.status_code).is_equal_to(400)
-        content = json.loads(response.content)
-        assert_that(content.get("errors")).is_not_none()
-
     def test_create_errors_on_empty_name(self):
         data = {
             "isDraft": True,
@@ -1955,16 +1948,6 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
         assert_that(res_unit_data.get("errors")[0].get("messages")[0]).contains(
             "Not draft state reservation units must have a translations."
         )
-        assert_that(ReservationUnit.objects.exists()).is_false()
-
-    def test_create_errors_without_unit_pk(self):
-        data = self.get_valid_data()
-        data.pop("unitPk")
-
-        response = self.query(self.get_create_query(), input_data=data)
-        assert_that(response.status_code).is_equal_to(400)
-        content = json.loads(response.content)
-        assert_that(content.get("errors")).is_not_none()
         assert_that(ReservationUnit.objects.exists()).is_false()
 
     def test_create_errors_on_empty_space_and_missing_resource(self):


### PR DESCRIPTION
Allows `null` to be passed for fields that may return `null` values in the API.

TILA-1065