### PR TITLE
Set reservation begin dates to test_filter_reservation_state_accepts_multiple_values

### DIFF
--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -167,12 +167,14 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             reservation_unit=[res_unit],
             recurring_reservation=None,
             name="Show me",
+            begin=datetime.datetime.now() + datetime.timedelta(days=2),
         )
         ReservationFactory(
             state=STATE_CHOICES.CANCELLED,
             reservation_unit=[res_unit],
             recurring_reservation=None,
             name="Show me too",
+            begin=datetime.datetime.now() + datetime.timedelta(days=1),
         )
         response = self.query(
             """


### PR DESCRIPTION
The test was failing randomly due to the begin date being created to a random point of time.
Fix random fail by adding static begin times to reservations in the test