### PR TITLE
TILA-1139: Add `authentication` to reservation unit by PK type

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -500,6 +500,7 @@ class ReservationUnitByPkType(ReservationUnitType, OpeningHoursMixin):
             "publish_ends",
             "max_reservations_per_user",
             "require_reservation_handling",
+            "authentication",
         ] + get_all_translatable_fields(model)
 
         interfaces = (graphene.relay.Node,)

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -237,6 +237,22 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
             content.get("data").get("reservationUnitByPk").get("pk")
         ).is_equal_to(self.reservation_unit.id)
 
+    def test_getting_authentication_by_pk(self):
+        response = self.query(
+            f"""
+            {{
+                reservationUnitByPk(pk: {self.reservation_unit.id}) {{
+                    authentication
+                }}
+            }}
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("reservationUnitByPk").get("authentication")
+        ).is_equal_to("WEAK")
+
     def test_getting_hauki_url_is_none_when_regular_user(self):
         settings.HAUKI_SECRET = "HAUKISECRET"
         settings.HAUKI_ADMIN_UI_URL = "https://test.com"


### PR DESCRIPTION
The `authentication` field was missing from `ReservationUnitByPkType`, even though it was in `ReservationUnitType`.

TILA-1139