### PR TITLE
TILA-1569 | Applications fetch in graphql

### DIFF
--- a/api/graphql/application_rounds/application_round_types.py
+++ b/api/graphql/application_rounds/application_round_types.py
@@ -21,7 +21,7 @@ from ..base_connection import TilavarausBaseConnection
 from ..reservations.reservation_types import ReservationPurposeType
 
 
-class AggregatedDataType(graphene.ObjectType):
+class ApplicationRoundAggregatedDataType(graphene.ObjectType):
     allocation_result_events_count = graphene.Int()
     allocation_duration_total = graphene.Int()
     total_reservation_duration = graphene.Int()
@@ -88,7 +88,7 @@ class ApplicationRoundType(AuthNode, PrimaryKeyObjectType):
 
     service_sector = graphene.Field(ServiceSectorType)
     status = graphene.Field(
-        graphene.Enum("status", ApplicationRoundStatus.STATUS_CHOICES)
+        graphene.Enum("applicationRoundStatus", ApplicationRoundStatus.STATUS_CHOICES)
     )
     status_timestamp = graphene.DateTime()
 
@@ -96,7 +96,7 @@ class ApplicationRoundType(AuthNode, PrimaryKeyObjectType):
     purposes = graphene.List(ReservationPurposeType)
     reservation_units = graphene.List(ReservationUnitType)
     application_round_baskets = graphene.List(ApplicationRoundBasketType)
-    aggregated_data = graphene.Field(AggregatedDataType)
+    aggregated_data = graphene.Field(ApplicationRoundAggregatedDataType)
     approved_by = graphene.String()
     applications_sent = graphene.Boolean()
     applications_count = graphene.Int()

--- a/api/graphql/applications/application_filtersets.py
+++ b/api/graphql/applications/application_filtersets.py
@@ -1,0 +1,27 @@
+from django_filters import rest_framework as filters
+
+from applications.models import Application, ApplicationRound, User
+from spaces.models import Unit
+
+
+class ApplicationFilterSet(filters.FilterSet):
+    application_round = filters.ModelChoiceFilter(
+        field_name="application_round", queryset=ApplicationRound.objects.all()
+    )
+    status = filters.BaseInFilter(field_name="latest_status")
+    unit = filters.ModelMultipleChoiceFilter(
+        method="filter_by_possible_units", queryset=Unit.objects.all()
+    )
+    user = filters.ModelChoiceFilter(field_name="user", queryset=User.objects.all())
+
+    class Meta:
+        model = Application
+        fields = ("application_round", "status", "unit", "user")
+
+    def filter_by_possible_units(self, qs, property, value):
+        if not value:
+            return qs
+
+        return qs.filter(
+            application_events__event_reservation_units__reservation_unit__unit__in=value
+        )

--- a/api/graphql/applications/application_types.py
+++ b/api/graphql/applications/application_types.py
@@ -1,16 +1,43 @@
 import graphene
+import graphene_django_optimizer as gql_optimizer
 from django.conf import settings
+from graphene_django import DjangoListField
 from graphene_permissions.mixins import AuthNode
-from graphene_permissions.permissions import AllowAny
+from graphene_permissions.permissions import AllowAny, AllowAuthenticated
 
 from api.graphql.base_connection import TilavarausBaseConnection
 from api.graphql.base_type import PrimaryKeyObjectType
+from api.graphql.reservation_units.reservation_unit_types import ReservationUnitType
+from api.graphql.reservations.reservation_types import (
+    AbilityGroupType,
+    AgeGroupType,
+    ReservationPurposeType,
+)
 from api.graphql.translate_fields import get_all_translatable_fields
