### PR TITLE
TILA-1829: Add reservationUnit filter

### DIFF
--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -14,7 +14,7 @@ from permissions.helpers import (
     get_service_sectors_where_can_view_reservations,
     get_units_where_can_view_reservations,
 )
-from reservation_units.models import ReservationUnitType
+from reservation_units.models import ReservationUnit, ReservationUnitType
 from reservations.models import STATE_CHOICES, Reservation, User
 from spaces.models import ServiceSector, Unit
 
@@ -59,6 +59,10 @@ class ReservationFilterSet(django_filters.FilterSet):
 
     unit = django_filters.ModelMultipleChoiceFilter(
         method="get_unit", queryset=Unit.objects.all()
+    )
+
+    reservation_unit = django_filters.ModelMultipleChoiceFilter(
+        method="get_reservation_unit", queryset=ReservationUnit.objects.all()
     )
 
     reservation_unit_type = django_filters.ModelMultipleChoiceFilter(
@@ -165,6 +169,12 @@ class ReservationFilterSet(django_filters.FilterSet):
             return qs
 
         return qs.filter(reservation_unit__unit__in=value)
+
+    def get_reservation_unit(self, qs, property, value):
+        if not value:
+            return qs
+
+        return qs.filter(reservation_unit__in=value)
 
     def get_reservation_unit_type(self, qs, property, value):
         if not value:

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -43,6 +43,40 @@ snapshots['ReservationQueryTestCase::test_admin_can_read_working_memo 1'] = {
     }
 }
 
+snapshots['ReservationQueryTestCase::test_filter_by_multiple_reservation_unit 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'movies',
+                        'reservationUnits': [
+                            {
+                                'nameFi': 'resunit'
+                            }
+                        ],
+                        'reserveeFirstName': 'Reser',
+                        'reserveeLastName': 'Vee'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'Test reservation',
+                        'reservationUnits': [
+                            {
+                                'nameFi': 'other unit'
+                            }
+                        ],
+                        'reserveeFirstName': 'First',
+                        'reserveeLastName': 'Name'
+                    }
+                }
+            ],
+            'totalCount': 2
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_filter_by_price_gte 1'] = {
     'data': {
         'reservations': {
@@ -71,6 +105,40 @@ snapshots['ReservationQueryTestCase::test_filter_by_price_lte 1'] = {
                 }
             ],
             'totalCount': 1
+        }
+    }
+}
+
+snapshots['ReservationQueryTestCase::test_filter_by_reservation_unit 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'movies',
+                        'reservationUnits': [
+                            {
+                                'nameFi': 'resunit'
+                            }
+                        ],
+                        'reserveeFirstName': 'Reser',
+                        'reserveeLastName': 'Vee'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'Test reservation',
+                        'reservationUnits': [
+                            {
+                                'nameFi': 'resunit'
+                            }
+                        ],
+                        'reserveeFirstName': 'First',
+                        'reserveeLastName': 'Name'
+                    }
+                }
+            ],
+            'totalCount': 2
         }
     }
 }


### PR DESCRIPTION
Add a new filter to Reservations GQL query: reservationUnit. Filter supports arrays so multiple Reservation Unit PKs can be used as a filter.