### PR TITLE
TILA-1695: Add service sectors to UnitType

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_units.py
+++ b/api/graphql/tests/snapshots/snap_test_units.py
@@ -24,6 +24,8 @@ snapshots['UnitsUpdateTestCase::test_getting_units 1'] = {
                         'phone': '+358 12 34567',
                         'reservationUnits': [
                         ],
+                        'serviceSectors': [
+                        ],
                         'shortDescriptionEn': '',
                         'shortDescriptionFi': 'Short description',
                         'shortDescriptionSv': '',

--- a/api/graphql/tests/test_units.py
+++ b/api/graphql/tests/test_units.py
@@ -107,6 +107,9 @@ class UnitsUpdateTestCase(UnitQueryTestCaseBase):
                             location {
                                 addressStreetFi
                             }
+                            serviceSectors {
+                                nameFi
+                            }
                         }
                     }
                 }

--- a/api/graphql/units/unit_types.py
+++ b/api/graphql/units/unit_types.py
@@ -29,6 +29,9 @@ class UnitType(AuthNode, PrimaryKeyObjectType):
     )
     spaces = graphene.List("api.graphql.spaces.space_types.SpaceType")
     location = graphene.Field("api.graphql.spaces.space_types.LocationType")
+    service_sectors = graphene.List(
+        "api.graphql.application_rounds.application_round_types.ServiceSectorType"
+    )
 
     class Meta:
         model = Unit
@@ -59,6 +62,9 @@ class UnitType(AuthNode, PrimaryKeyObjectType):
 
     def resolve_location(self, info):
         return getattr(self, "location", None)
+
+    def resolve_service_sectors(self, info):
+        return self.service_sectors.all()
 
 
 class UnitByPkType(UnitType, OpeningHoursMixin):


### PR DESCRIPTION
Adds `service_sectors` field to `UnitType`.