### PR TITLE
TILA-1730: Filtering reservation units by state

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -42,6 +42,7 @@ from permissions.api_permissions.graphene_permissions import (
     UnitPermission,
 )
 from permissions.helpers import can_manage_units
+from reservation_units.enums import ReservationUnitState
 from reservation_units.models import (
     Equipment,
     EquipmentCategory,
@@ -303,7 +304,7 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     buffer_time_before = Duration()
     buffer_time_after = Duration()
     metadata_set = graphene.Field(ReservationMetadataSetType)
-    state = graphene.String()
+    state = graphene.Field(graphene.Enum.from_enum(ReservationUnitState))
 
     permission_classes = (
         (ReservationUnitPermission,)

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -611,7 +611,7 @@ snapshots['ReservationUnitQueryTestCase::test_getting_reservation_units 1'] = {
                                 'nameFi': 'Small space'
                             }
                         ],
-                        'state': 'scheduledReservation',
+                        'state': 'SCHEDULED_RESERVATION',
                         'surfaceArea': '150.00',
                         'taxPercentage': {
                             'value': '24.00'
@@ -1302,7 +1302,7 @@ snapshots['ReservationUnitQueryTestCase::test_that_state_is_draft 1'] = {
                 {
                     'node': {
                         'nameFi': 'This should be draft',
-                        'state': 'draft'
+                        'state': 'DRAFT'
                     }
                 }
             ]
@@ -1317,7 +1317,7 @@ snapshots['ReservationUnitQueryTestCase::test_that_state_is_published 1'] = {
                 {
                     'node': {
                         'nameFi': 'This should be published',
-                        'state': 'published'
+                        'state': 'PUBLISHED'
                     }
                 }
             ]
@@ -1332,7 +1332,7 @@ snapshots['ReservationUnitQueryTestCase::test_that_state_is_scheduled_publishing
                 {
                     'node': {
                         'nameFi': 'This should be scheduled publishing',
-                        'state': 'scheduledPublishing'
+                        'state': 'SCHEDULED_PUBLISHING'
                     }
                 }
             ]
@@ -1347,7 +1347,7 @@ snapshots['ReservationUnitQueryTestCase::test_that_state_is_scheduled_reservatio
                 {
                     'node': {
                         'nameFi': 'This should be scheduled reservation',
-                        'state': 'scheduledReservation'
+                        'state': 'SCHEDULED_RESERVATION'
                     }
                 }
             ]

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -1355,6 +1355,120 @@ snapshots['ReservationUnitQueryTestCase::test_that_state_is_scheduled_reservatio
     }
 }
 
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_archived_returns_nothing 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_draft 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'I am a draft!',
+                        'state': 'DRAFT'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_mixed 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'I am a draft!',
+                        'state': 'DRAFT'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'I am scheduled for publishing!',
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'I am also scheduled for publishing!',
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_published 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': "Yey! I'm published!",
+                        'state': 'PUBLISHED'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_scheduled_publishing 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'I am scheduled for publishing!',
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'I am also scheduled for publishing!',
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_scheduled_reservation 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'test name fi',
+                        'state': 'SCHEDULED_RESERVATION'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'I am scheduled for reservation!',
+                        'state': 'SCHEDULED_RESERVATION'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'I am also scheduled for reservation!',
+                        'state': 'SCHEDULED_RESERVATION'
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['ReservationUnitsFilterTextSearchTestCase::test_filtering_by_reservation_unit_description_en 1'] = {
     'data': {
         'reservationUnits': {

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -2112,6 +2112,175 @@ class ReservationUnitsFilterTextSearchTestCase(ReservationUnitQueryTestCaseBase)
         self.assertMatchSnapshot(content)
 
 
+class ReservationUnitsFilterStateTestCase(ReservationUnitQueryTestCaseBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        now = datetime.datetime.now(tz=get_default_timezone())
+        cls.archived_reservation_unit = ReservationUnitFactory(
+            name="I am archived!", is_archived=True
+        )
+        cls.archived_reservation_unit = ReservationUnitFactory(
+            name="I am a draft!", is_archived=False, is_draft=True
+        )
+        cls.scheduled_publishing_reservation_unit_1 = ReservationUnitFactory(
+            name="I am scheduled for publishing!",
+            is_archived=False,
+            is_draft=False,
+            publish_begins=(now + datetime.timedelta(hours=1)),
+        )
+        cls.scheduled_publishing_reservation_unit_2 = ReservationUnitFactory(
+            name="I am also scheduled for publishing!",
+            is_archived=False,
+            is_draft=False,
+            publish_ends=(now - datetime.timedelta(hours=1)),
+        )
+        cls.scheduled_reservation_reservation_unit_1 = ReservationUnitFactory(
+            name="I am scheduled for reservation!",
+            is_archived=False,
+            is_draft=False,
+            reservation_begins=(now + datetime.timedelta(hours=1)),
+        )
+        cls.scheduled_reservation_reservation_unit_2 = ReservationUnitFactory(
+            name="I am also scheduled for reservation!",
+            is_archived=False,
+            is_draft=False,
+            reservation_ends=(now - datetime.timedelta(hours=1)),
+        )
+        cls.published_reservation_unit = ReservationUnitFactory(
+            name="Yey! I'm published!",
+            is_archived=False,
+            is_draft=False,
+        )
+
+    # Archived reservation units are always hidden
+    def test_filtering_by_archived_returns_nothing(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"ARCHIVED"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_true()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_filtering_by_draft(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"DRAFT"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_filtering_by_scheduled_publishing(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"SCHEDULED_PUBLISHING"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_filtering_by_scheduled_reservation(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"SCHEDULED_RESERVATION"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_filtering_by_published(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"PUBLISHED"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_filtering_by_mixed(self):
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:["DRAFT", "SCHEDULED_PUBLISHING"]){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+
 def get_mocked_opening_hours(uuid):
     resource_id = f"{settings.HAUKI_ORIGIN_ID}:{uuid}"
     return [

--- a/reservation_units/enums.py
+++ b/reservation_units/enums.py
@@ -2,11 +2,8 @@ from enum import Enum
 
 
 class ReservationUnitState(Enum):
-    DRAFT = "draft"
-    SCHEDULED_PUBLISHING = "scheduledPublishing"
-    SCHEDULED_RESERVATION = "scheduledReservation"
-    PUBLISHED = "published"
-    ARCHIVED = "archived"
-
-    def __str__(self):
-        return self.value
+    DRAFT = "DRAFT"
+    SCHEDULED_PUBLISHING = "SCHEDULED_PUBLISHING"
+    SCHEDULED_RESERVATION = "SCHEDULED_RESERVATION"
+    PUBLISHED = "PUBLISHED"
+    ARCHIVED = "ARCHIVED"

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -4,7 +4,6 @@ import uuid as uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models
-from django.utils.timezone import get_default_timezone
 from django.utils.translation import gettext_lazy as _
 from easy_thumbnails.fields import ThumbnailerImageField
 
@@ -574,21 +573,11 @@ class ReservationUnit(models.Model):
 
     @property
     def state(self) -> ReservationUnitState:
-        now = datetime.datetime.now(tz=get_default_timezone())
-        if self.is_archived:
-            return ReservationUnitState.ARCHIVED
-        elif self.is_draft:
-            return ReservationUnitState.DRAFT
-        elif (self.publish_begins and now < self.publish_begins) or (
-            self.publish_ends and now >= self.publish_ends
-        ):
-            return ReservationUnitState.SCHEDULED_PUBLISHING
-        elif (self.reservation_begins and now < self.reservation_begins) or (
-            self.reservation_ends and now >= self.reservation_ends
-        ):
-            return ReservationUnitState.SCHEDULED_RESERVATION
-        else:
-            return ReservationUnitState.PUBLISHED
+        from reservation_units.utils.reservation_unit_state_helper import (
+            ReservationUnitStateHelper,
+        )
+
+        return ReservationUnitStateHelper.get_state(self)
 
 
 class ReservationUnitImage(models.Model):

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -573,7 +573,7 @@ class ReservationUnit(models.Model):
         return settings.HAUKI_ORIGIN_ID
 
     @property
-    def state(self) -> str:
+    def state(self) -> ReservationUnitState:
         now = datetime.datetime.now(tz=get_default_timezone())
         if self.is_archived:
             return ReservationUnitState.ARCHIVED

--- a/reservation_units/utils/reservation_unit_state_helper.py
+++ b/reservation_units/utils/reservation_unit_state_helper.py
@@ -1,0 +1,108 @@
+import datetime
+
+from django.db.models import Q
+from django.utils.timezone import get_default_timezone
+
+from reservation_units.enums import ReservationUnitState
+from reservation_units.models import ReservationUnit
+
+
+class ReservationUnitStateHelper:
+
+    # ARCHIVED
+    def __is_archived(reservation_unit: ReservationUnit) -> bool:
+        return reservation_unit.is_archived
+
+    def __get_is_archived_query() -> Q:
+        return Q(is_archived=True)
+
+    # DRAFT
+    def __is_draft(reservation_unit: ReservationUnit) -> bool:
+        return reservation_unit.is_draft and not reservation_unit.is_archived
+
+    def __get_is_draft_query() -> Q:
+        return Q(
+            is_draft=True,
+            is_archived=False,
+        )
+
+    # SCHEDULED_PUBLISHING
+    def __is_scheduled_publishing(reservation_unit: ReservationUnit) -> bool:
+        now = datetime.datetime.now(tz=get_default_timezone())
+        if ReservationUnitStateHelper.__is_draft(
+            reservation_unit
+        ) or ReservationUnitStateHelper.__is_archived(reservation_unit):
+            return False
+
+        return (
+            reservation_unit.publish_begins and now < reservation_unit.publish_begins
+        ) or (reservation_unit.publish_ends and now >= reservation_unit.publish_ends)
+
+    def __get_is_scheduled_publishing_query() -> Q:
+        now = datetime.datetime.now(tz=get_default_timezone())
+        return Q(is_archived=False, is_draft=False) & (
+            Q(publish_begins__isnull=False, publish_begins__gt=now)
+            | Q(publish_ends__isnull=False, publish_ends__lte=now)
+        )
+
+    # SCHEDULED_RESERVATION
+    def __is_scheduled_reservation(reservation_unit: ReservationUnit) -> bool:
+        now = datetime.datetime.now(tz=get_default_timezone())
+        if ReservationUnitStateHelper.__is_draft(
+            reservation_unit
+        ) or ReservationUnitStateHelper.__is_archived(reservation_unit):
+            return False
+        return (
+            reservation_unit.reservation_begins
+            and now < reservation_unit.reservation_begins
+        ) or (
+            reservation_unit.reservation_ends
+            and now >= reservation_unit.reservation_ends
+        )
+
+    def __get_is_scheduled_reservation_query() -> Q:
+        now = datetime.datetime.now(tz=get_default_timezone())
+        return Q(reservation_begins__isnull=False, reservation_begins__gt=now) | Q(
+            reservation_ends__isnull=False, reservation_ends__lte=now
+        )
+
+    # PUBLISHED
+    def __get_is_published_query() -> Q:
+        now = datetime.datetime.now(tz=get_default_timezone())
+        return (
+            Q(is_archived=False)
+            & Q(is_draft=False)
+            & (Q(publish_begins__isnull=True) | Q(publish_begins__lte=now))
+            & (Q(publish_ends__isnull=True) | Q(publish_ends__gt=now))
+            & (Q(reservation_begins__isnull=True) | Q(reservation_begins__lte=now))
+            & (Q(reservation_ends__isnull=True) | Q(reservation_ends__gt=now))
+        )
+
+    @staticmethod
+    def get_state(reservation_unit: ReservationUnit) -> ReservationUnitState:
+        """Figure out the state of the Reservation Unit"""
+        if ReservationUnitStateHelper.__is_archived(reservation_unit):
+            return ReservationUnitState.ARCHIVED
+        elif ReservationUnitStateHelper.__is_draft(reservation_unit):
+            return ReservationUnitState.DRAFT
+        elif ReservationUnitStateHelper.__is_scheduled_publishing(reservation_unit):
+            return ReservationUnitState.SCHEDULED_PUBLISHING
+        elif ReservationUnitStateHelper.__is_scheduled_reservation(reservation_unit):
+            return ReservationUnitState.SCHEDULED_RESERVATION
+        else:
+            return ReservationUnitState.PUBLISHED
+
+    @staticmethod
+    def get_state_query(state: str) -> Q:
+        """Get matching filter query based on the Reservation Unit state (as string)"""
+        state = ReservationUnitState(state)
+        if state == ReservationUnitState.ARCHIVED:
+            return ReservationUnitStateHelper.__get_is_archived_query()
+        elif state == ReservationUnitState.DRAFT:
+            return ReservationUnitStateHelper.__get_is_draft_query()
+        elif state == ReservationUnitState.SCHEDULED_PUBLISHING:
+            return ReservationUnitStateHelper.__get_is_scheduled_publishing_query()
+        elif state == ReservationUnitState.SCHEDULED_RESERVATION:
+            return ReservationUnitStateHelper.__get_is_scheduled_reservation_query()
+        else:
+            return ReservationUnitStateHelper.__get_is_published_query()

--- a/reservation_units/utils/tests/test_reservation_unit_state_helper.py
+++ b/reservation_units/utils/tests/test_reservation_unit_state_helper.py
@@ -1,0 +1,82 @@
+import datetime
+
+from assertpy import assert_that
+from django.test.testcases import TestCase
+
+from reservation_units.enums import ReservationUnitState
+from reservation_units.models import ReservationUnit
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservation_units.utils.reservation_unit_state_helper import (
+    ReservationUnitStateHelper as Helper,
+)
+
+
+class ReservationUnitStateHelperTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.reservation_unit: ReservationUnit = ReservationUnitFactory()
+        cls.now = datetime.datetime.now(tz=datetime.timezone.utc)
+
+    def test_get_state_with_archived(self):
+        self.reservation_unit.is_archived = True
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.ARCHIVED
+        )
+
+    def test_get_state_with_archived_and_draft(self):
+        self.reservation_unit.is_archived = True
+        self.reservation_unit.is_draft = True
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.ARCHIVED
+        )
+
+    def test_get_state_with_draft(self):
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = True
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.DRAFT
+        )
+
+    def test_get_state_with_scheduled_publishing_and_publish_begins(self):
+        one_hour = datetime.timedelta(hours=1)
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        self.reservation_unit.publish_begins = self.now + one_hour
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.SCHEDULED_PUBLISHING
+        )
+
+    def test_get_state_with_scheduled_publishing_and_publish_end(self):
+        one_hour = datetime.timedelta(hours=1)
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        self.reservation_unit.publish_ends = self.now - one_hour
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.SCHEDULED_PUBLISHING
+        )
+
+    def test_get_state_with_scheduled_reservation_and_reservation_begins(self):
+        one_hour = datetime.timedelta(hours=1)
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        self.reservation_unit.reservation_begins = self.now + one_hour
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.SCHEDULED_RESERVATION
+        )
+
+    def test_get_state_with_scheduled_reservation_and_reservation_ends(self):
+        one_hour = datetime.timedelta(hours=1)
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        self.reservation_unit.reservation_ends = self.now - one_hour
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.SCHEDULED_RESERVATION
+        )
+
+    def test_get_state_with_published(self):
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.PUBLISHED
+        )


### PR DESCRIPTION
`state` is a calculated field.  Because the value depends on the current time, we can't really store it to the database. For these reasons I made a separate utility class that handles the state calculation and filter generation. I couldn't figure out an easier way to do this, but if you know how to improve this, please let me know ☺️ 

Oh I also switched strings to enums ☺️ 