### PR TITLE
TILA-1720: Add ServiceSector to GraphQL

### DIFF
--- a/api/graphql/application_rounds/application_round_types.py
+++ b/api/graphql/application_rounds/application_round_types.py
@@ -6,6 +6,7 @@ from graphene_permissions.permissions import AllowAny
 
 from api.graphql.base_type import PrimaryKeyObjectType
 from api.graphql.reservation_units.reservation_unit_types import ReservationUnitType
+from api.graphql.spaces.space_types import ServiceSectorType
 from api.graphql.translate_fields import get_all_translatable_fields
 from applications.models import (
     ApplicationEventAggregateData,
@@ -15,7 +16,6 @@ from applications.models import (
     ApplicationStatus,
 )
 from permissions.api_permissions.graphene_permissions import ApplicationRoundPermission
-from spaces.models import ServiceSector
 
 from ..base_connection import TilavarausBaseConnection
 from ..reservations.reservation_types import ReservationPurposeType
@@ -26,20 +26,6 @@ class ApplicationRoundAggregatedDataType(graphene.ObjectType):
     allocation_duration_total = graphene.Int()
     total_reservation_duration = graphene.Int()
     total_hour_capacity = graphene.Int()
-
-
-class ServiceSectorType(AuthNode, PrimaryKeyObjectType):
-    permission_classes = (
-        (ApplicationRoundPermission,)
-        if not settings.TMP_PERMISSIONS_DISABLED
-        else (AllowAny,)
-    )
-
-    class Meta:
-        model = ServiceSector
-        fields = ["id"] + get_all_translatable_fields(model)
-        interfaces = (graphene.relay.Node,)
-        connection_class = TilavarausBaseConnection
 
 
 class ApplicationRoundBasketType(AuthNode, PrimaryKeyObjectType):

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -72,7 +72,7 @@ from api.graphql.spaces.space_mutations import (
     SpaceDeleteMutation,
     SpaceUpdateMutation,
 )
-from api.graphql.spaces.space_types import SpaceType
+from api.graphql.spaces.space_types import ServiceSectorType, SpaceType
 from api.graphql.terms_of_use.terms_of_use_types import TermsOfUseType
 from api.graphql.units.unit_filtersets import UnitsFilterSet
 from api.graphql.units.unit_mutations import UnitUpdateMutation
@@ -95,6 +95,7 @@ from permissions.api_permissions.graphene_permissions import (
     ReservationUnitCancellationRulePermission,
     ReservationUnitPermission,
     ResourcePermission,
+    ServiceSectorPermission,
     SpacePermission,
     TaxPercentagePermission,
     TermsOfUsePermission,
@@ -330,6 +331,14 @@ class ReservationMetadataSetFilter(AuthFilter):
     )
 
 
+class ServiceSectorFilter(AuthFilter):
+    permission_classes = (
+        (ServiceSectorPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else (AllowAny,)
+    )
+
+
 class Query(graphene.ObjectType):
     applications = ApplicationsFilter(
         ApplicationType, filterset_class=ApplicationFilterSet
@@ -373,6 +382,7 @@ class Query(graphene.ObjectType):
     spaces = SpacesFilter(SpaceType)
     space = relay.Node.Field(SpaceType)
     space_by_pk = Field(SpaceType, pk=graphene.Int())
+    service_sectors = ServiceSectorFilter(ServiceSectorType)
 
     units = UnitsFilter(UnitType, filterset_class=UnitsFilterSet)
     unit = relay.Node.Field(UnitType)

--- a/api/graphql/spaces/space_types.py
+++ b/api/graphql/spaces/space_types.py
@@ -13,7 +13,7 @@ from permissions.api_permissions.graphene_permissions import (
     ResourcePermission,
     SpacePermission,
 )
-from spaces.models import Building, District, Location, RealEstate, Space
+from spaces.models import Building, District, Location, RealEstate, ServiceSector, Space
 
 
 class DistrictType(PrimaryKeyObjectType):
@@ -104,5 +104,14 @@ class LocationType(PrimaryKeyObjectType):
             "latitude",
         ] + get_all_translatable_fields(model)
 
+        interfaces = (graphene.relay.Node,)
+        connection_class = TilavarausBaseConnection
+
+
+class ServiceSectorType(PrimaryKeyObjectType):
+    class Meta:
+        model = ServiceSector
+        fields = ["id"] + get_all_translatable_fields(model)
+        filter_fields = []
         interfaces = (graphene.relay.Node,)
         connection_class = TilavarausBaseConnection

--- a/api/graphql/tests/snapshots/snap_test_service_sectors.py
+++ b/api/graphql/tests/snapshots/snap_test_service_sectors.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['ServiceSectorsGraphQLTestCase::test_getting_service_sectors 1'] = {
+    'data': {
+        'serviceSectors': {
+            'edges': [
+                {
+                    'node': {
+                        'nameEn': None,
+                        'nameFi': 'Yksityinen',
+                        'nameSv': None
+                    }
+                },
+                {
+                    'node': {
+                        'nameEn': None,
+                        'nameFi': 'Kulttuuri ja vapaa-aika',
+                        'nameSv': None
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_service_sectors.py
+++ b/api/graphql/tests/test_service_sectors.py
@@ -1,0 +1,37 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from graphene_django.utils import GraphQLTestCase
+from rest_framework.test import APIClient
+
+from spaces.models import ServiceSector
+
+
+class ServiceSectorsGraphQLTestCase(GraphQLTestCase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.api_client = APIClient()
+
+    def test_getting_service_sectors(self):
+        ServiceSector.objects.create(name="Yksityinen")
+        ServiceSector.objects.create(name="Kulttuuri ja vapaa-aika")
+        response = self.query(
+            """
+            query {
+                serviceSectors {
+                    edges {
+                        node {
+                            nameFi
+                            nameEn
+                            nameSv
+                        }
+                    }
+                }
+            }
+            """
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -391,3 +391,13 @@ class ReservationMetadataSetPermission(BasePermission):
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
         return False
+
+
+class ServiceSectorPermission(BasePermission):
+    @classmethod
+    def has_permission(self, info: ResolveInfo) -> bool:
+        return True
+
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        return False


### PR DESCRIPTION
This PR adds ServiceService to GraphQL. I also moved `ServiceSectorType` from `application_round_types.py` to `space_types.py`.

Example query:
```
{
  serviceSectors {
    edges {
      node {
        pk
        nameFi
        nameSv
        nameEn
      }
    }
  }
}
```