### PR TITLE
Set reservation to REQUIRES_HANDLING on subsidy

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -474,9 +474,14 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
     def validated_data(self):
         validated_data = super().validated_data
 
-        if self.instance.reservation_unit.filter(
+        reservation_unit_requires_handling = self.instance.reservation_unit.filter(
             require_reservation_handling=True
-        ).exists():
+        ).exists()
+
+        if (
+            reservation_unit_requires_handling
+            or self.instance.applying_for_free_of_charge
+        ):
             validated_data["state"] = STATE_CHOICES.REQUIRES_HANDLING
         else:
             validated_data["state"] = STATE_CHOICES.CONFIRMED


### PR DESCRIPTION
When reservation has applying_for_free_of_charge on, reservation is moved to REQUIRES_HANDLING state on confirm mutate call.

Refs TILA-1767