### PR TITLE
TILA-1741: Hide archived reservation units by default

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_filtersets.py
+++ b/api/graphql/reservation_units/reservation_unit_filtersets.py
@@ -46,8 +46,6 @@ class ReservationUnitsFilterSet(django_filters.FilterSet):
 
     is_draft = django_filters.BooleanFilter(field_name="is_draft")
 
-    is_archived = django_filters.BooleanFilter(field_name="is_archived")
-
     is_visible = django_filters.BooleanFilter(method="get_is_visible")
 
     application_round = django_filters.ModelMultipleChoiceFilter(

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -263,6 +263,16 @@ class ReservationUnitsFilter(AuthFilter, django_filters.FilterSet):
         else (AllowAny,)
     )
 
+    @classmethod
+    def resolve_queryset(
+        cls, connection, iterable, info, args, filtering_args, filterset_class
+    ):
+        queryset = super().resolve_queryset(
+            connection, iterable, info, args, filtering_args, filterset_class
+        )
+        # Hide archived reservation units
+        return queryset.filter(is_archived=False)
+
 
 class ReservationUnitTypesFilter(AuthFilter, django_filters.FilterSet):
     permission_classes = (

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -58,42 +58,6 @@ snapshots['ReservationUnitQueryTestCase::test_filtering_by_active_application_ro
     }
 }
 
-snapshots['ReservationUnitQueryTestCase::test_filtering_by_is_archived_false 1'] = {
-    'data': {
-        'reservationUnits': {
-            'edges': [
-                {
-                    'node': {
-                        'isArchived': False,
-                        'nameFi': 'test name fi'
-                    }
-                },
-                {
-                    'node': {
-                        'isArchived': False,
-                        'nameFi': "I'm visible"
-                    }
-                }
-            ]
-        }
-    }
-}
-
-snapshots['ReservationUnitQueryTestCase::test_filtering_by_is_archived_true 1'] = {
-    'data': {
-        'reservationUnits': {
-            'edges': [
-                {
-                    'node': {
-                        'isArchived': True,
-                        'nameFi': "I'm visible"
-                    }
-                }
-            ]
-        }
-    }
-}
-
 snapshots['ReservationUnitQueryTestCase::test_filtering_by_is_draft_false 1'] = {
     'data': {
         'reservationUnits': {
@@ -1316,14 +1280,14 @@ snapshots['ReservationUnitQueryTestCase::test_order_by_unit_reverse_order 1'] = 
     }
 }
 
-snapshots['ReservationUnitQueryTestCase::test_that_state_is_archived 1'] = {
+snapshots['ReservationUnitQueryTestCase::test_should_not_return_archived_reservation_units 1'] = {
     'data': {
         'reservationUnits': {
             'edges': [
                 {
                     'node': {
-                        'nameFi': 'This should be archived',
-                        'state': 'archived'
+                        'isArchived': False,
+                        'nameFi': 'test name fi'
                     }
                 }
             ]


### PR DESCRIPTION
The only way to interact with archived reservation units is the Django Admin, I also removed `is_archived` filter since there is no use for it.