### PR TITLE
TILA-1758 | ApplicationEventScheduleResult GraphQl API

### DIFF
--- a/api/graphql/applications/application_mutations.py
+++ b/api/graphql/applications/application_mutations.py
@@ -8,12 +8,20 @@ from graphene_permissions.permissions import AllowAny
 
 from api.graphql.applications.application_event_serializers import (
     ApplicationEventCreateSerializer,
+    ApplicationEventScheduleResultCreateSerializer,
+    ApplicationEventScheduleResultUpdateSerializer,
     ApplicationEventUpdateSerializer,
 )
-from api.graphql.applications.application_types import ApplicationEventType
+from api.graphql.applications.application_types import (
+    ApplicationEventScheduleResultType,
+    ApplicationEventType,
+)
 from api.graphql.base_mutations import AuthDeleteMutation, AuthSerializerMutation
 from applications.models import ApplicationEvent, ApplicationEventStatus
-from permissions.api_permissions.graphene_permissions import ApplicationEventPermission
+from permissions.api_permissions.graphene_permissions import (
+    ApplicationEventPermission,
+    ApplicationEventScheduleResultPermission,
+)
 
 
 class ApplicationEventCreateMutation(AuthSerializerMutation, SerializerMutation):
@@ -61,3 +69,41 @@ class ApplicationEventDeleteMutation(AuthDeleteMutation, ClientIDMutation):
             raise ValidationError("ApplicationEvent cannot be deleted anymore.")
 
         return None
+
+
+class ApplicationEventScheduleResultCreateMutation(
+    AuthSerializerMutation, SerializerMutation
+):
+    application_event_schedule_result = graphene.Field(
+        ApplicationEventScheduleResultType
+    )
+
+    permission_classes = (
+        (ApplicationEventScheduleResultPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else (AllowAny,)
+    )
+
+    class Meta:
+        model_operations = ["create"]
+
+        serializer_class = ApplicationEventScheduleResultCreateSerializer
+
+
+class ApplicationEventScheduleResultUpdateMutation(
+    AuthSerializerMutation, SerializerMutation
+):
+    application_event_schedule_result = graphene.Field(
+        ApplicationEventScheduleResultType
+    )
+
+    permission_classes = (
+        (ApplicationEventScheduleResultPermission,)
+        if not settings.TMP_PERMISSIONS_DISABLED
+        else (AllowAny,)
+    )
+
+    class Meta:
+        model_operations = ["update"]
+        lookup_field = "application_event_schedule"
+        serializer_class = ApplicationEventScheduleResultUpdateSerializer

--- a/api/graphql/applications/application_types.py
+++ b/api/graphql/applications/application_types.py
@@ -31,9 +31,10 @@ from permissions.api_permissions.graphene_field_decorators import (
 )
 from permissions.api_permissions.graphene_permissions import (
     AddressPermission,
+    ApplicationEventScheduleResultPermission,
     ApplicationPermission,
     CityPermission,
-    OrganisationPermission, ApplicationEventScheduleResultPermission,
+    OrganisationPermission,
 )
 from spaces.models import Space
 from utils.query_performance import QueryPerformanceOptimizerMixin

--- a/api/graphql/applications/application_types.py
+++ b/api/graphql/applications/application_types.py
@@ -33,7 +33,7 @@ from permissions.api_permissions.graphene_permissions import (
     AddressPermission,
     ApplicationPermission,
     CityPermission,
-    OrganisationPermission,
+    OrganisationPermission, ApplicationEventScheduleResultPermission,
 )
 from spaces.models import Space
 from utils.query_performance import QueryPerformanceOptimizerMixin
@@ -167,6 +167,10 @@ class ApplicationEventScheduleType(AuthNode, PrimaryKeyObjectType):
         filter_fields = ()
         interfaces = (graphene.relay.Node,)
         connection_class = TilavarausBaseConnection
+
+    @check_resolver_permission(ApplicationEventScheduleResultPermission)
+    def resolve_application_event_schedule_result(self, info: graphene.ResolveInfo):
+        return getattr(self, "application_event_schedule_result", None)
 
 
 class EventReservationUnitType(AuthNode, PrimaryKeyObjectType):

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -123,6 +123,8 @@ from .application_rounds.application_round_types import ApplicationRoundType
 from .applications.application_mutations import (
     ApplicationEventCreateMutation,
     ApplicationEventDeleteMutation,
+    ApplicationEventScheduleResultCreateMutation,
+    ApplicationEventScheduleResultUpdateMutation,
     ApplicationEventUpdateMutation,
 )
 
@@ -508,6 +510,13 @@ class Mutation(graphene.ObjectType):
     create_application_event = ApplicationEventCreateMutation.Field()
     update_application_event = ApplicationEventUpdateMutation.Field()
     delete_application_event = ApplicationEventDeleteMutation.Field()
+
+    create_application_event_schedule_result = (
+        ApplicationEventScheduleResultCreateMutation.Field()
+    )
+    update_application_event_schedule_result = (
+        ApplicationEventScheduleResultUpdateMutation.Field()
+    )
 
     create_reservation = ReservationCreateMutation.Field()
     update_reservation = ReservationUpdateMutation.Field()

--- a/api/graphql/tests/test_application_events/snapshots/snap_test_application_events_query.py
+++ b/api/graphql/tests/test_application_events/snapshots/snap_test_application_events_query.py
@@ -304,3 +304,51 @@ snapshots['ApplicationEventQueryTestCase::test_query_ok 1'] = {
         }
     }
 }
