### PR TITLE
Change exact search to iexact for searching from pk

### DIFF
--- a/reservation_units/admin.py
+++ b/reservation_units/admin.py
@@ -40,7 +40,7 @@ class ReservationUnitAdmin(admin.ModelAdmin):
     form = ReservationUnitAdminForm
     inlines = [ReservationUnitImageInline]
     readonly_fields = ["uuid"]
-    search_fields = ["name", "unit__name", "pk__exact", "unit__service_sectors__name"]
+    search_fields = ["name", "unit__name", "pk__iexact", "unit__service_sectors__name"]
 
 
 @admin.register(ReservationUnitImage)

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -546,7 +546,7 @@ class ReservationUnit(models.Model):
         ordering = ("id",)
 
     def __str__(self):
-        return "{}".format(self.name)
+        return "{}, {}".format(self.name, getattr(self.unit, "name", ""))
 
     def get_location(self):
         # For now we assume that if reservation has multiple spaces they all have same location


### PR DESCRIPTION
In reservation unit django admin autocomplete it had the autocomplete
field with pk__exact which caused all string searches to cause an error.
This can be solved by using iexact so it intreprets as string as well.

**EDIT**
added the unit's name to reservation unit's __str__ method to get it to django admin views.