### PR TITLE
TILA-1859: Document payment type codes

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_serializers.py
+++ b/api/graphql/reservation_units/reservation_unit_serializers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from django.core import validators
 from graphene.utils.str_converters import to_camel_case
 from rest_framework import serializers
@@ -37,15 +35,6 @@ from resources.models import Resource
 from services.models import Service
 from spaces.models import Space, Unit
 from terms_of_use.models import TermsOfUse
-
-
-def get_payment_type_codes() -> List[str]:
-    return list(
-        map(
-            lambda payment_type: payment_type.code,
-            ReservationUnitPaymentType.objects.all(),
-        )
-    )
 
 
 class EquipmentCreateSerializer(EquipmentSerializer, PrimaryKeySerializer):
@@ -276,10 +265,6 @@ class ReservationUnitCreateSerializer(ReservationUnitSerializer, PrimaryKeySeria
         ),
         allow_empty=True,
         required=False,
-        help_text=(
-            "What kind of payment types this reservation unit has. Possible values are "
-            f"{', '.join(value for value in get_payment_type_codes())}"
-        ),
     )
 
     translation_fields = get_all_translatable_fields(ReservationUnit)

--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -64,6 +64,15 @@ from reservation_units.utils.reservation_unit_reservation_scheduler import (
 )
 
 
+def get_payment_type_codes() -> List[str]:
+    return list(
+        map(
+            lambda payment_type: payment_type.code,
+            ReservationUnitPaymentType.objects.all(),
+        )
+    )
+
+
 class KeywordType(AuthNode, PrimaryKeyObjectType):
     class Meta:
         model = Keyword
@@ -288,7 +297,13 @@ class EquipmentType(AuthNode, PrimaryKeyObjectType):
 
 
 class ReservationUnitPaymentTypeType(AuthNode, PrimaryKeyObjectType):
-    code = graphene.Field(graphene.String)
+    code = graphene.Field(
+        graphene.String,
+        description=(
+            "Available values: "
+            f"{', '.join(value for value in get_payment_type_codes())}"
+        ),
+    )
 
     class Meta:
         model = ReservationUnitPaymentType


### PR DESCRIPTION
For some reason the `help_text` argument in the custom `ValidatingListField` does not work. I tried to check it with a debugger. The value is clearly set, but it does not show in the GraphiQL.

As a quick fix, I moved the documentation under `PaymentTypeType`. There it works with `description` parameter.