-from applications.models import City
-from permissions.api_permissions.graphene_permissions import CityPermission
+from applications.models import (
+    Address,
+    Application,
+    ApplicationEvent,
+    ApplicationEventSchedule,
+    ApplicationEventStatus,
+    ApplicationStatus,
+    City,
+    EventReservationUnit,
+    Organisation,
+    Person,
+)
+from permissions.api_permissions.graphene_field_decorators import (
+    check_resolver_permission,
+)
+from permissions.api_permissions.graphene_permissions import (
+    AddressPermission,
+    ApplicationPermission,
+    CityPermission,
+    OrganisationPermission,
+)
 
 
-class CityType(AuthNode, PrimaryKeyObjectType):
+class CityType(gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType):
     permission_classes = (
         (CityPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
     )
@@ -18,6 +45,279 @@ class CityType(AuthNode, PrimaryKeyObjectType):
     class Meta:
         model = City
         fields = ["name"] + get_all_translatable_fields(model)
-        filter_fields = []
+        filter_fields = ()
         interfaces = (graphene.relay.Node,)
         connection_class = TilavarausBaseConnection
+
+
+class AddressType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (AddressPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
+    )
+
+    class Meta:
+        model = Address
+        fields = ("street_address", "post_code", "city")
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class PersonType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
+    )
+
+    class Meta:
+        model = Person
+        fields = ("id", "first_name", "last_name", "email", "phone_number")
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class OrganisationType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (OrganisationPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else [AllowAny]
+    )
+
+    address = graphene.Field(AddressType)
+
+    class Meta:
+        model = Organisation
+        fields = (
+            "id",
+            "name",
+            "identifier",
+            "year_established",
+            "active_members",
+            "organisation_type",
+            "core_business",
+            "email",
+            "address",
+        )
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class ApplicationEventAggregatedDataType(graphene.ObjectType):
+    duration_total = graphene.Float()
+    reservations_total = graphene.Float()
+    allocation_results_duration_total = graphene.Float()
+    allocation_results_reservations_total = graphene.Float()
+
+
+class ApplicationEventScheduleType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
+    )
+
+    class Meta:
+        model = ApplicationEventSchedule
+        fields = ("id", "day", "begin", "end", "priority")
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class EventReservationUnitType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
+    )
+
+    reservation_unit_id = graphene.Int()
+    reservation_unit_details = graphene.Field(
+        ReservationUnitType, source="reservation_unit"
+    )
+
+    class Meta:
+        model = EventReservationUnit
+        fields = (
+            "id",
+            "priority",
+            "reservation_unit_id",
+            "reservation_unit_details",
+        )
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class ApplicationEventType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
+    )
+
+    age_group_id = graphene.Int()
+    ability_group_id = graphene.Int()
+    application_id = graphene.Int()
+    purpose_id = graphene.Int()
+
+    application_event_schedules = DjangoListField(ApplicationEventScheduleType)
+
+    age_group_display = graphene.Field(AgeGroupType, source="age_group")
+
+    ability_group = graphene.Field(AbilityGroupType)
+
+    purpose = graphene.Field(ReservationPurposeType)
+
+    event_reservation_units = DjangoListField(EventReservationUnitType)
+
+    status = graphene.Field(
+        graphene.Enum("applicationEventStatus", ApplicationEventStatus.STATUS_CHOICES)
+    )
+
+    weekly_amount_reductions_count = graphene.Int()
+
+    declined_reservation_units = DjangoListField(ReservationUnitType)
+
+    aggregated_data = graphene.Field(
+        ApplicationEventAggregatedDataType, source="aggregated_data_dict"
+    )
+
+    class Meta:
+        model = ApplicationEvent
+        fields = (
+            "id",
+            "name",
+            "num_persons",
+            "age_group_id",
+            "ability_group_id",
+            "min_duration",
+            "max_duration",
+            "application_id",
+            "events_per_week",
+            "biweekly",
+            "begin",
+            "end",
+            "purpose_id",
+            "uuid",
+            "status",
+            "application_event_schedules",
+            "age_group_display",
+            "ability_group",
+            "purpose",
+            "event_reservation_units",
+            "declined_reservation_unit_ids",
+            "weekly_amount_reductions_count",
+            "aggregated_data",
+        )
+        filter_fields = ()
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+    def resolve_min_duration(self, info: graphene.ResolveInfo):
+        return self.min_duration.total_seconds()
+
+    def resolve_max_duration(self, info: graphene.ResolveInfo):
+        return self.max_duration.total_seconds()
+
+    def resolve_weekly_amount_reductions_count(self, info: graphene.ResolveInfo):
+        # TODO: this can be optimized everywhere by annotating Count("weekly_amount_reductions") to queries
+        return (
+            self.weekly_amount_reductions__count
+            if hasattr(self, "weekly_amount_reductions__count")
+            else self.weekly_amount_reductions.count()
+        )
+
+
+class ApplicationAggregatedDataType(graphene.ObjectType):
+    applied_min_duration_total = graphene.Float()
+    applied_reservations_total = graphene.Float()
+    created_reservations_total = graphene.Float()
+    reservations_duration_total = graphene.Float()
+
+
+class ApplicationType(
+    gql_optimizer.OptimizedDjangoObjectType, AuthNode, PrimaryKeyObjectType
+):
+    permission_classes = (
+        (ApplicationPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else [AllowAny]
+    )
+
+    contact_person = graphene.Field(PersonType)
+
+    organisation = graphene.Field(OrganisationType)
+
+    application_round_id = graphene.Int()
+
+    application_events = DjangoListField(ApplicationEventType)
+
+    status = graphene.Field(
+        graphene.Enum("applicationStatus", ApplicationStatus.STATUS_CHOICES)
+    )
+
+    aggregated_data = graphene.Field(
+        ApplicationAggregatedDataType,
+        source="aggregated_data_dict",
+    )
+
+    billing_address = graphene.Field(AddressType)
+
+    applicant_id = graphene.Int()
+    applicant_name = graphene.String()
+    applicant_email = graphene.String()
+
+    home_city = graphene.Field(CityType)
+
+    class Meta:
+        model = Application
+        fields = (
+            "id",
+            "applicant_type",
+            "applicant_id",
+            "applicant_name",
+            "applicant_email",
+            "organisation",
+            "application_round_id",
+            "contact_person",
+            "application_events",
+            "status",
+            "aggregated_data",
+            "billing_address",
+            "home_city",
+            "created_date",
+            "last_modified_date",
+            "additional_information",
+        )
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+    def resolve_applicant_id(self, info: graphene.ResolveInfo):
+        if not self.user:
+            return None
+
+        return self.user.id
+
+    def resolve_applicant_name(self, info: graphene.ResolveInfo):
+        if not self.user:
+            return None
+
+        return self.user.get_full_name()
+
+    def resolve_applicant_email(self, info: graphene.ResolveInfo):
+        if not self.user:
+            return None
+
+        return self.user.email
+
+    @check_resolver_permission(OrganisationPermission)
+    def resolve_organisation(self, info: graphene.ResolveInfo):
+        return self.organisation

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -273,9 +273,6 @@ class EquipmentType(AuthNode, PrimaryKeyObjectType):
 
 
 class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
-    name_fi = graphene.String()
-    name_sv = graphene.String()
-    name_en = graphene.String()
     spaces = graphene.List(SpaceType)
     resources = graphene.List(ResourceType)
     services = graphene.List(ServiceType)

--- a/api/graphql/tests/test_applications/base.py
+++ b/api/graphql/tests/test_applications/base.py
@@ -1,0 +1,143 @@
+from datetime import date, time
+
+import freezegun
+import snapshottest
+from dateutil.relativedelta import relativedelta
+from rest_framework.test import APIClient
+
+from applications.models import (
+    Application,
+    ApplicationEventStatus,
+    ApplicationStatus,
+    Organisation,
+)
+from applications.tests.factories import (
+    AddressFactory,
+    ApplicationEventFactory,
+    ApplicationEventScheduleFactory,
+    ApplicationEventStatusFactory,
+    ApplicationFactory,
+    ApplicationStatusFactory,
+    CityFactory,
+    EventReservationUnitFactory,
+    OrganisationFactory,
+    PersonFactory,
+)
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import (
+    AbilityGroupFactory,
+    AgeGroupFactory,
+    ReservationPurposeFactory,
+)
+from spaces.tests.factories import UnitGroupFactory
+
+from ..base import GrapheneTestCaseBase
+
+
+@freezegun.freeze_time("2022-05-02T12:00:00Z")
+class ApplicationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+
+        cls.application = ApplicationFactory(
+            applicant_type=Application.APPLICANT_TYPE_COMMUNITY,
+            additional_information="Something to fill the field with text",
+            user=cls.regular_joe,
+            home_city=CityFactory(name="Test city"),
+            billing_address=AddressFactory(
+                street_address="Test street", post_code="00100"
+            ),
+            contact_person=PersonFactory(
+                first_name="Test",
+                last_name="Person",
+                email="test.person@test.com",
+                phone_number="+358400123456",
+            ),
+            organisation=OrganisationFactory(
+                name="Test organisation",
+                identifier="Some identifier",
+                year_established=2022,
+                address=AddressFactory(
+                    street_address="Organisation street", post_code="00100"
+                ),
+                active_members=200,
+                organisation_type=Organisation.REGISTERED_ASSOCIATION,
+                core_business="Testing testing",
+                email="organisation@test.com",
+            ),
+        )
+
+        ApplicationStatusFactory(
+            application=cls.application, status=ApplicationStatus.IN_REVIEW
+        )
+
+        test_date = date(2022, 5, 2)
+        application_event = ApplicationEventFactory(
+            application=cls.application,
+            name="Test application",
+            events_per_week=2,
+            num_persons=10,
+            begin=test_date,
+            end=test_date + relativedelta(days=3),
+            age_group=AgeGroupFactory(minimum=10, maximum=15),
+            ability_group=AbilityGroupFactory(name="Ability test group"),
+            purpose=ReservationPurposeFactory(
+                name="Test purpose",
+                name_fi="Test purpose FI",
+                name_sv="Test purpose SV",
+                name_en="Test purpose EN",
+            ),
+        )
+
+        ApplicationEventStatusFactory(
+            application_event=application_event, status=ApplicationEventStatus.CREATED
+        )
+
+        test_unit_1 = ReservationUnitFactory(
+            name="Declined unit 1",
+            name_fi="Declined unit FI 1",
+            name_en="Declined unit EN 1",
+            name_sv="Declined unit SV 1",
+        )
+        test_unit_2 = ReservationUnitFactory(
+            name="Declined unit 2",
+            name_fi="Declined unit FI 2",
+            name_en="Declined unit EN 2",
+            name_sv="Declined unit SV 2",
+        )
+
+        application_event.declined_reservation_units.add(test_unit_1, test_unit_2)
+
+        ApplicationEventScheduleFactory(
+            day=1,
+            begin=time(12, 00),
+            end=time(13, 00),
+            priority=300,
+            application_event=application_event,
+        )
+        ApplicationEventScheduleFactory(
+            day=2,
+            begin=time(13, 00),
+            end=time(14, 00),
+            priority=200,
+            application_event=application_event,
+        )
+        ApplicationEventScheduleFactory(
+            day=3,
+            begin=time(14, 00),
+            end=time(15, 00),
+            priority=100,
+            application_event=application_event,
+        )
+
+        cls.event_reservation_unit = EventReservationUnitFactory(
+            priority=1,
+            reservation_unit=test_unit_1,
+            application_event=application_event,
+        )
+        cls.unit_group = UnitGroupFactory(
+            units=(cls.event_reservation_unit.reservation_unit.unit,)
+        )
+
+        cls.api_client = APIClient()

--- a/api/graphql/tests/test_applications/snapshots/snap_base.py
+++ b/api/graphql/tests/test_applications/snapshots/snap_base.py
@@ -1,0 +1,576 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['ApplicationsGraphQLFiltersTestCase::test_application_filter_by_application_round 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLFiltersTestCase::test_application_filter_by_status 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLFiltersTestCase::test_application_filter_by_unit 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLFiltersTestCase::test_application_filter_by_user 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_regular_user_can_view_only_own_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_service_sector_admin_cannot_view_other_sector_than_own 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_service_sector_user_can_view_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_super_admin_can_view_all_applications 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                },
+                {
+                    'node': {
+                        'additionalInformation': None,
+                        'applicantType': 'ASSOCIATION',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_unit_admin_can_view_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_unit_admin_cannot_view_other_unit_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_unit_group_admin_can_view_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLPermissionsTestCase::test_unit_group_admin_cannot_view_other_group_application 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_aggregate_data_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'aggregatedData': {
+                            'appliedMinDurationTotal': 0.0,
+                            'appliedReservationsTotal': 0.0,
+                            'createdReservationsTotal': 0.0,
+                            'reservationsDurationTotal': 0.0
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_applicant_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicantEmail': 'joe.regularl@foo.com',
+                        'applicantName': 'joe regular'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_applicant_no_value 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicantEmail': None,
+                        'applicantName': None
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_ability_group_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'abilityGroup': {
+                                    'name': 'Ability test group'
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_age_group_display_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'ageGroupDisplay': {
+                                    'maximum': 15,
+                                    'minimum': 10
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_aggregated_data_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'aggregatedData': {
+                                    'allocationResultsDurationTotal': None,
+                                    'allocationResultsReservationsTotal': None,
+                                    'durationTotal': None,
+                                    'reservationsTotal': None
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_application_event_schedules_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'applicationEventSchedules': [
+                                    {
+                                        'begin': '12:00:00',
+                                        'day': 'A_1',
+                                        'end': '13:00:00',
+                                        'priority': 'A_300'
+                                    },
+                                    {
+                                        'begin': '13:00:00',
+                                        'day': 'A_2',
+                                        'end': '14:00:00',
+                                        'priority': 'A_200'
+                                    },
+                                    {
+                                        'begin': '14:00:00',
+                                        'day': 'A_3',
+                                        'end': '15:00:00',
+                                        'priority': 'A_100'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_basic_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'begin': '2022-05-02',
+                                'biweekly': False,
+                                'end': '2022-05-05',
+                                'eventsPerWeek': 2,
+                                'maxDuration': 7200.0,
+                                'minDuration': 3600.0,
+                                'name': 'Test application',
+                                'numPersons': 10,
+                                'status': 'created'
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_declined_reservation_unit_ids_field 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'declinedReservationUnits': [
+                                    {
+                                        'nameFi': 'Declined unit FI 1'
+                                    },
+                                    {
+                                        'nameFi': 'Declined unit FI 2'
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_event_reservation_unit_base_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'eventReservationUnits': [
+                                    {
+                                        'priority': 1
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_application_events_purpose_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEvents': [
+                            {
+                                'purpose': {
+                                    'nameEn': 'Test purpose EN',
+                                    'nameFi': 'Test purpose FI',
+                                    'nameSv': 'Test purpose SV'
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_billing_address_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'billingAddress': {
+                            'city': 'Helsinki',
+                            'postCode': '00100',
+                            'streetAddress': 'Test street'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_contact_person_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'contactPerson': {
+                            'email': 'test.person@test.com',
+                            'firstName': 'Test',
+                            'lastName': 'Person',
+                            'phoneNumber': '+358400123456'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_home_city_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'homeCity': {
+                            'name': 'Test city'
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_organisation_fields 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'organisation': {
+                            'activeMembers': 200,
+                            'address': {
+                                'city': 'Helsinki',
+                                'postCode': '00100',
+                                'streetAddress': 'Organisation street'
+                            },
+                            'coreBusiness': 'Testing testing',
+                            'email': 'organisation@test.com',
+                            'identifier': 'Some identifier',
+                            'name': 'Test organisation',
+                            'organisationType': 'REGISTERED_ASSOCIATION',
+                            'yearEstablished': 2022
+                        }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_application_status_field 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'status': 'in_review'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationsGraphQLTestCase::test_getting_applications_base_testcase 1'] = {
+    'data': {
+        'applications': {
+            'edges': [
+                {
+                    'node': {
+                        'additionalInformation': 'Something to fill the field with text',
+                        'applicantType': 'COMMUNITY',
+                        'createdDate': '2022-05-02T12:00:00+00:00',
+                        'lastModifiedDate': '2022-05-02T12:00:00+00:00'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_applications/test_application_permissions.py
+++ b/api/graphql/tests/test_applications/test_application_permissions.py
@@ -1,0 +1,385 @@
+import json
+
+from assertpy import assert_that
+from django.contrib.auth import get_user_model
+
+from applications.models import Application
+from applications.tests.factories import (
+    ApplicationEventFactory,
+    ApplicationFactory,
+    EventReservationUnitFactory,
+)
+from permissions.models import (
+    ServiceSectorRole,
+    ServiceSectorRoleChoice,
+    ServiceSectorRolePermission,
+    UnitRole,
+    UnitRoleChoice,
+    UnitRolePermission,
+)
+from reservation_units.tests.factories import ReservationUnitFactory
+from spaces.tests.factories import UnitGroupFactory
+
+from .base import ApplicationTestCaseBase
+
+
+class ApplicationsGraphQLPermissionsTestCase(ApplicationTestCaseBase):
+    def setUp(self):
+        super().setUp()
+
+        # This application should not be in most of the responses
+        # Only in super admin fetch
+        ApplicationFactory(applicant_type=Application.APPLICANT_TYPE_ASSOCIATION)
+
+    # -----------------------
+    # Helper function section
+    # -----------------------
+
+    def perform_basic_query(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        return response
+
+    def create_service_sector_admin(self):
+        service_sector_admin = get_user_model().objects.create(
+            username="ss_admin",
+            first_name="Amin",
+            last_name="Dee",
+            email="amin.dee@foo.com",
+        )
+
+        ServiceSectorRole.objects.create(
+            user=service_sector_admin,
+            role=ServiceSectorRoleChoice.objects.get(code="admin"),
+            service_sector=self.application.application_round.service_sector,
+        )
+        ServiceSectorRolePermission.objects.create(
+            role=ServiceSectorRoleChoice.objects.get(code="admin"),
+            permission="can_handle_applications",
+        )
+
+        return service_sector_admin
+
+    def create_unit_admin(self):
+        unit_group_admin = get_user_model().objects.create(
+            username="ss_admin",
+            first_name="Amin",
+            last_name="Dee",
+            email="amin.dee@foo.com",
+        )
+
+        unit_role = UnitRole.objects.create(
+            user=unit_group_admin,
+            role=UnitRoleChoice.objects.get(code="admin"),
+        )
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="admin"),
+            permission="can_validate_applications",
+        )
+
+        unit_role.unit.add(self.event_reservation_unit.reservation_unit.unit)
+
+        return unit_group_admin
+
+    def create_unit_group_admin(self):
+        unit_admin = get_user_model().objects.create(
+            username="ss_admin",
+            first_name="Amin",
+            last_name="Dee",
+            email="amin.dee@foo.com",
+        )
+
+        unit_role = UnitRole.objects.create(
+            user=unit_admin,
+            role=UnitRoleChoice.objects.get(code="admin"),
+        )
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="admin"),
+            permission="can_validate_applications",
+        )
+
+        unit_role.unit_group.add(self.unit_group)
+
+        return unit_admin
+
+    # ---------------------
+    # Test function section
+    # ---------------------
+
+    def test_application_mutation_fails(self):
+        self.client.force_login(self.general_admin)
+
+        mutation_query = """
+            mutation updateApplications($input: ApplicationsUpdateMutationInput!) {
+                updateApplications(input: $input) {
+                    status
+                }
+            }
+        """
+        status_fetch_query = """
+            query {
+                applications {
+                    edges {
+                        node {
+                            pk
+                            status
+                        }
+                    }
+                }
+            }
+        """
+
+        response = self.query(status_fetch_query)
+        initial_state = json.loads(response.content)
+
+        response = self.query(mutation_query, input_data={"id": 1, "status": "draft"})
+        assert_that(response.status_code).is_equal_to(400)
+        content = json.loads(response.content)
+
+        # Find correct error message
+        message_found = False
+        for msg in content.get("errors"):
+            if "Cannot query field 'updateApplications'" in msg.get("message", ""):
+                message_found = True
+        assert_that(message_found).is_true()
+
+        response = self.query(status_fetch_query)
+        updated_state = json.loads(response.content)
+
+        assert_that(updated_state).is_equal_to(initial_state)
+
+    def test_not_logged_in_user_does_not_receive_data(self):
+        self.client.logout()
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(
+            content.get("data", {}).get("applications", {}).get("edges")
+        ).is_empty()
+
+    def test_unauthorized_user_does_not_receive_data(self):
+        unauthorized_user = get_user_model().objects.create()
+        self.client.force_login(unauthorized_user)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data", {}).get("applications", {}).get("edges")
+        ).is_empty()
+
+    def test_regular_user_can_view_only_own_application(self):
+        self.client.force_login(self.regular_joe)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_service_sector_user_can_view_application(self):
+        service_sector_admin = self.create_service_sector_admin()
+
+        self.client.force_login(service_sector_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_service_sector_admin_cannot_view_other_sector_than_own(self):
+        service_sector_admin = self.create_service_sector_admin()
+
+        # Create new service sector admin to test that this Application does not get added to the response
+        service_sector_admin_two = get_user_model().objects.create(
+            username="ss_admin_two",
+            first_name="AminAdmin",
+            last_name="DeeDee",
+            email="aminadmin.deedee@foo.com",
+        )
+
+        application_two = ApplicationFactory(
+            applicant_type=Application.APPLICANT_TYPE_ASSOCIATION
+        )
+
+        ServiceSectorRole.objects.create(
+            user=service_sector_admin_two,
+            role=ServiceSectorRoleChoice.objects.get(code="admin"),
+            service_sector=application_two.application_round.service_sector,
+        )
+        ServiceSectorRolePermission.objects.create(
+            role=ServiceSectorRoleChoice.objects.get(code="admin"),
+            permission="can_handle_applications",
+        )
+
+        self.client.force_login(service_sector_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_unit_admin_can_view_application(self):
+        unit_admin = self.create_unit_admin()
+
+        self.client.force_login(unit_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_unit_admin_cannot_view_other_unit_application(self):
+        unit_admin = self.create_unit_admin()
+
+        # Create new unit admin to test that this Application does not get added to the response
+        unit_admin_two = get_user_model().objects.create(
+            username="ss_admin_two",
+            first_name="AminAdmin",
+            last_name="DeeDee",
+            email="aminadmin.deedee@foo.com",
+        )
+
+        unit_role = UnitRole.objects.create(
+            user=unit_admin_two,
+            role=UnitRoleChoice.objects.get(code="admin"),
+        )
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="admin"),
+            permission="can_validate_applications",
+        )
+
+        application_two = ApplicationFactory(
+            applicant_type=Application.APPLICANT_TYPE_ASSOCIATION
+        )
+        application_event = ApplicationEventFactory(application=application_two)
+        test_unit_1 = ReservationUnitFactory(
+            name="Declined unit 10",
+            name_fi="Declined unit FI 10",
+            name_en="Declined unit EN 10",
+            name_sv="Declined unit SV 10",
+        )
+        event_reservation_unit = EventReservationUnitFactory(
+            priority=1,
+            reservation_unit=test_unit_1,
+            application_event=application_event,
+        )
+
+        unit_role.unit.add(event_reservation_unit.reservation_unit.unit)
+
+        self.client.force_login(unit_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_unit_group_admin_can_view_application(self):
+        unit_group_admin = self.create_unit_group_admin()
+
+        self.client.force_login(unit_group_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_unit_group_admin_cannot_view_other_group_application(self):
+        unit_group_admin = self.create_unit_group_admin()
+
+        # Create new unit group admin to test that this Application does not get added to the response
+        unit_group_admin_two = get_user_model().objects.create(
+            username="ss_admin_two",
+            first_name="AminAdmin",
+            last_name="DeeDee",
+            email="aminadmin.deedee@foo.com",
+        )
+
+        unit_role = UnitRole.objects.create(
+            user=unit_group_admin_two,
+            role=UnitRoleChoice.objects.get(code="admin"),
+        )
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="admin"),
+            permission="can_validate_applications",
+        )
+
+        application_two = ApplicationFactory(
+            applicant_type=Application.APPLICANT_TYPE_ASSOCIATION
+        )
+        application_event = ApplicationEventFactory(application=application_two)
+        test_unit_1 = ReservationUnitFactory(
+            name="Declined unit 10",
+            name_fi="Declined unit FI 10",
+            name_en="Declined unit EN 10",
+            name_sv="Declined unit SV 10",
+        )
+        event_reservation_unit = EventReservationUnitFactory(
+            priority=1,
+            reservation_unit=test_unit_1,
+            application_event=application_event,
+        )
+        unit_group = UnitGroupFactory(
+            units=(event_reservation_unit.reservation_unit.unit,)
+        )
+
+        unit_role.unit_group.add(unit_group)
+
+        self.client.force_login(unit_group_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_super_admin_can_view_all_applications(self):
+        self.client.force_login(self.general_admin)
+
+        response = self.perform_basic_query()
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/api/graphql/tests/test_applications/test_applications.py
+++ b/api/graphql/tests/test_applications/test_applications.py
@@ -1,0 +1,454 @@
+import json
+
+from assertpy import assert_that
+
+from .base import ApplicationTestCaseBase
+
+
+class ApplicationsGraphQLTestCase(ApplicationTestCaseBase):
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.regular_joe)
+
+    def test_getting_applications_base_testcase(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_applicant_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicantName
+                            applicantEmail
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_applicant_no_value(self):
+        self.application.user = None
+        self.application.save()
+
+        self.client.force_login(self.general_admin)
+
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicantName
+                            applicantEmail
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_home_city_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            homeCity {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_billing_address_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            billingAddress {
+                                streetAddress
+                                postCode
+                                city
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_aggregate_data_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            aggregatedData {
+                                appliedMinDurationTotal
+                                appliedReservationsTotal
+                                createdReservationsTotal
+                                reservationsDurationTotal
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_status_field(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            status
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_contact_person_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            contactPerson {
+                                firstName
+                                lastName
+                                email
+                                phoneNumber
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_organisation_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            organisation {
+                                name
+                                identifier
+                                yearEstablished
+                                activeMembers
+                                coreBusiness
+                                organisationType
+                                email
+                                address {
+                                    streetAddress
+                                    postCode
+                                    city
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_basic_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                name
+                                numPersons
+                                minDuration
+                                maxDuration
+                                eventsPerWeek
+                                biweekly
+                                begin
+                                end
+                                status
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_age_group_display_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                ageGroupDisplay {
+                                    minimum
+                                    maximum
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_ability_group_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                abilityGroup {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_purpose_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                purpose {
+                                    nameFi
+                                    nameEn
+                                    nameSv
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_aggregated_data_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                aggregatedData {
+                                    durationTotal
+                                    reservationsTotal
+                                    allocationResultsDurationTotal
+                                    allocationResultsReservationsTotal
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_declined_reservation_unit_ids_field(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                declinedReservationUnits {
+                                    nameFi
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_application_event_schedules_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                applicationEventSchedules {
+                                    day
+                                    begin
+                                    end
+                                    priority
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_application_events_event_reservation_unit_base_fields(self):
+        response = self.query(
+            """
+            query {
+                applications {
+                    edges {
+                        node {
+                            applicationEvents {
+                                eventReservationUnits {
+                                    priority
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/api/graphql/tests/test_applications/test_applications_filters.py
+++ b/api/graphql/tests/test_applications/test_applications_filters.py
@@ -1,0 +1,122 @@
+import json
+
+from assertpy import assert_that
+
+from applications.models import Application, ApplicationStatus
+from applications.tests.factories import ApplicationFactory, ApplicationStatusFactory
+
+from .base import ApplicationTestCaseBase
+
+
+class ApplicationsGraphQLFiltersTestCase(ApplicationTestCaseBase):
+    def setUp(self):
+        super().setUp()
+
+        self.client.force_login(self.general_admin)
+
+        # This application should not be in any of the test queries
+        application = ApplicationFactory(
+            applicant_type=Application.APPLICANT_TYPE_ASSOCIATION
+        )
+
+        ApplicationStatusFactory(
+            application=application,
+            status=ApplicationStatus.DRAFT,
+        )
+
+    def test_application_filter_by_application_round(self):
+        query = f"""
+            query {{
+                applications(applicationRound: {self.application.application_round.id}) {{
+                    edges {{
+                        node {{
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        response = self.query(query)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_filter_by_status(self):
+        query = f"""
+            query {{
+                applications(status: "{self.application.status}") {{
+                    edges {{
+                        node {{
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        response = self.query(query)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_filter_by_unit(self):
+        unit = self.event_reservation_unit.reservation_unit.unit
+        query = f"""
+            query {{
+                applications(unit: "{unit.id}") {{
+                    edges {{
+                        node {{
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        response = self.query(query)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_application_filter_by_user(self):
+        query = f"""
+            query {{
+                applications(user: "{self.regular_joe.id}") {{
+                    edges {{
+                        node {{
+                            applicantType
+                            createdDate
+                            lastModifiedDate
+                            additionalInformation
+                        }}
+                    }}
+                }}
+            }}
+        """
+
+        response = self.query(query)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/applications/tests/factories.py
+++ b/applications/tests/factories.py
@@ -4,7 +4,14 @@ from django.utils.timezone import get_default_timezone
 from factory import LazyAttribute, SubFactory, post_generation
 from factory.django import DjangoModelFactory
 from factory.faker import Faker
-from factory.fuzzy import FuzzyChoice, FuzzyDate, FuzzyDateTime, FuzzyInteger, FuzzyText
+from factory.fuzzy import (
+    FuzzyChoice,
+    FuzzyDate,
+    FuzzyDateTime,
+    FuzzyFloat,
+    FuzzyInteger,
+    FuzzyText,
+)
 from pytz import UTC
 
 from applications.models import (
@@ -261,3 +268,11 @@ class ApplicationEventStatusFactory(DjangoModelFactory):
         ]
     )
     application_event = SubFactory(ApplicationEventFactory)
+
+
+class ApplicationAggregateDataFactory(DjangoModelFactory):
+    class Meta:
+        model = "applications.ApplicationAggregateData"
+
+    name = FuzzyText(length=20)
+    value = FuzzyFloat(low=0, high=255)

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -47,7 +47,7 @@ elif [ "$1" = "test" ]; then
         exit $exitcode
     fi
     _log_boxed "Running tests"
-    pytest --cov-report= --cov=tilavaraus
+    pytest --cov-report=html --cov
     exitcode=$?
     if [ $exitcode -ne 0 ]; then
         exit $exitcode

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -4,6 +4,7 @@ from django.shortcuts import get_object_or_404
 from graphene import ResolveInfo
 from graphene_permissions.permissions import BasePermission
 
+from applications.models import Application
 from permissions.helpers import (
     can_create_reservation,
     can_handle_reservation,
@@ -19,6 +20,7 @@ from permissions.helpers import (
     can_manage_units_reservation_units,
     can_manage_units_spaces,
     can_modify_reservation,
+    can_read_application,
     can_view_recurring_reservation,
 )
 from reservation_units.models import ReservationUnit, ReservationUnitImage
@@ -27,6 +29,55 @@ from spaces.models import Unit
 
 
 class ApplicationRoundPermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False
+
+
+class ApplicationPermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return info.context.user.is_authenticated
+
+    @classmethod
+    def has_node_permission(cls, info: ResolveInfo, id: str) -> bool:
+        user = info.context.user
+        application = Application.objects.filter(id=id)
+
+        if application:
+            return user.is_authenticated and can_read_application(user, application)
+
+        return False
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False
+
+    @classmethod
+    def has_filter_permission(cls, info: ResolveInfo) -> bool:
+        return info.context.user.is_authenticated
+
+
+class OrganisationPermission(BasePermission):
+    @classmethod
+    def has_permission(cls, info: ResolveInfo) -> bool:
+        return info.context.user.is_authenticated
+
+    @classmethod
+    def has_node_permission(cls, info: ResolveInfo, id: str) -> bool:
+        user = info.context.user
+        return user.is_authenticated
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False
+
+
+class AddressPermission(BasePermission):
     @classmethod
     def has_permission(cls, info: ResolveInfo) -> bool:
         return True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,7 @@
 [pytest]
 DJANGO_SETTINGS_MODULE=tilavarauspalvelu.settings
 python_files = tests.py test_*.py *_tests.py
+norecursedirs = .git venv build
 filterwarnings =
     ignore:.*collections.*:DeprecationWarning:graphene
     ignore:.*ugettext_lazy.*::recurrence

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ Django==3.2.13
 django-auditlog==1.0a1
 django-celery-results
 django-cors-headers==3.6.0
-django-debug-toolbar
 django-enumfields==2.0.0
 django-environ==0.4.5
 django-extensions==3.0.9
@@ -24,6 +23,7 @@ easy-thumbnails==2.7.1
 flake8==3.8.4
 freezegun==0.3.14
 graphene-django==3.0.0b7
+graphene-django-optimizer~=0.9.1
 graphene_permissions==1.1.4
 helsinki-profile-gdpr-api
 icalendar==4.0.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -66,7 +66,6 @@ django==3.2.13
     # via
     #   -r requirements.in
     #   django-cors-headers
-    #   django-debug-toolbar
     #   django-extra-fields
     #   django-filter
     #   django-graphql-jwt
@@ -86,8 +85,6 @@ django-auditlog==1.0a1
 django-celery-results==2.2.0
     # via -r requirements.in
 django-cors-headers==3.6.0
-    # via -r requirements.in
-django-debug-toolbar==3.2.4
     # via -r requirements.in
 django-enumfields==2.0.0
     # via -r requirements.in
@@ -158,6 +155,8 @@ graphene-django==3.0.0b7
     #   -r requirements.in
     #   django-graphql-jwt
     #   graphene-permissions
+graphene-django-optimizer==0.9.1
+    # via -r requirements.in
 graphene-file-upload==1.3.0
     # via -r requirements.in
 graphene-permissions==1.1.4
@@ -207,7 +206,7 @@ pep517==0.10.0
     # via pip-tools
 pillow==9.0.1
     # via easy-thumbnails
-pip-tools==6.1.0
+pip-tools==6.6.0
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
@@ -319,9 +318,7 @@ social-auth-app-django==4.0.0
 social-auth-core==4.1.0
     # via social-auth-app-django
 sqlparse==0.4.2
-    # via
-    #   django
-    #   django-debug-toolbar
+    # via django
 termcolor==1.1.0
     # via snapshottest
 text-unidecode==1.3
@@ -356,6 +353,8 @@ wasmer-compiler-cranelift==1.0.0
     # via fastdiff
 wcwidth==0.2.5
     # via prompt-toolkit
+wheel==0.37.1
+    # via pip-tools
 whitenoise==5.2.0
     # via -r requirements.in
 

--- a/reservations/tests/factories.py
+++ b/reservations/tests/factories.py
@@ -83,3 +83,10 @@ class ReservationFactory(DjangoModelFactory):
 
         for resunit in reservation_units:
             self.reservation_unit.add(resunit)
+
+
+class AbilityGroupFactory(DjangoModelFactory):
+    class Meta:
+        model = "reservations.AbilityGroup"
+
+    name = FuzzyText()

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,8 +7,27 @@ max-complexity = 10
 [pycodestyle]
 ignore = W503
 
-[tool.pytest]
-norecursedirs = .git venv build
+[coverage:run]
+source = 
+    allocation/
+    api/
+    applications/
+    email_notification/
+    opening_hours/
+    permissions/
+    reservation_units/
+    reservations/
+    resources/
+    services/
+    spaces/
+    terms_of_use/
+    tilavarauspalvelu/
+    users/
+    verkkokauppa/
+omit =
+    *migrations*
+    *snapshots*
+    *tests*
 
 
 [isort]

--- a/spaces/tests/factories.py
+++ b/spaces/tests/factories.py
@@ -25,6 +25,19 @@ class UnitFactory(DjangoModelFactory):
         model = "spaces.Unit"
 
 
+class UnitGroupFactory(DjangoModelFactory):
+    class Meta:
+        model = "spaces.UnitGroup"
+
+    @post_generation
+    def units(self, create, units, **kwargs):
+        if not create or not units:
+            return
+
+        for unit in units:
+            self.units.add(unit)
+
+
 class SpaceFactory(DjangoModelFactory):
     class Meta:
         model = "spaces.Space"

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -206,7 +206,6 @@ env = environ.Env(
     DEFAULT_FROM_EMAIL=(str, django_default_from_email),
     # Tprek
     TPREK_UNIT_URL=(str, "https://www.hel.fi/palvelukarttaws/rest/v4/unit/"),
-    USE_DEBUG_TOOLBAR=(bool, False),
     # GDPR API
     GDPR_API_QUERY_SCOPE=(str, ""),
     GDPR_API_DELETE_SCOPE=(str, ""),
@@ -505,16 +504,3 @@ GRAPH_MODELS = {
 }
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
-
-USE_DEBUG_TOOLBAR = env("USE_DEBUG_TOOLBAR")
-if DEBUG and USE_DEBUG_TOOLBAR:
-    # Hardcode to internal IPs as debug toolbar will expose internal information
-    INTERNAL_IPS = ["127.0.0.1", "localhost"]
-    INSTALLED_APPS.append("debug_toolbar")
-
-    # According to documentation, this should be as early as possible in the middleware tree
-    MIDDLEWARE.insert(0, "debug_toolbar.middleware.DebugToolbarMiddleware")
-
-    # NOTE: If you run this in docker,
-    # here is additional information for set-up: https://django-debug-toolbar.readthedocs.io/en/latest/installation.html
-    # right before "Troubleshooting"

--- a/tilavarauspalvelu/urls.py
+++ b/tilavarauspalvelu/urls.py
@@ -25,6 +25,3 @@ urlpatterns.extend(other_patterns)
 
 if settings.DEBUG:
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-
-if settings.DEBUG and settings.USE_DEBUG_TOOLBAR:
-    urlpatterns += [path("__debug__/", include("debug_toolbar.urls"))]


### PR DESCRIPTION
Applications endpoint was translated to GraphQL in this branch for better specification in data fetches. This will improve performance when less information is queried and gathered in each request when only the necessary data has to be fetched instead of all possible values.

* Translate `/v1/applications/` endpoint from REST to GraphQL.
* Move performance investigation tooling to documentation instead of ready-made settings.
* Improve code coverage pytest settings.

Refs TILA-1569