### PR TITLE
TILA-1639 | Reservations can be made to as long as reservation unit allows

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -157,6 +157,61 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
             )
         return value
 
+    def validate(self, data):
+        begin = data.get("begin", getattr(self.instance, "begin", None))
+        end = data.get("end", getattr(self.instance, "end", None))
+        begin = begin.astimezone(DEFAULT_TIMEZONE)
+        end = end.astimezone(DEFAULT_TIMEZONE)
+
+        reservation_units = data.get(
+            "reservation_unit", getattr(self.instance, "reservation_unit", None)
+        )
+        if hasattr(reservation_units, "all"):
+            reservation_units = reservation_units.all()
+
+        sku = None
+        for reservation_unit in reservation_units:
+            self.check_reservation_time(reservation_unit, begin, end)
+            self.check_reservation_overlap(reservation_unit, begin, end)
+            self.check_reservation_duration(reservation_unit, begin, end)
+            self.check_buffer_times(data, reservation_unit)
+            self.check_reservation_days_before(begin, reservation_unit)
+            self.check_max_reservations_per_user(
+                self.context.get("request").user, reservation_unit
+            )
+            self.check_sku(sku, reservation_unit.sku)
+            self.check_reservation_kind(reservation_unit)
+
+            # Scheduler dependent checks.
+            scheduler = ReservationUnitReservationScheduler(
+                reservation_unit, opening_hours_end=end.date()
+            )
+            self.check_opening_hours(scheduler, begin, end)
+            self.check_open_application_round(scheduler, begin, end)
+            self.check_reservation_start_time(begin, scheduler)
+
+            sku = reservation_unit.sku
+
+        data["sku"] = sku
+        data["state"] = STATE_CHOICES.CREATED
+        data[
+            "buffer_time_before"
+        ] = self._get_biggest_buffer_time_from_reservation_units(
+            "buffer_time_before", reservation_units
+        )
+        data[
+            "buffer_time_after"
+        ] = self._get_biggest_buffer_time_from_reservation_units(
+            "buffer_time_after", reservation_units
+        )
+        user = self.context.get("request").user
+        if settings.TMP_PERMISSIONS_DISABLED and user.is_anonymous:
+            user = None
+
+        data["user"] = user
+
+        return data
+
     def check_reservation_time(self, reservation_unit: ReservationUnit, begin, end):
         is_invalid_begin = (
             reservation_unit.reservation_begins
@@ -217,58 +272,6 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
             raise serializers.ValidationError(
                 "Reservation duration less than one or more reservation unit's minimum duration."
             )
-
-    def validate(self, data):
-        begin = data.get("begin", getattr(self.instance, "begin", None))
-        end = data.get("end", getattr(self.instance, "end", None))
-        begin = begin.astimezone(DEFAULT_TIMEZONE)
-        end = end.astimezone(DEFAULT_TIMEZONE)
-
-        reservation_units = data.get(
-            "reservation_unit", getattr(self.instance, "reservation_unit", None)
-        )
-        if hasattr(reservation_units, "all"):
-            reservation_units = reservation_units.all()
-
-        sku = None
-        for reservation_unit in reservation_units:
-            scheduler = ReservationUnitReservationScheduler(
-                reservation_unit, opening_hours_end=end.date()
-            )
-            self.check_reservation_time(reservation_unit, begin, end)
-            self.check_reservation_overlap(reservation_unit, begin, end)
-            self.check_opening_hours(scheduler, begin, end)
-            self.check_open_application_round(scheduler, begin, end)
-            self.check_reservation_duration(reservation_unit, begin, end)
-            self.check_buffer_times(data, reservation_unit)
-            self.check_reservation_days_before(begin, reservation_unit)
-            self.check_reservation_start_time(begin, scheduler)
-            self.check_max_reservations_per_user(
-                self.context.get("request").user, reservation_unit
-            )
-            self.check_sku(sku, reservation_unit.sku)
-            self.check_reservation_kind(reservation_unit)
-            sku = reservation_unit.sku
-
-        data["sku"] = sku
-        data["state"] = STATE_CHOICES.CREATED
-        data[
-            "buffer_time_before"
-        ] = self._get_biggest_buffer_time_from_reservation_units(
-            "buffer_time_before", reservation_units
-        )
-        data[
-            "buffer_time_after"
-        ] = self._get_biggest_buffer_time_from_reservation_units(
-            "buffer_time_after", reservation_units
-        )
-        user = self.context.get("request").user
-        if settings.TMP_PERMISSIONS_DISABLED and user.is_anonymous:
-            user = None
-
-        data["user"] = user
-
-        return data
 
     def _get_biggest_buffer_time_from_reservation_units(
         self, field: str, reservation_units: List[ReservationUnit]

--- a/api/graphql/tests/test_reservations/base.py
+++ b/api/graphql/tests/test_reservations/base.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional
+from typing import Dict, List, Optional
 
 import freezegun
 import snapshottest
@@ -35,7 +35,7 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
         self,
         reservation_unit: Optional[ReservationUnit] = None,
         date: Optional[datetime.date] = None,
-    ):
+    ) -> List[Dict]:
         if not reservation_unit:
             reservation_unit = self.reservation_unit
         if not date:

--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -153,12 +153,17 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
             datetime.datetime(2022, 1, 2, 10, 0).astimezone(DEFAULT_TIMEZONE)
         )
 
-    def test_application_round_is_open_no_opening_times_after(self, mock):
+    def test_application_round_is_open_no_opening_times_after_reservation_ends_date_passed(
+        self, mock
+    ):
         self.app_round.reservation_period_begin = datetime.date(2022, 1, 1)
         self.app_round.reservation_period_end = datetime.date(2022, 1, 2)
+        self.reservation_unit.reservation_ends = datetime.datetime(2021, 12, 31, 0)
+        self.reservation_unit.save()
         self.app_round.set_status(ApplicationRoundStatus.IN_REVIEW)
         self.app_round.save()
 
+        self.scheduler.__init__(self.reservation_unit, opening_hours_end=self.DATES[2])
         begin, end = self.scheduler.get_next_available_reservation_time()
         assert_that(begin).is_none()
         assert_that(end).is_none()
@@ -177,8 +182,12 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
         )
 
         begin, end = self.scheduler.get_next_available_reservation_time()
-        assert_that(begin).is_none()
-        assert_that(end).is_none()
+        assert_that(begin).is_equal_to(
+            datetime.datetime(2023, 7, 1, 10).astimezone(DEFAULT_TIMEZONE)
+        )
+        assert_that(end).is_equal_to(
+            datetime.datetime(2023, 7, 1, 11).astimezone(DEFAULT_TIMEZONE)
+        )
 
     def test_get_reservation_unit_possible_start_times(self, mock):
         start_date = datetime.date(2022, 1, 1)


### PR DESCRIPTION
... with a limitation of two years. 
Previously reservations could be made only to next spring because of the seasonal reservation applications etc. but since from that spec we have been introduced few fields in the ReservationUnit which we can use to determine these times.

Also fixes one buggy in the scheduler where scrolling time over daylight saving using timedelta and the timezone
diff did not get noticed and thus it resulted those cases the winter diff (+02.00 instead of +03:00

TILA-1639