### PR TITLE
TILA-1407 | Show applications to unit group admins

### DIFF
--- a/api/applications_api/views.py
+++ b/api/applications_api/views.py
@@ -55,9 +55,15 @@ class ApplicationViewSet(viewsets.ModelViewSet):
         unit_ids = user.unit_roles.filter(
             role__permissions__permission="can_validate_applications"
         ).values_list("unit", flat=True)
-        units = Unit.objects.filter(id__in=unit_ids)
+        group_ids = user.unit_roles.filter(
+            role__permissions__permission="can_validate_applications"
+        ).values_list("unit_group", flat=True)
 
-        return queryset.filter(
+        units = Unit.objects.filter(
+            Q(id__in=unit_ids) | Q(unit_groups__in=group_ids)
+        ).values_list("id", flat=True)
+
+        qs = queryset.filter(
             Q(
                 application_round__service_sector__in=get_service_sectors_where_can_view_applications(
                     user
@@ -68,6 +74,7 @@ class ApplicationViewSet(viewsets.ModelViewSet):
             )
             | Q(user=user)
         ).distinct()
+        return qs
 
 
 class ApplicationEventViewSet(viewsets.ModelViewSet):

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -823,9 +823,12 @@ def unit_group_admin(unit_group):
         email="amin.ug@foo.com",
     )
 
-    unit_role = UnitRole.objects.create(
-        user=user, role=UnitRoleChoice.objects.get(code="admin")
+    admin_role_choice = UnitRoleChoice.objects.get(code="admin")
+    UnitRolePermission.objects.create(
+        role=admin_role_choice, permission="can_validate_applications"
     )
+    unit_role = UnitRole.objects.create(user=user, role=admin_role_choice)
+
     unit_role.unit_group.add(unit_group)
 
     return user


### PR DESCRIPTION
Shows applications to unit group  admins for those who have permissions
"can_validate_applications" even though application would have events to
other units => right to see application is when there is at least one event
to the unit group admin's unit. (ReservationUnit that belongs to the
unit that belongs to the group)

TILA-1407