### PR TITLE
TILA-1882 | Add filter for units to filter only with_permission

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_units.py
+++ b/api/graphql/tests/snapshots/snap_test_units.py
@@ -7,7 +7,40 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
-snapshots['UnitsUpdateTestCase::test_getting_units 1'] = {
+snapshots['UnitsQueryTestCase::test_getting_only_with_permission_when_service_sector_admin 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Service sector unit'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsQueryTestCase::test_getting_only_with_permission_when_unit_admin 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test unit'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': "Show me! I'm from unit group"
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsQueryTestCase::test_getting_units 1'] = {
     'data': {
         'units': {
             'edges': [
@@ -39,7 +72,7 @@ snapshots['UnitsUpdateTestCase::test_getting_units 1'] = {
     }
 }
 
-snapshots['UnitsUpdateTestCase::test_getting_units_filtered_by_name 1'] = {
+snapshots['UnitsQueryTestCase::test_getting_units_filtered_by_name 1'] = {
     'data': {
         'units': {
             'edges': [
@@ -53,7 +86,7 @@ snapshots['UnitsUpdateTestCase::test_getting_units_filtered_by_name 1'] = {
     }
 }
 
-snapshots['UnitsUpdateTestCase::test_getting_units_filtered_by_service_sector 1'] = {
+snapshots['UnitsQueryTestCase::test_getting_units_filtered_by_service_sector 1'] = {
     'data': {
         'units': {
             'edges': [
@@ -72,7 +105,7 @@ snapshots['UnitsUpdateTestCase::test_getting_units_filtered_by_service_sector 1'
     }
 }
 
-snapshots['UnitsUpdateTestCase::test_getting_units_sorted_by_name_asc 1'] = {
+snapshots['UnitsQueryTestCase::test_getting_units_sorted_by_name_asc 1'] = {
     'data': {
         'units': {
             'edges': [
@@ -101,7 +134,7 @@ snapshots['UnitsUpdateTestCase::test_getting_units_sorted_by_name_asc 1'] = {
     }
 }
 
-snapshots['UnitsUpdateTestCase::test_getting_units_sorted_by_name_desc 1'] = {
+snapshots['UnitsQueryTestCase::test_getting_units_sorted_by_name_desc 1'] = {
     'data': {
         'units': {
             'edges': [

--- a/api/graphql/units/unit_filtersets.py
+++ b/api/graphql/units/unit_filtersets.py
@@ -1,4 +1,5 @@
 import django_filters
+from django.db.models import Q
 
 from .unit_types import Unit
 
@@ -13,6 +14,10 @@ class UnitsFilterSet(django_filters.FilterSet):
     name_sv = django_filters.CharFilter(field_name="name_sv", lookup_expr="istartswith")
     service_sector = django_filters.NumberFilter(field_name="service_sectors__pk")
 
+    only_with_permission = django_filters.BooleanFilter(
+        method="get_only_with_permission"
+    )
+
     order_by = django_filters.OrderingFilter(
         fields=("name_fi", "name_en", "name_sv", "rank")
     )
@@ -22,3 +27,23 @@ class UnitsFilterSet(django_filters.FilterSet):
             return qs.filter(id__in=[model.id for model in value])
 
         return qs
+
+    def get_only_with_permission(self, qs, property, value):
+        """Returns units where the user has any kind of permissions"""
+        if not value:
+            return qs
+
+        user = self.request.user
+        if user.is_anonymous:
+            return qs.none()
+        return qs.filter(
+            Q(id__in=user.unit_roles.values_list("unit", flat=True))
+            | Q(id__in=user.unit_roles.values_list("unit_group", flat=True))
+            | Q(
+                id__in=Unit.objects.filter(
+                    service_sectors__in=user.service_sector_roles.values_list(
+                        "service_sector", flat=True
+                    )
+                )
+            )
+        ).distinct()


### PR DESCRIPTION
With this filter api results only the units which the has some permission through service sector roles or unit roles.

Refs TILA-1882