### PR TITLE
TILA-1721 | Use append instead of push then adding parent selects

### DIFF
--- a/utils/query_performance.py
+++ b/utils/query_performance.py
@@ -265,7 +265,7 @@ class QueryPerformanceOptimizerMixin:
             selects.append(optimization_value.get("field_name"))
 
         if optimization_type == "select_for_parent":
-            parent_selects.push(optimization_value)
+            parent_selects.append(optimization_value)
 
         if optimization_type == "prefetch_for_parent":
 


### PR DESCRIPTION
In QueryPerformanceOptimzerMixin class there was miney mini bug when select_for_parent type of optimizations.
Piece of code was calling push instead of append. This fixes that one.

TILA-1721