### PR TITLE
TILA-1471 | Increase header block size

### DIFF
--- a/deploy/uwsgi.yml
+++ b/deploy/uwsgi.yml
@@ -7,6 +7,7 @@ uwsgi:
   umask: 022
   reload-on-rss: 300
   http: :8000
+  buffer-size: 8192
 
   # Workload settings
   # Automatically scales up worker count when application is


### PR DESCRIPTION
It seems block size is not large enough with the default. This commit double the header block size.

This can be because some requests having longer urls than others and only narrowly passing the threshold. We do not want to increase this too much [as it could be a security risk](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#buffer-size), but only slightly to suit our current needs.

Refs TILA-1471