### PR TITLE
TILA-1814: Add validation error with code class

### DIFF
--- a/api/graphql/application_errors.py
+++ b/api/graphql/application_errors.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import Optional
+
+from graphql.error import GraphQLError
+
+
+class ValidationErrorCodes(Enum):
+    pass
+
+
+class ValidationErrorWithCode(GraphQLError):
+    def __init__(
+        self,
+        message: str,
+        error_code: ValidationErrorCodes,
+        field: Optional[str] = None,
+    ) -> None:
+        super().__init__(message, None, None, None, None, None)
+        self.extensions = {
+            "error_code": error_code.value,
+            "field": field or "nonFieldError",
+        }


### PR DESCRIPTION
There is now a new `ValidationErrorWithCode` exception class that can be used as validation errors in cases where we want to have a machine-readable code addition to human-readable error message. The class is not yet used anywhere so this is just a preparation PR for the actual use-case.

I tried to find a way to extend existing `ValidationError` and failed miserably. However, I learned that the GraphQL "standard" is to use provided `GraphQLError` and add any additional data under `extensions` field. So this ended up being my approach.

This WILL change the error response so it might require some frontend changes but that is fine. I got a seal of approval from the frontend devs 🦭

Here is an example how the response changes.

Current:
```graphql
{
  "data": {
    "createReservation": {
      "errors": [
        {
          "messages": [
            "Reservation unit is not reservable within this reservation time."
          ],
          "field": "nonFieldErrors"
        }
      ],
      "pk": null,
      "begin": null,
      "end": null
    }
  }
}
```

New:
```graphql
{
  "errors": [
    {
      "message": "Reservation unit is not reservable within this reservation time.",
      "locations": [
        {
          "line": 11,
          "column": 3
        }
      ],
      "path": [
        "createReservation"
      ],
      "extensions": {
        "error_code": "RESERVATION_TIME_UNAVAILABLE",
        "field": "nonFieldError"
      }
    }
  ],
  "data": {
    "createReservation": null
  }
}
```
