### PR TITLE
TILA-1743: Fix flaky reservation test

### DIFF
--- a/api/graphql/tests/test_reservations/snapshots/snap_base.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_base.py
@@ -76,6 +76,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission 1'] = {
                         'description': 'movies&popcorn',
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': 'This is some reason.',
+                        'name': 'movies',
                         'reserveeAddressCity': 'Helsinki',
                         'reserveeAddressStreet': 'Mannerheimintie 2',
                         'reserveeAddressZip': '00100',
@@ -112,6 +113,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'description': 'something super secret',
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': 'Only admins can see me.',
+                        'name': 'admin movies',
                         'reserveeAddressCity': 'Nowhere',
                         'reserveeAddressStreet': 'Mystery street 2',
                         'reserveeAddressZip': '00100',
@@ -138,6 +140,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'description': 'movies&popcorn',
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': 'This is some reason.',
+                        'name': 'movies',
                         'reserveeAddressCity': 'Helsinki',
                         'reserveeAddressStreet': 'Mannerheimintie 2',
                         'reserveeAddressZip': '00100',
@@ -220,32 +223,6 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                 {
                     'node': {
                         'begin': '2021-10-12T12:00:00+00:00',
-                        'billingAddressCity': 'Turku',
-                        'billingAddressStreet': 'Aurakatu 12B',
-                        'billingAddressZip': '20100',
-                        'billingEmail': 'billing@example.com',
-                        'billingFirstName': 'Reser',
-                        'billingLastName': 'Vee',
-                        'billingPhone': '+358234567890',
-                        'cancelDetails': '',
-                        'description': 'movies&popcorn',
-                        'end': '2021-10-12T13:00:00+00:00',
-                        'freeOfChargeReason': 'This is some reason.',
-                        'reserveeAddressCity': 'Helsinki',
-                        'reserveeAddressStreet': 'Mannerheimintie 2',
-                        'reserveeAddressZip': '00100',
-                        'reserveeEmail': 'reservee@example.com',
-                        'reserveeFirstName': 'Reser',
-                        'reserveeId': '5727586-5',
-                        'reserveeLastName': 'Vee',
-                        'reserveeOrganisationName': 'Test organisation',
-                        'reserveePhone': '+358123456789',
-                        'user': 'joe.regularl@foo.com'
-                    }
-                },
-                {
-                    'node': {
-                        'begin': '2021-10-12T12:00:00+00:00',
                         'billingAddressCity': None,
                         'billingAddressStreet': None,
                         'billingAddressZip': None,
@@ -257,6 +234,7 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'description': None,
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': None,
+                        'name': 'admin movies',
                         'reserveeAddressCity': None,
                         'reserveeAddressStreet': None,
                         'reserveeAddressZip': None,
@@ -267,6 +245,33 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'reserveeOrganisationName': None,
                         'reserveePhone': None,
                         'user': None
+                    }
+                },
+                {
+                    'node': {
+                        'begin': '2021-10-12T12:00:00+00:00',
+                        'billingAddressCity': 'Turku',
+                        'billingAddressStreet': 'Aurakatu 12B',
+                        'billingAddressZip': '20100',
+                        'billingEmail': 'billing@example.com',
+                        'billingFirstName': 'Reser',
+                        'billingLastName': 'Vee',
+                        'billingPhone': '+358234567890',
+                        'cancelDetails': '',
+                        'description': 'movies&popcorn',
+                        'end': '2021-10-12T13:00:00+00:00',
+                        'freeOfChargeReason': 'This is some reason.',
+                        'name': 'movies',
+                        'reserveeAddressCity': 'Helsinki',
+                        'reserveeAddressStreet': 'Mannerheimintie 2',
+                        'reserveeAddressZip': '00100',
+                        'reserveeEmail': 'reservee@example.com',
+                        'reserveeFirstName': 'Reser',
+                        'reserveeId': '5727586-5',
+                        'reserveeLastName': 'Vee',
+                        'reserveeOrganisationName': 'Test organisation',
+                        'reserveePhone': '+358123456789',
+                        'user': 'joe.regularl@foo.com'
                     }
                 }
             ],

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -44,7 +44,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             billing_address_zip="20100",
             billing_phone="+358234567890",
             billing_email="hidden.billing@example.com",
-            name="movies",
+            name="admin movies",
             description="something super secret",
             reservation_unit=[self.reservation_unit],
             begin=reservation_begin,
@@ -68,6 +68,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
                     totalCount
                     edges {
                         node {
+                            name
                             user
                             reserveeFirstName
                             reserveeLastName


### PR DESCRIPTION
I introduced some flaky tests in the previous PR. Tests were randomly failing because order of the results changed randomly. Now entries have different name and result is sorted by name so order should be always the same.