### PR TITLE
TILA-1881 | Take into account unit_groups when getting viewable reservations

### DIFF
--- a/api/graphql/tests/test_reservations/base.py
+++ b/api/graphql/tests/test_reservations/base.py
@@ -17,7 +17,7 @@ from reservation_units.tests.factories import (
 )
 from reservations.models import ReservationMetadataField, ReservationMetadataSet
 from reservations.tests.factories import ReservationPurposeFactory
-from spaces.tests.factories import SpaceFactory, UnitFactory
+from spaces.tests.factories import SpaceFactory, UnitFactory, UnitGroupFactory
 
 DEFAULT_TIMEZONE = get_default_timezone()
 
@@ -57,6 +57,26 @@ class ReservationTestCaseBase(GrapheneTestCaseBase, snapshottest.TestCase):
 
         UnitRolePermission.objects.create(
             role=cls.unit_role_choice, permission="can_manage_reservations"
+        )
+
+        cls.reservation_viewer = get_user_model().objects.create(
+            username="res_viewer",
+            first_name="Reservation",
+            last_name="Viewer",
+            email="reservation.viewer@foo.com",
+            reservation_notification="ALL",
+        )
+        unit_group_viewer_role_choice = UnitRoleChoice.objects.get(code="viewer")
+
+        cls.unit_group_role = UnitRole.objects.create(
+            role=unit_group_viewer_role_choice, user=cls.reservation_viewer
+        )
+
+        cls.unit_group = UnitGroupFactory(units=[cls.unit])
+        cls.unit_group_role.unit_group.add(cls.unit_group)
+
+        UnitRolePermission.objects.create(
+            role=unit_group_viewer_role_choice, permission="can_view_reservations"
         )
 
     def get_mocked_opening_hours(

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -603,6 +603,70 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
     }
 }
 
+snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group_admin_viewer 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'begin': '2021-10-12T12:00:00+00:00',
+                        'billingAddressCity': 'Hidden',
+                        'billingAddressStreet': 'Privacy 12B',
+                        'billingAddressZip': '20100',
+                        'billingEmail': 'hidden.billing@example.com',
+                        'billingFirstName': 'Shouldbe',
+                        'billingLastName': 'Hidden',
+                        'billingPhone': '+358234567890',
+                        'cancelDetails': '',
+                        'description': 'something super secret',
+                        'end': '2021-10-12T13:00:00+00:00',
+                        'freeOfChargeReason': 'Only admins can see me.',
+                        'name': 'admin movies',
+                        'reserveeAddressCity': 'Nowhere',
+                        'reserveeAddressStreet': 'Mystery street 2',
+                        'reserveeAddressZip': '00100',
+                        'reserveeEmail': 'shouldbe.hidden@example.com',
+                        'reserveeFirstName': 'Shouldbe',
+                        'reserveeId': '5727586-5',
+                        'reserveeLastName': 'Hidden',
+                        'reserveeOrganisationName': 'Hidden organisation',
+                        'reserveePhone': '+358123456789',
+                        'user': 'amin.general@foo.com'
+                    }
+                },
+                {
+                    'node': {
+                        'begin': '2021-10-12T12:00:00+00:00',
+                        'billingAddressCity': 'Turku',
+                        'billingAddressStreet': 'Aurakatu 12B',
+                        'billingAddressZip': '20100',
+                        'billingEmail': 'billing@example.com',
+                        'billingFirstName': 'Reser',
+                        'billingLastName': 'Vee',
+                        'billingPhone': '+358234567890',
+                        'cancelDetails': '',
+                        'description': 'movies&popcorn',
+                        'end': '2021-10-12T13:00:00+00:00',
+                        'freeOfChargeReason': 'This is some reason.',
+                        'name': 'movies',
+                        'reserveeAddressCity': 'Helsinki',
+                        'reserveeAddressStreet': 'Mannerheimintie 2',
+                        'reserveeAddressZip': '00100',
+                        'reserveeEmail': 'reservee@example.com',
+                        'reserveeFirstName': 'Reser',
+                        'reserveeId': '5727586-5',
+                        'reserveeLastName': 'Vee',
+                        'reserveeOrganisationName': 'Test organisation',
+                        'reserveePhone': '+358123456789',
+                        'user': 'joe.regularl@foo.com'
+                    }
+                }
+            ],
+            'totalCount': 2
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_filter_requested 1'] = {
     'data': {
         'reservations': {

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -422,6 +422,19 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_filter_only_with_permission_unit_group_admin_viewer(self):
+        self.create_reservation_by_admin()
+
+        self.client.force_login(self.reservation_viewer)
+        response = self.query(
+            self.get_query_with_personal_fields(
+                """reservations(onlyWithPermission:true, orderBy:"name")"""
+            )
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
     def test_filter_by_user(self):
         self.create_reservation_by_admin()
         self.client.force_login(self.general_admin)

--- a/permissions/helpers.py
+++ b/permissions/helpers.py
@@ -255,6 +255,15 @@ def get_units_where_can_view_reservations(user: User) -> QuerySet:
     units = user.unit_roles.filter(
         role__permissions__permission=permission
     ).values_list("unit", flat=True)
+    unit_groups = user.unit_roles.filter(
+        role__permissions__permission=permission
+    ).values_list("unit_group")
+
+    units = (
+        Unit.objects.filter(Q(unit_groups__in=unit_groups) | Q(id__in=units))
+        .distinct()
+        .values_list("id", flat=True)
+    )
 
     return units
 


### PR DESCRIPTION
In permission helper function get_units_where_can_view_reservations gets units where user has permissions to view. It didin't take into account unit_groups.
This changes the function to get units from unit groups as well.

Refs TILA-1881