### PR TITLE
TILA-1148 | require_reservation_handling usage in apis

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -251,6 +251,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "publish_ends",
             "metadata_set_pk",
             "max_reservations_per_user",
+            "require_reservation_handling",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -357,6 +357,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "publish_ends",
             "metadata_set",
             "max_reservations_per_user",
+            "require_reservation_handling",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],
@@ -497,6 +498,7 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "publish_begins",
             "publish_ends",
             "max_reservations_per_user",
+            "require_reservation_handling",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -406,7 +406,9 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
     def validated_data(self):
         validated_data = super().validated_data
 
-        if self.instance.reservation_unit.filter(metadata_set__isnull=False).exists():
+        if self.instance.reservation_unit.filter(
+            require_reservation_handling=True
+        ).exists():
             validated_data["state"] = STATE_CHOICES.REQUIRES_HANDLING
         else:
             validated_data["state"] = STATE_CHOICES.CONFIRMED

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -430,6 +430,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'purposes': [
                         ],
                         'requireIntroduction': False,
+                        'requireReservationHandling': False,
                         'reservationBegins': '2021-05-03T00:00:00+00:00',
                         'reservationEnds': '2021-05-03T00:00:00+00:00',
                         'reservationStartInterval': 'INTERVAL_30_MINS',

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -208,6 +208,7 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
                               requiredFields
                             }
                             maxReservationsPerUser
+                            requireReservationHandling
                           }
                         }
                     }
@@ -1813,6 +1814,7 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
             "reservationEnds": "2021-05-03T00:00:00+00:00",
             "metadataSetPk": self.metadata_set.pk,
             "maxReservationsPerUser": 2,
+            "requireReservationHandling": True,
         }
 
     def test_create(self):
@@ -1872,6 +1874,7 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
         assert_that(res_unit.max_reservations_per_user).is_equal_to(
             data.get("maxReservationsPerUser")
         )
+        assert_that(res_unit.require_reservation_handling).is_equal_to(True)
 
     @mock.patch(
         "reservation_units.utils.hauki_exporter.ReservationUnitHaukiExporter.send_reservation_unit_to_hauki"

--- a/api/graphql/tests/test_reservations/test_reservation_confirm.py
+++ b/api/graphql/tests/test_reservations/test_reservation_confirm.py
@@ -11,10 +11,7 @@ from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
 from applications.models import City
 from opening_hours.tests.test_get_periods import get_mocked_periods
 from reservations.models import STATE_CHOICES, AgeGroup
-from reservations.tests.factories import (
-    ReservationFactory,
-    ReservationMetadataSetFactory,
-)
+from reservations.tests.factories import ReservationFactory
 
 
 @freezegun.freeze_time("2021-10-12T12:00:00Z")
@@ -72,7 +69,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         self, mock_periods, mock_opening_hours
     ):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self.reservation_unit.metadata_set = ReservationMetadataSetFactory(name="Form")
+        self.reservation_unit.require_reservation_handling = True
         self.reservation_unit.save()
         self.client.force_login(self.regular_joe)
         input_data = self.get_valid_confirm_data()


### PR DESCRIPTION
Adds functionality to add/change/read the `require_reservation_handling` boolean value through the api.
Change confirm serializer to check the boolean value instead of the metadata_set too determine is the reservation state to be REQUIRES_HANDLING (or not)

TILA-1148
