### PR TITLE
TILA-1272 | Check for empty app_event_id in event status perm check

### DIFF
--- a/api/tests/test_application_status_api.py
+++ b/api/tests/test_application_status_api.py
@@ -282,6 +282,13 @@ class ApplicationEventStatusApiPermissionsTestCase(ApplicationStatusBaseTestCase
             .status
         ).is_equal_to(ApplicationEventStatus.VALIDATED)
 
+    def test_status_change_with_empty_data_returns_403(self):
+        response = self.applicant_api_client.post(
+            reverse("application_event_status-list"),
+            data={},
+        )
+        assert_that(response.status_code).is_equal_to(403)
+
 
 @mock.patch(
     "applications.utils.reservation_creation.ReservationScheduler",

--- a/permissions/api_permissions/drf_permissions.py
+++ b/permissions/api_permissions/drf_permissions.py
@@ -251,6 +251,8 @@ class ApplicationEventStatusPermission(permissions.BasePermission):
         return self.check_permissions_for_single(request, status, application_event_id)
 
     def check_permissions_for_single(self, request, status, application_event_id):
+        if not application_event_id:
+            return False
         try:
             service_sector = ServiceSector.objects.get(
                 applicationround=ApplicationRound.objects.get(


### PR DESCRIPTION
There were an error raised when application event status end point got request with empty data dict => check against empty
application_event_id and return forbidden when empty

TILA-1272