### PR TITLE
TILA-1843: Update reservation time validation

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -429,6 +429,9 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
 
     def check_reservation_days_before(self, begin, reservation_unit):
         now = datetime.datetime.now().astimezone(get_default_timezone())
+        start_of_the_day = datetime.datetime.combine(now, datetime.time.min).astimezone(
+            get_default_timezone()
+        )
 
         if reservation_unit.reservations_max_days_before and now < (
             begin
@@ -439,7 +442,7 @@ class ReservationCreateSerializer(PrimaryKeySerializer):
                 ValidationErrorCodes.RESERVATION_NOT_WITHIN_ALLOWED_TIME_RANGE,
             )
 
-        if reservation_unit.reservations_min_days_before and now > (
+        if reservation_unit.reservations_min_days_before and start_of_the_day > (
             begin
             - datetime.timedelta(days=reservation_unit.reservations_min_days_before)
         ):

--- a/api/graphql/tests/test_reservations/base.py
+++ b/api/graphql/tests/test_reservations/base.py
@@ -42,6 +42,8 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
         self,
         reservation_unit: Optional[ReservationUnit] = None,
         date: Optional[datetime.date] = None,
+        start_hour: int = 6,
+        end_hour: int = 22,
     ) -> List[Dict]:
         if not reservation_unit:
             reservation_unit = self.reservation_unit
@@ -51,9 +53,15 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
         resource_id = f"{settings.HAUKI_ORIGIN_ID}:{reservation_unit.uuid}"
         origin_id = str(reservation_unit.uuid)
 
-        return [self._get_single_opening_hour_block(resource_id, origin_id, date)]
+        return [
+            self._get_single_opening_hour_block(
+                resource_id, origin_id, date, start_hour, end_hour
+            )
+        ]
 
-    def _get_single_opening_hour_block(self, resource_id, origin_id, date):
+    def _get_single_opening_hour_block(
+        self, resource_id, origin_id, date, start_hour, end_hour
+    ):
         return {
             "timezone": DEFAULT_TIMEZONE,
             "resource_id": resource_id,
@@ -61,8 +69,8 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
             "date": date,
             "times": [
                 TimeElement(
-                    start_time=datetime.time(hour=6),
-                    end_time=datetime.time(hour=22),
+                    start_time=datetime.time(hour=start_hour),
+                    end_time=datetime.time(hour=end_hour),
                     end_time_on_next_day=False,
                     resource_state=State.WITH_RESERVATION,
                     periods=[],


### PR DESCRIPTION
Reservations_min_days_before is not checked against current time
but the beginning of the current day. Previously, at 12:00 you could
only book a unit for the next day at 12:00, but now it is possible to
book it for 00:00 next day.

Similar logic is already done in the frontend.