### PR TITLE
TILA-1139: Expose `authentication` field for reservation units in the GraphQL API

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -206,6 +206,14 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False,
         allow_null=True,
     )
+    authentication = ChoiceCharField(
+        required=False,
+        choices=ReservationUnit.AUTHENTICATION_TYPES,
+        help_text=(
+            "Authentication required for reserving this reservation unit. Possible values are "
+            f"{', '.join(value[0].upper() for value in ReservationUnit.AUTHENTICATION_TYPES)}."
+        ),
+    )
 
     translation_fields = get_all_translatable_fields(ReservationUnit)
 
@@ -252,6 +260,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "metadata_set_pk",
             "max_reservations_per_user",
             "require_reservation_handling",
+            "authentication",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -358,6 +358,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
             "metadata_set",
             "max_reservations_per_user",
             "require_reservation_handling",
+            "authentication",
         ] + get_all_translatable_fields(model)
         filter_fields = {
             "name_fi": ["exact", "icontains", "istartswith"],

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -395,6 +395,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                         'additionalInstructionsSv': 'Ytterligare instruktioner',
                         'applicationRounds': [
                         ],
+                        'authentication': 'WEAK',
                         'bufferTimeAfter': 900,
                         'bufferTimeBefore': 900,
                         'cancellationRule': {


### PR DESCRIPTION
Exposes the `authentication` field in the GraphQL API for reservation units.

TILA-1139