### PR TITLE
Remove purpose pk from ReservationType fields

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -182,7 +182,6 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             "name",
             "description",
             "purpose",
-            "purpose_pk",
             "unit_price",
             "tax_percentage_value",
             "price",


### PR DESCRIPTION
There is no such field + the purposes pk can be fetch through the purpose in query. Like `{reservations{ edges { node { purpose { pk } } } } }`