### PR TITLE
TILA-1407 | Show applications to unit admins

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -30,6 +30,7 @@ from permissions.models import (
     ServiceSectorRoleChoice,
     UnitRole,
     UnitRoleChoice,
+    UnitRolePermission,
 )
 from reservation_units.models import Equipment, EquipmentCategory, ReservationUnit
 from reservations.models import AbilityGroup, AgeGroup, Reservation, ReservationPurpose
@@ -743,10 +744,12 @@ def unit_admin(unit):
         last_name="Uuu",
         email="amin.u@foo.com",
     )
-
-    unit_role = UnitRole.objects.create(
-        user=user, role=UnitRoleChoice.objects.get(code="admin")
+    admin_role_choice = UnitRoleChoice.objects.get(code="admin")
+    UnitRolePermission.objects.create(
+        role=admin_role_choice, permission="can_validate_applications"
     )
+    unit_role = UnitRole.objects.create(user=user, role=admin_role_choice)
+
     unit_role.unit.add(unit)
 
     return user

--- a/permissions/helpers.py
+++ b/permissions/helpers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Union
+from typing import Iterable, List, Union
 
 from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
@@ -27,7 +27,9 @@ def has_unit_group_permission(
     ).exists()
 
 
-def has_unit_permission(user: User, units: list, required_permission: str) -> bool:
+def has_unit_permission(
+    user: User, units: Iterable[Unit], required_permission: str
+) -> bool:
     if not units or user.is_anonymous:
         return False
     unit_groups = []
@@ -194,7 +196,7 @@ def can_manage_service_sectors_applications(
     )
 
 
-def can_validate_unit_applications(user: User, units: [Unit]) -> bool:
+def can_validate_unit_applications(user: User, units: Iterable[Unit]) -> bool:
     permission = "can_validate_applications"
     return (
         is_superuser(user)
@@ -224,6 +226,7 @@ def can_read_application(user: User, application: Application) -> bool:
         or can_manage_service_sectors_applications(
             user, application.application_round.service_sector
         )
+        or can_validate_unit_applications(user, application.units)
     )
 
 


### PR DESCRIPTION
Shows applications to unit admins for those who have permissions
"can_validate_applications" even though application would have events to
other units => right to see application is when there is at least one event
to the unit admin's unit. (ReservationUnit that belongs to the unit)

TILA-1407