### PR TITLE
TILA-1736 | Remove obsolete id references and change necessary to pk

### DIFF
--- a/api/graphql/applications/application_types.py
+++ b/api/graphql/applications/application_types.py
@@ -127,8 +127,6 @@ class EventReservationUnitType(AuthNode, PrimaryKeyObjectType):
         (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
     )
 
-    reservation_unit_id = graphene.Int()
-
     reservation_unit = graphene.Field(ReservationUnitType)
 
     class Meta:
@@ -136,7 +134,6 @@ class EventReservationUnitType(AuthNode, PrimaryKeyObjectType):
         fields = (
             "id",
             "priority",
-            "reservation_unit_id",
             "reservation_unit",
         )
         filter_fields = ()
@@ -151,11 +148,6 @@ class ApplicationEventType(AuthNode, PrimaryKeyObjectType):
     permission_classes = (
         (AllowAuthenticated,) if not settings.TMP_PERMISSIONS_DISABLED else [AllowAny]
     )
-
-    age_group_id = graphene.Int()
-    ability_group_id = graphene.Int()
-    application_id = graphene.Int()
-    purpose_id = graphene.Int()
 
     application_event_schedules = graphene.List(ApplicationEventScheduleType)
 
@@ -179,16 +171,12 @@ class ApplicationEventType(AuthNode, PrimaryKeyObjectType):
             "id",
             "name",
             "num_persons",
-            "age_group_id",
-            "ability_group_id",
             "min_duration",
             "max_duration",
-            "application_id",
             "events_per_week",
             "biweekly",
             "begin",
             "end",
-            "purpose_id",
             "uuid",
             "status",
             "application_event_schedules",
@@ -196,7 +184,7 @@ class ApplicationEventType(AuthNode, PrimaryKeyObjectType):
             "ability_group",
             "purpose",
             "event_reservation_units",
-            "declined_reservation_unit_ids",
+            "declined_reservation_units",
             "weekly_amount_reductions_count",
             "aggregated_data",
         )
@@ -243,8 +231,6 @@ class ApplicationType(QueryPerformanceOptimizerMixin, AuthNode, PrimaryKeyObject
 
     organisation = graphene.Field(OrganisationType)
 
-    application_round_id = graphene.Int()
-
     application_events = graphene.List(ApplicationEventType)
 
     status = graphene.Field(
@@ -258,7 +244,7 @@ class ApplicationType(QueryPerformanceOptimizerMixin, AuthNode, PrimaryKeyObject
 
     billing_address = graphene.Field(AddressType)
 
-    applicant_id = graphene.Int()
+    applicant_pk = graphene.Int()
     applicant_name = graphene.String()
     applicant_email = graphene.String()
 
@@ -268,12 +254,13 @@ class ApplicationType(QueryPerformanceOptimizerMixin, AuthNode, PrimaryKeyObject
         model = Application
         fields = (
             "id",
+            "pk",
             "applicant_type",
-            "applicant_id",
+            "applicant_pk",
             "applicant_name",
             "applicant_email",
             "organisation",
-            "application_round_id",
+            "application_round",
             "contact_person",
             "application_events",
             "status",
@@ -387,7 +374,7 @@ class ApplicationType(QueryPerformanceOptimizerMixin, AuthNode, PrimaryKeyObject
             ),
         }
 
-    def resolve_applicant_id(self, info: graphene.ResolveInfo):
+    def resolve_applicant_pk(self, info: graphene.ResolveInfo):
         if not self.user:
             return None
 


### PR DESCRIPTION
In application graphql types there was some *_id fields declared which
we don't need in graphql since we can just add the corresponding
relative type.
This removes the id fields and introduces relatative types if needed and
changes one id to _pk which is what we prefer.

TILA-1736