### PR TITLE
TILA-1226: Fix ordering reservation units by unit

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_filtersets.py
+++ b/api/graphql/reservation_units/reservation_unit_filtersets.py
@@ -52,7 +52,9 @@ class ReservationUnitsFilterSet(django_filters.FilterSet):
             ("reservation_unit_type__name_fi", "type_fi"),
             ("reservation_unit_type__name_en", "type_en"),
             ("reservation_unit_type__name_sv", "type_sv"),
-            "unit",
+            ("unit__name_fi", "unit_name_fi"),
+            ("unit__name_en", "unit_name_en"),
+            ("unit__name_sv", "unit_name_sv"),
         )
     )
 

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -644,14 +644,45 @@ snapshots['ReservationUnitQueryTestCase::test_order_by_unit 1'] = {
                 {
                     'node': {
                         'unit': {
-                            'nameFi': 'test unit fi'
+                            'nameEn': '_',
+                            'nameFi': '1',
+                            'nameSv': '_'
                         }
                     }
                 },
                 {
                     'node': {
                         'unit': {
-                            'nameFi': 'testunit'
+                            'nameEn': '_',
+                            'nameFi': '2',
+                            'nameSv': '1'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '_',
+                            'nameFi': '2',
+                            'nameSv': '2'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '1',
+                            'nameFi': '3',
+                            'nameSv': '_'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '2',
+                            'nameFi': '3',
+                            'nameSv': '_'
                         }
                     }
                 }
@@ -667,14 +698,45 @@ snapshots['ReservationUnitQueryTestCase::test_order_by_unit_reverse_order 1'] = 
                 {
                     'node': {
                         'unit': {
-                            'nameFi': 'testunit'
+                            'nameEn': '2',
+                            'nameFi': '3',
+                            'nameSv': '_'
                         }
                     }
                 },
                 {
                     'node': {
                         'unit': {
-                            'nameFi': 'test unit fi'
+                            'nameEn': '1',
+                            'nameFi': '3',
+                            'nameSv': '_'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '_',
+                            'nameFi': '2',
+                            'nameSv': '2'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '_',
+                            'nameFi': '2',
+                            'nameSv': '1'
+                        }
+                    }
+                },
+                {
+                    'node': {
+                        'unit': {
+                            'nameEn': '_',
+                            'nameFi': '1',
+                            'nameSv': '_'
                         }
                     }
                 }

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -1091,17 +1091,24 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
         self.assertMatchSnapshot(content)
 
     def test_order_by_unit(self):
-        unit = UnitFactory(name="testunit", name_fi="testunit")
-        ReservationUnitFactory(
-            unit=unit,
-        )
+        ReservationUnit.objects.all().delete()
+        ReservationUnitFactory(unit=UnitFactory(name_fi="2", name_sv="2", name_en="_"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="3", name_sv="_", name_en="2"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="2", name_sv="1", name_en="_"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="3", name_sv="_", name_en="1"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="1", name_sv="_", name_en="_"))
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
-                reservationUnits(orderBy: "unit") {
+                reservationUnits(orderBy: "unitNameFi,unitNameSv,unitNameEn") {
                     edges {
                         node {
-                            unit {nameFi}
+                            unit {
+                                nameFi
+                                nameSv
+                                nameEn
+                            }
                         }
                     }
                 }
@@ -1113,17 +1120,24 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
         self.assertMatchSnapshot(content)
 
     def test_order_by_unit_reverse_order(self):
-        unit = UnitFactory(name="testunit", name_fi="testunit")
-        ReservationUnitFactory(
-            unit=unit,
-        )
+        ReservationUnit.objects.all().delete()
+        ReservationUnitFactory(unit=UnitFactory(name_fi="2", name_sv="2", name_en="_"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="3", name_sv="_", name_en="2"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="2", name_sv="1", name_en="_"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="3", name_sv="_", name_en="1"))
+        ReservationUnitFactory(unit=UnitFactory(name_fi="1", name_sv="_", name_en="_"))
+        self.client.force_login(self.regular_joe)
         response = self.query(
             """
             query {
-                reservationUnits(orderBy: "-unit") {
+                reservationUnits(orderBy: "-unitNameFi,-unitNameSv,-unitNameEn") {
                     edges {
                         node {
-                            unit {nameFi}
+                            unit {
+                                nameFi
+                                nameSv
+                                nameEn
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
Removed the `unit` order parameter which wasn't very useful since it orders by PK.

Replaced it with `unitNameFi`, `unitNameSv`, and `unitNameEn`. This is more consistent with the way you can currently order e.g. by reservation unit type. It also adds a bit more flexibility for the UI by allowing to order based on the user's language, if needed.

TILA-1226