### PR TITLE
TILA-1837 | Add new filters to Units query

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_units.py
+++ b/api/graphql/tests/snapshots/snap_test_units.py
@@ -167,3 +167,22 @@ snapshots['UnitsQueryTestCase::test_getting_units_sorted_by_name_desc 1'] = {
         }
     }
 }
+
+snapshots['UnitsQueryTestCase::test_getting_units_with_published_reservation_units 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Include me A'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Include me B'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/snapshots/snap_test_units.py
+++ b/api/graphql/tests/snapshots/snap_test_units.py
@@ -45,6 +45,44 @@ snapshots['UnitsQueryTestCase::test_getting_only_with_permission_when_unit_admin
     }
 }
 
+snapshots['UnitsQueryTestCase::test_getting_own_reservations_false 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test unit'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': "I'm in a result as I should with Test unit."
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsQueryTestCase::test_getting_own_reservations_true 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Include me A'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Include me B'
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['UnitsQueryTestCase::test_getting_units 1'] = {
     'data': {
         'units': {
@@ -180,6 +218,30 @@ snapshots['UnitsQueryTestCase::test_getting_units_with_published_reservation_uni
                 {
                     'node': {
                         'nameFi': 'Include me B'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['UnitsQueryTestCase::test_order_by_own_reservation_count 1'] = {
+    'data': {
+        'units': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': "I'm first"
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': 'Then me'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': "I'm last."
                     }
                 }
             ]

--- a/api/graphql/tests/test_units.py
+++ b/api/graphql/tests/test_units.py
@@ -16,6 +16,7 @@ from permissions.models import (
     UnitRolePermission,
 )
 from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import ReservationFactory
 from spaces.models import Unit
 from spaces.tests.factories import ServiceSectorFactory, UnitFactory, UnitGroupFactory
 
@@ -318,6 +319,140 @@ class UnitsQueryTestCase(UnitTestCaseBase):
             """
             query {
                 units(publishedReservationUnits: true) {
+                    edges {
+                        node {
+                            nameFi
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_getting_own_reservations_true(self):
+        other_user = get_user_model().objects.create(
+            username="sapr",
+            first_name="Sam",
+            last_name="Sprite",
+            email="s.sprite@foo.com",
+        )
+        a_unit = UnitFactory(name="Include me A")
+        b_unit = UnitFactory(name="Include me B")
+        d_unit = UnitFactory(name="Don't you ever show me")
+
+        resu_a = ReservationUnitFactory(
+            unit=a_unit,
+        )
+        resu_b = ReservationUnitFactory(unit=b_unit)
+        resu_d = ReservationUnitFactory(unit=d_unit)
+        resu_too_d = ReservationUnitFactory(unit=d_unit)
+
+        ReservationFactory(reservation_unit=[resu_a], user=self.regular_joe)
+        ReservationFactory(reservation_unit=[resu_b], user=self.regular_joe)
+        ReservationFactory(reservation_unit=[resu_d], user=other_user)
+        ReservationFactory(reservation_unit=[resu_too_d], user=other_user)
+
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            """
+            query {
+                units(ownReservations: true) {
+                    edges {
+                        node {
+                            nameFi
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_getting_own_reservations_false(self):
+        other_user = get_user_model().objects.create(
+            username="sapr",
+            first_name="Sam",
+            last_name="Sprite",
+            email="s.sprite@foo.com",
+        )
+        a_unit = UnitFactory(name="Me you no see")
+        b_unit = UnitFactory(name="Me neither")
+        d_unit = UnitFactory(name="I'm in a result as I should with Test unit.")
+
+        resu_a = ReservationUnitFactory(
+            unit=a_unit,
+        )
+        resu_b = ReservationUnitFactory(unit=b_unit)
+        resu_d = ReservationUnitFactory(unit=d_unit)
+        resu_too_d = ReservationUnitFactory(unit=d_unit)
+
+        ReservationFactory(reservation_unit=[resu_a], user=self.regular_joe)
+        ReservationFactory(reservation_unit=[resu_b], user=self.regular_joe)
+        ReservationFactory(reservation_unit=[resu_d], user=other_user)
+        ReservationFactory(reservation_unit=[resu_too_d], user=other_user)
+
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            """
+            query {
+                units(ownReservations: false) {
+                    edges {
+                        node {
+                            nameFi
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_order_by_own_reservation_count(self):
+        other_user = get_user_model().objects.create(
+            username="sapr",
+            first_name="Sam",
+            last_name="Sprite",
+            email="s.sprite@foo.com",
+        )
+        no_unit = UnitFactory(name="Don't show me")
+        a_unit = UnitFactory(name="I'm first")
+        b_unit = UnitFactory(name="Then me")
+        l_unit = UnitFactory(name="I'm last.")
+
+        resu_a = ReservationUnitFactory(
+            unit=a_unit,
+        )
+        resu_b = ReservationUnitFactory(unit=b_unit)
+        resu_d = ReservationUnitFactory(unit=l_unit)
+        resu_too_d = ReservationUnitFactory(unit=l_unit)
+        no_resu = ReservationUnitFactory(unit=no_unit)
+
+        ReservationFactory.create_batch(
+            4, reservation_unit=[resu_a], user=self.regular_joe
+        )
+        ReservationFactory.create_batch(
+            3, reservation_unit=[resu_b], user=self.regular_joe
+        )
+        ReservationFactory(reservation_unit=[resu_d], user=self.regular_joe)
+        ReservationFactory.create_batch(
+            3, reservation_unit=[resu_too_d], user=other_user
+        )
+        ReservationFactory(reservation_unit=[no_resu], user=other_user)
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            """
+            query {
+                units(ownReservations: true orderBy: "-reservationCount") {
                     edges {
                         node {
                             nameFi


### PR DESCRIPTION
Adds filters for querying units with published reservation units and units with own reservation (and the possibility to order them by the count)

TILA-1837