### PR TITLE
Refresh RedHat subscriptions in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN if [ "x$BUILD_MODE" = "xlocal" ]; \
     fi;
 
 # Enable the repos you need
+RUN subscription-manager refresh
 RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 #RUN subscription-manager repos --disable rhel-8-for-x86_64-baseos-beta-rpms
 #RUN subscription-manager repos --disable rhel-8-for-x86_64-appstream-beta-rpms


### PR DESCRIPTION
An attempt to fix the `403 Unauthorized` errors with some RedHat repos.

Based on various RedHat discussions where refreshing the subscriptions has worked.