### PR TITLE
TILA-1257 | Unit importer to django admin

### DIFF
--- a/spaces/admin.py
+++ b/spaces/admin.py
@@ -1,4 +1,6 @@
-from django.contrib import admin
+from django.conf import settings
+from django.contrib import admin, messages
+from django.core.management import call_command
 from mptt.admin import MPTTModelAdmin
 
 from .models import (
@@ -54,6 +56,21 @@ class SpaceAdmin(MPTTModelAdmin):
 class UnitAdmin(admin.ModelAdmin):
     model = Unit
     inlines = [LocationInline]
+    actions = ["update_from_tprek"]
+
+    @admin.action
+    def update_from_tprek(self, request, queryset):
+        ids = queryset.filter(tprek_id__isnull=False).values_list("tprek_id", flat=True)
+        try:
+            output = call_command(
+                "import_units", settings.TPREK_UNIT_URL, "--ids", *ids
+            )
+        except Exception as e:
+            self.message_user(
+                request, f"Error while importing units: {e}", level=messages.ERROR
+            )
+        else:
+            self.message_user(request, output, level=messages.SUCCESS)
 
 
 @admin.register(UnitGroup)

--- a/spaces/importers/units.py
+++ b/spaces/importers/units.py
@@ -80,11 +80,11 @@ class UnitImporter:
             self.field_map = field_map
 
         self.imported_unit_ids = []
+        self.creation_counter = 0
+        self.update_counter = 0
 
     @transaction.atomic
     def import_units(self, import_hauki_resource_id=False):
-        self.creation_counter = 0
-        self.update_counter = 0
         self.import_hauki_resource_ids = import_hauki_resource_id
 
         resp = requests.get(self.url)
@@ -94,7 +94,7 @@ class UnitImporter:
         if self.single:
             unit_data = [unit_data]
 
-        for row in unit_data:
+        for row in filter(lambda data: data is not None, unit_data):
             created = self.create_unit(row)
             self._update_counters(created)
 

--- a/spaces/management/commands/import_units.py
+++ b/spaces/management/commands/import_units.py
@@ -66,9 +66,12 @@ class Command(BaseCommand):
         for id in ids:
             importer.url = "{}{}".format(url, id)
             importer.import_units(import_hauki_resource_id=import_hauki_resource_ids)
+        return (
+            f"Created: {importer.creation_counter} Updated: {importer.update_counter}"
+        )
 
     def get_version(self):
         """
         Custom version for devops etc scenarios to know which version running.
         """
-        return "0.0.1"
+        return "0.0.2"

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -203,6 +203,8 @@ env = environ.Env(
     EMAIL_PORT=(str, django_default_email_port),
     SEND_RESERVATION_NOTIFICATION_EMAILS=(str, False),
     DEFAULT_FROM_EMAIL=(str, django_default_from_email),
+    # Tprek
+    TPREK_UNIT_URL=(str, "https://www.hel.fi/palvelukarttaws/rest/v4/unit/"),
 )
 
 environ.Env.read_env()
@@ -282,6 +284,9 @@ EMAIL_TEMPLATE_CONTEXT_ATTRS = [
     "reservation_number",
 ]
 SEND_RESERVATION_NOTIFICATION_EMAILS = env("SEND_RESERVATION_NOTIFICATION_EMAILS")
+
+# TPREK
+TPREK_UNIT_URL = env("TPREK_UNIT_URL")
 
 # Configure sentry
 if env("SENTRY_DSN"):


### PR DESCRIPTION
Add unit importer to django admin to UnitAdmin actions => so user can update unit information from tprek (to those where tprek_id is known)

TILA-1257
