### PR TITLE
TILA-1394 | static files serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,11 @@ For development purposes requirement to authenticate can be turned off by settin
 environment variable TMP_PERMISSIONS_DISABLED to True.
 
 ![Data model visualization](tilavarauspalvelu_visualized.svg)
+
+## Deployed application settings & static files
+
+Contrary to more common set-ups, this application does not have a reverse proxy serving static files. Instead, static files are served by both Django and uwsgi.
+
+Static files are served by the [Whitenoise](https://whitenoise.evans.io/en/stable/) package. These are all files that are not uploaded by the users in Django Admin pages.
+
+Media files are served by the [uwsgi static files implementation](https://uwsgi-docs.readthedocs.io/en/latest/StaticFiles.html) offloaded to threads. These are all files uploaded by users in Django Admin pages. If there are performance issues (I.E. 502 errors from the Application Gateway) it is very likely process count and or process scale-up must be tweaked higher.

--- a/deploy/uwsgi.yml
+++ b/deploy/uwsgi.yml
@@ -3,11 +3,33 @@ uwsgi:
   # python docker image cannot use that due to linker mishaps
   # plugins: python3,http
   wsgi-file: tilavarauspalvelu/wsgi.py
-  processes: $(UWSGI_NUM_PROCESSES)
-  threads: 1
-  master: true
   #uid: tvp
   umask: 022
   reload-on-rss: 300
   http: :8000
+
+  # Workload settings
+  # Automatically scales up worker count when application is
+  # under load.
+  master: true
+  threads: 1
+  cheaper-algo: busyness
+  cheaper-overload: 5
+  cheaper-busyness-backlog-alert: 20
+  cheaper-busyness-backlog-step: 4
+  cheaper: $(UWSGI_MIN_NUM_PROCESSES)
+  cheaper-initial: $(UWSGI_MIN_NUM_PROCESSES)
+  processes: $(UWSGI_MAX_NUM_PROCESSES)
+  cheaper-step: 2
+
+  # Offload static file serving to separate threads
+  # Application logic can then always be handled
+  file-serve-mode: offloading
+  offload-threads: 8
   static-map: $(MEDIA_URL)=$(MEDIA_ROOT)
+
+  # Ignore logging errors for cases when http pipes are closed
+  # before workers has had the time to serve content to the pipe
+  ignore-sigpipe: true
+  ignore-write-errors: true
+  disable-write-exception: true

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -105,13 +105,14 @@ MIDDLEWARE = [
     "tilavarauspalvelu.multi_proxy_middleware.MultipleProxyMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    # Keep this after security middleware, correct place according to whitenoise documentation
+    "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "whitenoise.middleware.WhiteNoiseMiddleware",
     "auditlog.middleware.AuditlogMiddleware",
 ]
 
@@ -238,6 +239,8 @@ MEDIA_ROOT = env("MEDIA_ROOT")
 
 STATIC_URL = env("STATIC_URL")
 MEDIA_URL = env("MEDIA_URL")
+
+STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
 HAUKI_API_URL = env("HAUKI_API_URL")
 HAUKI_ORIGIN_ID = env("HAUKI_ORIGIN_ID")


### PR DESCRIPTION
Application started dropping connections when the application was under load. These changes scale-up amount of workers when load increases. Static files are also served in an unconventional way. Documentation is updated to ease understanding of potential failures in the future.

* Improve application performance on-load.
* Improve documentation

Refs TILA-1394