### PR TITLE
TILA-1691: Allow sorting units by name

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -75,6 +75,7 @@ from api.graphql.spaces.space_mutations import (
 )
 from api.graphql.spaces.space_types import SpaceType
 from api.graphql.terms_of_use.terms_of_use_types import TermsOfUseType
+from api.graphql.units.unit_filtersets import UnitsFilterSet
 from api.graphql.units.unit_mutations import UnitUpdateMutation
 from api.graphql.units.unit_types import UnitByPkType, UnitType
 from applications.models import Application
@@ -235,7 +236,7 @@ class SpacesFilter(AuthFilter):
     )
 
 
-class UnitsFilter(AuthFilter):
+class UnitsFilter(AuthFilter, django_filters.FilterSet):
     permission_classes = (
         (UnitPermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
     )
@@ -375,7 +376,7 @@ class Query(graphene.ObjectType):
     space = relay.Node.Field(SpaceType)
     space_by_pk = Field(SpaceType, pk=graphene.Int())
 
-    units = UnitsFilter(UnitType)
+    units = UnitsFilter(UnitType, filterset_class=UnitsFilterSet)
     unit = relay.Node.Field(UnitType)
     unit_by_pk = Field(UnitByPkType, pk=graphene.Int())
 

--- a/api/graphql/tests/snapshots/snap_test_units.py
+++ b/api/graphql/tests/snapshots/snap_test_units.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['UnitsUpdateTestCase::test_getting_units 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'descriptionEn': '',
+                        'descriptionFi': 'Test description',
+                        'descriptionSv': '',
+                        'email': 'test@example.com',
+                        'location': None,
+                        'nameEn': None,
+                        'nameFi': 'Test unit',
+                        'nameSv': None,
+                        'phone': '+358 12 34567',
+                        'reservationUnits': [
+                        ],
+                        'shortDescriptionEn': '',
+                        'shortDescriptionFi': 'Short description',
+                        'shortDescriptionSv': '',
+                        'spaces': [
+                        ],
+                        'webPage': 'https://hel.fi'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsUpdateTestCase::test_getting_units_sorted_by_name_asc 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Aaaaaa'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Bbbbbb'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Cccccc'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Test unit'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsUpdateTestCase::test_getting_units_sorted_by_name_desc 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test unit'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Cccccc'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Bbbbbb'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Aaaaaa'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/units/unit_filtersets.py
+++ b/api/graphql/units/unit_filtersets.py
@@ -1,0 +1,17 @@
+import django_filters
+
+from .unit_types import Unit
+
+
+class UnitsFilterSet(django_filters.FilterSet):
+    pk = django_filters.ModelMultipleChoiceFilter(
+        field_name="pk", method="filter_by_pk", queryset=Unit.objects.all()
+    )
+
+    order_by = django_filters.OrderingFilter(fields=("name_fi", "name_en", "name_sv"))
+
+    def filter_by_pk(self, qs, property, value):
+        if value:
+            return qs.filter(id__in=[model.id for model in value])
+
+        return qs


### PR DESCRIPTION
Adds `UnitsFiltersSet` and enables sorting `Unit` by name. I also added some tests to cover basic query cases.