+
+snapshots['ApplicationEventScheduleResultQueryTestCase::test_schedule_results 1'] = {
+    'data': {
+        'applicationEvents': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEventSchedules': [
+                            {
+                                'applicationEventScheduleResult': {
+                                    'accepted': False,
+                                    'allocatedBegin': '12:00:00',
+                                    'allocatedDay': 'MONDAY',
+                                    'allocatedEnd': '14:00:00',
+                                    'allocatedReservationUnit': {
+                                        'nameFi': 'You got this reservation unit'
+                                    },
+                                    'declined': False
+                                },
+                                'begin': '12:00:00',
+                                'day': 1,
+                                'end': '13:00:00',
+                                'priority': 300
+                            },
+                            {
+                                'applicationEventScheduleResult': None,
+                                'begin': '13:00:00',
+                                'day': 2,
+                                'end': '14:00:00',
+                                'priority': 200
+                            },
+                            {
+                                'applicationEventScheduleResult': None,
+                                'begin': '14:00:00',
+                                'day': 3,
+                                'end': '15:00:00',
+                                'priority': 100
+                            }
+                        ],
+                        'name': 'Test application',
+                        'numPersons': 10,
+                        'status': 'created'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_application_events/snapshots/snap_test_application_events_query_permissions.py
+++ b/api/graphql/tests/test_application_events/snapshots/snap_test_application_events_query_permissions.py
@@ -7,6 +7,108 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['ApplicationEventScheduleResultQueryPermissionsTestCase::test_general_admin_can_see_schedule_result 1'] = {
+    'data': {
+        'applicationEvents': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEventSchedules': [
+                            {
+                                'applicationEventScheduleResult': {
+                                    'accepted': False
+                                }
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationEventScheduleResultQueryPermissionsTestCase::test_regular_user_cannot_see_schedule_result 1'] = {
+    'data': {
+        'applicationEvents': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEventSchedules': [
+                            {
+                                'applicationEventScheduleResult': None
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationEventScheduleResultQueryPermissionsTestCase::test_service_sector_admin_can_see_schedule_result 1'] = {
+    'data': {
+        'applicationEvents': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEventSchedules': [
+                            {
+                                'applicationEventScheduleResult': {
+                                    'accepted': False
+                                }
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ApplicationEventScheduleResultQueryPermissionsTestCase::test_unit_admin_can_see_schedule_result 1'] = {
+    'data': {
+        'applicationEvents': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationEventSchedules': [
+                            {
+                                'applicationEventScheduleResult': {
+                                    'accepted': False
+                                }
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            },
+                            {
+                                'applicationEventScheduleResult': None
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['ApplicationEventsGraphQLPermissionsTestCase::test_regular_user_can_view_only_own_applications_event 1'] = {
     'data': {
         'applicationEvents': {

--- a/api/graphql/tests/test_application_events/test_application_event_schedule_result_create.py
+++ b/api/graphql/tests/test_application_events/test_application_event_schedule_result_create.py
@@ -1,0 +1,180 @@
+import datetime
+import json
+
+from assertpy import assert_that
+from django.contrib.auth import get_user_model
+
+from api.graphql.tests.test_application_events.base import (
+    ApplicationEventPermissionsTestCaseBase,
+)
+from applications.models import ApplicationEventScheduleResult
+from applications.tests.factories import ApplicationFactory
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import (
+    AbilityGroupFactory,
+    AgeGroupFactory,
+    ReservationPurposeFactory,
+)
+from spaces.tests.factories import ServiceSectorFactory
+
+
+class ApplicationEventScheduleResultCreateTestCase(
+    ApplicationEventPermissionsTestCaseBase
+):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.age_group = AgeGroupFactory()
+        cls.application_too = ApplicationFactory(user=cls.regular_joe)
+        cls.purpose = ReservationPurposeFactory()
+        cls.ability_group = AbilityGroupFactory()
+        cls.reservation_unit = ReservationUnitFactory()
+
+        cls.other_user = get_user_model().objects.create(
+            username="other",
+            first_name="oth",
+            last_name="er",
+            email="oth.er@foo.com",
+        )
+        cls.application_event = cls.application.application_events.first()
+        cls.schedule = cls.application_event.application_event_schedules.filter(
+            priority=300
+        ).first()
+
+    def get_create_query(self):
+        return """
+            mutation createApplicationEventScheduleResult($input: ApplicationEventScheduleResultCreateMutationInput!) {
+                createApplicationEventScheduleResult(input: $input){
+                    applicationEventSchedule
+                    errors {
+                        messages field
+                    }
+                }
+            }
+        """
+
+    def get_data(self):
+        return {
+            "applicationEventSchedule": self.schedule.id,
+            "allocatedReservationUnit": self.reservation_unit.id,
+        }
+
+    def test_create_result(self):
+        data = {
+            "accepted": True,
+            "declined": True,
+            "allocatedDay": 1,
+            "allocatedBegin": "10:00",
+            "allocatedEnd": "12:00",
+            "applicationEventSchedule": self.schedule.id,
+            "allocatedReservationUnit": self.reservation_unit.id,
+        }
+        assert_that(
+            getattr(self.schedule, "application_event_schedule_result", None)
+        ).is_none()
+        self.client.force_login(self.general_admin)
+
+        response = self.query(self.get_create_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        app_event_data = content.get("data").get("createApplicationEventScheduleResult")
+        assert_that(content.get("errors")).is_none()
+        assert_that(app_event_data.get("errors")).is_none()
+
+        self.schedule.refresh_from_db()
+        assert_that(
+            getattr(self.schedule, "application_event_schedule_result", None)
+        ).is_not_none()
+
+        result = ApplicationEventScheduleResult.objects.get(pk=self.schedule.id)
+
+        assert_that(result.application_event_schedule.id).is_equal_to(self.schedule.id)
+        assert_that(result.allocated_begin).is_equal_to(
+            datetime.time.fromisoformat(data["allocatedBegin"])
+        )
+        assert_that(result.allocated_end).is_equal_to(
+            datetime.time.fromisoformat(data["allocatedEnd"])
+        )
+        assert_that(result.allocated_reservation_unit.id).is_equal_to(
+            data["allocatedReservationUnit"]
+        )
+        assert_that(result.allocated_day).is_equal_to(data["allocatedDay"])
+        assert_that(result.allocated_duration).is_equal_to(datetime.timedelta(hours=2))
+        assert_that(result.accepted).is_equal_to(data["accepted"])
+        assert_that(result.declined).is_equal_to(data["declined"])
+
+    def test_create_result_with_empty_data_uses_schedule_data(self):
+        assert_that(
+            getattr(self.schedule, "application_event_schedule_result", None)
+        ).is_none()
+        self.client.force_login(self.general_admin)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        app_event_data = content.get("data").get("createApplicationEventScheduleResult")
+        assert_that(content.get("errors")).is_none()
+        assert_that(app_event_data.get("errors")).is_none()
+
+        self.schedule.refresh_from_db()
+
+        result = ApplicationEventScheduleResult.objects.get(pk=self.schedule.id)
+
+        assert_that(result.application_event_schedule.id).is_equal_to(self.schedule.id)
+        assert_that(result.allocated_begin).is_equal_to(self.schedule.begin)
+        assert_that(result.allocated_end).is_equal_to(self.schedule.end)
+        assert_that(result.allocated_reservation_unit.id).is_equal_to(
+            self.reservation_unit.id
+        )
+        assert_that(result.allocated_day).is_equal_to(self.schedule.day)
+        assert_that(result.allocated_duration).is_equal_to(datetime.timedelta(hours=1))
+        assert_that(result.accepted).is_false()
+        assert_that(result.declined).is_false()
+
+    def test_application_user_cannot_create_result(self):
+        assert_that(
+            getattr(self.schedule, "application_event_schedule_result", None)
+        ).is_none()
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+        assert_that(
+            ApplicationEventScheduleResult.objects.filter(pk=self.schedule.id).exists()
+        ).is_false()
+
+    def test_service_sector_admin_can_create_result(self):
+        service_sector_admin = self.create_service_sector_admin()
+        self.client.force_login(service_sector_admin)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        app_event_data = content.get("data").get("createApplicationEventScheduleResult")
+        assert_that(content.get("errors")).is_none()
+        assert_that(app_event_data.get("errors")).is_none()
+
+        self.schedule.refresh_from_db()
+
+        result = ApplicationEventScheduleResult.objects.get(pk=self.schedule.id)
+
+        assert_that(result.application_event_schedule.id).is_equal_to(self.schedule.id)
+
+    def test_wrong_service_sector_admin_cannot_create_result(
+        self,
+    ):
+        service_sector_admin = self.create_service_sector_admin(
+            service_sector=ServiceSectorFactory()
+        )
+        self.client.force_login(service_sector_admin)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+        assert_that(
+            ApplicationEventScheduleResult.objects.filter(pk=self.schedule.id).exists()
+        ).is_false()

--- a/api/graphql/tests/test_application_events/test_application_event_schedule_result_update.py
+++ b/api/graphql/tests/test_application_events/test_application_event_schedule_result_update.py
@@ -1,0 +1,145 @@
+import datetime
+import json
+
+from assertpy import assert_that
+from django.contrib.auth import get_user_model
+
+from api.graphql.tests.test_application_events.base import (
+    ApplicationEventPermissionsTestCaseBase,
+)
+from applications.tests.factories import (
+    ApplicationEventScheduleResultFactory,
+    ApplicationFactory,
+)
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import (
+    AbilityGroupFactory,
+    AgeGroupFactory,
+    ReservationPurposeFactory,
+)
+from spaces.tests.factories import ServiceSectorFactory
+
+
+class ApplicationEventScheduleResultUpdateTestCase(
+    ApplicationEventPermissionsTestCaseBase
+):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        cls.age_group = AgeGroupFactory()
+        cls.application_too = ApplicationFactory(user=cls.regular_joe)
+        cls.purpose = ReservationPurposeFactory()
+        cls.ability_group = AbilityGroupFactory()
+        cls.reservation_unit = ReservationUnitFactory()
+
+        cls.other_user = get_user_model().objects.create(
+            username="other",
+            first_name="oth",
+            last_name="er",
+            email="oth.er@foo.com",
+        )
+        cls.application_event = cls.application.application_events.first()
+        cls.schedule = cls.application_event.application_event_schedules.filter(
+            priority=300
+        ).first()
+        cls.result = ApplicationEventScheduleResultFactory(
+            accepted=False,
+            declined=False,
+            allocated_day=1,
+            allocated_begin=cls.schedule.begin,
+            allocated_end=cls.schedule.end,
+            application_event_schedule=cls.schedule,
+            allocated_reservation_unit=cls.reservation_unit,
+        )
+
+    def get_create_query(self):
+        return """
+            mutation updateApplicationEventScheduleResult($input: ApplicationEventScheduleResultUpdateMutationInput!) {
+                updateApplicationEventScheduleResult(input: $input){
+                    applicationEventSchedule
+                    errors {
+                        messages field
+                    }
+                }
+            }
+        """
+
+    def get_data(self):
+        return {
+            "accepted": True,
+            "applicationEventSchedule": self.schedule.id,
+            "allocatedReservationUnit": self.reservation_unit.id,
+        }
+
+    def test_update_result_updates_only_given_fields(self):
+        data = self.get_data()
+        data["declined"] = True
+
+        self.client.force_login(self.general_admin)
+
+        response = self.query(self.get_create_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        app_event_data = content.get("data").get("updateApplicationEventScheduleResult")
+        assert_that(content.get("errors")).is_none()
+        assert_that(app_event_data.get("errors")).is_none()
+
+        self.schedule.refresh_from_db()
+        self.result.refresh_from_db()
+
+        assert_that(self.result.application_event_schedule.id).is_equal_to(
+            self.schedule.id
+        )
+        assert_that(self.result.allocated_begin).is_equal_to(self.schedule.begin)
+        assert_that(self.result.allocated_end).is_equal_to(self.schedule.end)
+        assert_that(self.result.allocated_reservation_unit.id).is_equal_to(
+            self.reservation_unit.id
+        )
+        assert_that(self.result.allocated_day).is_equal_to(self.schedule.day)
+        assert_that(self.result.allocated_duration).is_equal_to(
+            datetime.timedelta(hours=1)
+        )
+        assert_that(self.result.accepted).is_true()
+        assert_that(self.result.declined).is_true()
+
+    def test_application_user_cannot_update_result(self):
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+
+        self.result.refresh_from_db()
+        assert_that(self.result.accepted).is_false()
+
+    def test_service_sector_admin_can_update_result(self):
+        service_sector_admin = self.create_service_sector_admin()
+        self.client.force_login(service_sector_admin)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        app_event_data = content.get("data").get("updateApplicationEventScheduleResult")
+        assert_that(content.get("errors")).is_none()
+        assert_that(app_event_data.get("errors")).is_none()
+
+        self.result.refresh_from_db()
+        assert_that(self.result.accepted).is_true()
+
+    def test_wrong_service_sector_admin_cannot_update_result(
+        self,
+    ):
+        service_sector_admin = self.create_service_sector_admin(
+            service_sector=ServiceSectorFactory()
+        )
+        self.client.force_login(service_sector_admin)
+
+        response = self.query(self.get_create_query(), input_data=self.get_data())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+
+        self.result.refresh_from_db()
+        assert_that(self.result.accepted).is_false()

--- a/applications/models.py
+++ b/applications/models.py
@@ -32,14 +32,16 @@ logger = logging.getLogger(__name__)
 User = get_user_model()
 
 DAY_CHOICES = (
-    (0, _("Monday")),
-    (1, _("Tuesday")),
-    (2, _("Wednesday")),
-    (3, _("Thursday")),
-    (4, _("Friday")),
-    (5, _("Saturday")),
-    (6, _("Sunday")),
+    (0, "Monday"),
+    (1, "Tuesday"),
+    (2, "Wednesday"),
+    (3, "Thursday"),
+    (4, "Friday"),
+    (5, "Saturday"),
+    (6, "Sunday"),
 )
+
+TRANSLATED_DAY_CHOICES = tuple((k, _(v)) for k, v in DAY_CHOICES)
 
 
 def year_not_in_future(year: Optional[int]):
@@ -1228,7 +1230,9 @@ class EventOccurrence(object):
 
 
 class ApplicationEventSchedule(models.Model):
-    day = models.IntegerField(verbose_name=_("Day"), choices=DAY_CHOICES, null=False)
+    day = models.IntegerField(
+        verbose_name=_("Day"), choices=TRANSLATED_DAY_CHOICES, null=False
+    )
 
     begin = models.TimeField(
         verbose_name=_("Start"),
@@ -1330,7 +1334,7 @@ class ApplicationEventScheduleResult(models.Model):
 
     allocated_duration = models.DurationField()
     allocated_day = models.IntegerField(
-        verbose_name=_("Day"), choices=DAY_CHOICES, null=False
+        verbose_name=_("Day"), choices=TRANSLATED_DAY_CHOICES, null=False
     )
 
     allocated_begin = models.TimeField(


### PR DESCRIPTION
Adds `ApplicationEventScheduleResult` to GraphQl. 
This can be queried through `ApplicationEventSchedule` in `ApplicationEventType`

Adds mutations to create and edit `ApplicationEventScheduleResult`s 

TILA-1758