### PR TITLE
TILA-1773: Add pricing fields to Reservation Unit mutation.

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -18,6 +18,7 @@ from api.reservation_units_api import (
 from reservation_units.models import (
     Equipment,
     EquipmentCategory,
+    PricingType,
     Purpose,
     ReservationKind,
     ReservationUnit,
@@ -152,6 +153,12 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False,
         allow_null=True,
     )
+    pricing_terms_pk = serializers.PrimaryKeyRelatedField(
+        queryset=TermsOfUse.objects.filter(terms_type=TermsOfUse.TERMS_TYPE_PRICING),
+        source="pricing_terms",
+        required=False,
+        allow_null=True,
+    )
     cancellation_terms_pk = serializers.PrimaryKeyRelatedField(
         queryset=TermsOfUse.objects.filter(
             terms_type=TermsOfUse.TERMS_TYPE_CANCELLATION
@@ -235,6 +242,15 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         required=False, default=False, help_text="Is reservation unit archived"
     )
 
+    pricing_type = ChoiceCharField(
+        required=False,
+        choices=PricingType.choices,
+        help_text=(
+            "What kind of pricing type this reservation unit has. Possible values are "
+            f"{', '.join(value.upper() for value in PricingType)}."
+        ),
+    )
+
     translation_fields = get_all_translatable_fields(ReservationUnit)
 
     class Meta(ReservationUnitSerializer.Meta):
@@ -290,6 +306,9 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
             "allow_reservations_without_opening_hours",
             "is_archived",
             "state",
+            "pricing_terms_pk",
+            "pricing_terms",
+            "pricing_type",
         ] + get_all_translatable_fields(ReservationUnit)
 
     def __init__(self, *args, **kwargs):
@@ -302,6 +321,7 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         self.fields["payment_terms_pk"].write_only = True
         self.fields["cancellation_terms_pk"].write_only = True
         self.fields["service_specific_terms_pk"].write_only = True
+        self.fields["pricing_terms_pk"].write_only = True
         self.fields["tax_percentage_pk"].write_only = True
         self.fields["metadata_set_pk"].write_only = True
 

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -2596,6 +2596,9 @@ class ReservationUnitMutationsTestCaseBase(GrapheneTestCaseBase):
             name_sv="sv",
         )
         cls.metadata_set = ReservationMetadataSetFactory(name="Test form")
+        cls.pricing_term = TermsOfUseFactory(
+            name="Test pricing terms", terms_type=TermsOfUse.TERMS_TYPE_PRICING
+        )
 
     def setUp(self):
         self.client.force_login(self.general_admin)
@@ -2712,6 +2715,31 @@ class ReservationUnitCreateAsDraftTestCase(ReservationUnitMutationsTestCaseBase)
 
         res_unit = ReservationUnit.objects.first()
         assert_that(res_unit).is_none()
+
+    def test_create_with_pricing_fields(self):
+        self.client.force_login(self.general_admin)
+        data = {
+            "isDraft": True,
+            "nameFi": "Unit with pricing fields",
+            "unitPk": self.unit.id,
+            "pricingType": "PAID",
+            "pricingTermsPk": self.pricing_term.pk,
+        }
+        response = self.query(self.get_create_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("createReservationUnit").get("pk")
+        ).is_not_none()
+
+        created_unit = ReservationUnit.objects.get(
+            pk=content.get("data").get("createReservationUnit").get("pk")
+        )
+        assert_that(created_unit).is_not_none()
+        assert_that(created_unit.pricing_type).is_equal_to(PricingType.PAID)
+        assert_that(created_unit.pricing_terms).is_equal_to(self.pricing_term)
 
 
 class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBase):
@@ -3227,6 +3255,28 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
             ReservationKind.DIRECT_AND_SEASON
         )
 
+    def test_create_with_pricing_fields(self):
+        self.client.force_login(self.general_admin)
+        data = self.get_valid_data()
+        data["pricingType"] = "PAID"
+        data["pricingTermsPk"] = self.pricing_term.pk
+
+        response = self.query(self.get_create_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("createReservationUnit").get("pk")
+        ).is_not_none()
+
+        created_unit = ReservationUnit.objects.get(
+            pk=content.get("data").get("createReservationUnit").get("pk")
+        )
+        assert_that(created_unit).is_not_none()
+        assert_that(created_unit.pricing_type).is_equal_to(PricingType.PAID)
+        assert_that(created_unit.pricing_terms).is_equal_to(self.pricing_term)
+
 
 @override_settings(AUDIT_LOGGING_ENABLED=True)
 class ReservationUnitUpdateDraftTestCase(ReservationUnitMutationsTestCaseBase):
@@ -3470,6 +3520,28 @@ class ReservationUnitUpdateDraftTestCase(ReservationUnitMutationsTestCaseBase):
             content_type_id=content_type_id, object_id=self.res_unit.pk
         ).count()
         assert_that(log_entry_count).is_equal_to(1)
+
+    def test_update_with_pricing_fields(self):
+        self.client.force_login(self.general_admin)
+        data = self.get_valid_update_data()
+        data["pricingType"] = "PAID"
+        data["pricingTermsPk"] = self.pricing_term.pk
+
+        response = self.query(self.get_update_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("updateReservationUnit").get("pk")
+        ).is_not_none()
+
+        created_unit = ReservationUnit.objects.get(
+            pk=content.get("data").get("updateReservationUnit").get("pk")
+        )
+        assert_that(created_unit).is_not_none()
+        assert_that(created_unit.pricing_type).is_equal_to(PricingType.PAID)
+        assert_that(created_unit.pricing_terms).is_equal_to(self.pricing_term)
 
 
 class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase):
@@ -3963,3 +4035,25 @@ class ReservationUnitUpdateNotDraftTestCase(ReservationUnitMutationsTestCaseBase
 
         self.res_unit.refresh_from_db()
         assert_that(self.res_unit.min_persons).is_equal_to(1)
+
+    def test_update_with_pricing_fields(self):
+        self.client.force_login(self.general_admin)
+        data = self.get_valid_update_data()
+        data["pricingType"] = "PAID"
+        data["pricingTermsPk"] = self.pricing_term.pk
+
+        response = self.query(self.get_update_query(), input_data=data)
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data").get("updateReservationUnit").get("pk")
+        ).is_not_none()
+
+        created_unit = ReservationUnit.objects.get(
+            pk=content.get("data").get("updateReservationUnit").get("pk")
+        )
+        assert_that(created_unit).is_not_none()
+        assert_that(created_unit.pricing_type).is_equal_to(PricingType.PAID)
+        assert_that(created_unit.pricing_terms).is_equal_to(self.pricing_term)


### PR DESCRIPTION
Originally, I thought that the pricing fields are managed via Django Admin, but that assumption turned out to be wrong. So, now they are part of the mutations.

Refs TILA-1773