### PR TITLE
TILA-1864: Task for scheduled pricing update

### DIFF
--- a/reservation_units/pricing_updates.py
+++ b/reservation_units/pricing_updates.py
@@ -1,0 +1,24 @@
+from datetime import date
+
+from .models import PricingStatus, ReservationUnitPricing
+
+
+def update_reservation_unit_pricings(today: date) -> int:
+    future_pricings = ReservationUnitPricing.objects.filter(
+        status=PricingStatus.PRICING_STATUS_FUTURE, begins=today
+    )
+    num_updated = 0
+    for future_pricing in future_pricings:
+        active_pricing = future_pricing.reservation_unit.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_ACTIVE
+        ).first()
+
+        if active_pricing is not None:
+            active_pricing.status = PricingStatus.PRICING_STATUS_PAST
+            active_pricing.save()
+
+        future_pricing.status = PricingStatus.PRICING_STATUS_ACTIVE
+        future_pricing.save()
+
+        num_updated += 1
+    return num_updated

--- a/reservation_units/tasks.py
+++ b/reservation_units/tasks.py
@@ -1,0 +1,16 @@
+from datetime import date
+from logging import getLogger
+
+from tilavarauspalvelu.celery import app
+
+from .pricing_updates import update_reservation_unit_pricings
+
+logger = getLogger(__name__)
+
+
+@app.task(name="update_reservation_unit_pricings")
+def _update_reservation_unit_pricings() -> None:
+    today = date.today()
+    logger.info(f"Updating reservation unit pricing with date {today}")
+    num_updated = update_reservation_unit_pricings()
+    logger.info(f"Updated {num_updated} reservation units with date {today}")

--- a/reservation_units/tests/test_pricing_updates.py
+++ b/reservation_units/tests/test_pricing_updates.py
@@ -1,0 +1,96 @@
+from datetime import date
+
+from assertpy import assert_that
+from django.test import TestCase
+
+from reservation_units.models import PricingStatus
+from reservation_units.pricing_updates import update_reservation_unit_pricings
+from reservation_units.tests.factories import (
+    ReservationUnitFactory,
+    ReservationUnitPricingFactory,
+)
+
+
+class PricingUpdatesTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.runit_1 = ReservationUnitFactory(name="Unit that should be updated")
+        ReservationUnitPricingFactory(
+            begins=date(2022, 1, 1),
+            status=PricingStatus.PRICING_STATUS_ACTIVE,
+            reservation_unit=cls.runit_1,
+        )
+        ReservationUnitPricingFactory(
+            begins=date(2022, 9, 19),
+            status=PricingStatus.PRICING_STATUS_FUTURE,
+            reservation_unit=cls.runit_1,
+        )
+
+        cls.runit_2 = ReservationUnitFactory(
+            name="Unit with future price with non-matching date"
+        )
+        ReservationUnitPricingFactory(
+            begins=date(2022, 1, 1),
+            status=PricingStatus.PRICING_STATUS_ACTIVE,
+            reservation_unit=cls.runit_2,
+        )
+        ReservationUnitPricingFactory(
+            begins=date(2022, 9, 20),
+            status=PricingStatus.PRICING_STATUS_FUTURE,
+            reservation_unit=cls.runit_2,
+        )
+
+        cls.runit_3 = ReservationUnitFactory(name="Unit without future price")
+        ReservationUnitPricingFactory(
+            begins=date(2022, 1, 1),
+            status=PricingStatus.PRICING_STATUS_ACTIVE,
+            reservation_unit=cls.runit_3,
+        )
+
+    def test_update_reservation_unit_pricings(self):
+        today = date(2022, 9, 19)
+        num_updated = update_reservation_unit_pricings(today)
+        assert_that(num_updated).is_equal_to(1)
+
+        self.runit_1.refresh_from_db()
+        self.runit_2.refresh_from_db()
+        self.runit_3.refresh_from_db()
+
+        active_pricing_1 = self.runit_1.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_ACTIVE
+        ).first()
+        future_pricing_1 = self.runit_1.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_FUTURE
+        ).first()
+        past_pricing_1 = self.runit_1.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_PAST
+        ).first()
+        assert_that(active_pricing_1.begins).is_equal_to(today)
+        assert_that(future_pricing_1).is_none()
+        assert_that(past_pricing_1.begins).is_equal_to(date(2022, 1, 1))
+
+        active_pricing_2 = self.runit_2.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_ACTIVE
+        ).first()
+        future_pricing_2 = self.runit_2.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_FUTURE
+        ).first()
+        past_pricing_2 = self.runit_2.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_PAST
+        ).first()
+        assert_that(active_pricing_2.begins).is_equal_to(date(2022, 1, 1))
+        assert_that(future_pricing_2.begins).is_equal_to(date(2022, 9, 20))
+        assert_that(past_pricing_2).is_none()
+
+        active_pricing_3 = self.runit_3.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_ACTIVE
+        ).first()
+        future_pricing_3 = self.runit_3.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_FUTURE
+        ).first()
+        past_pricing_3 = self.runit_3.pricings.filter(
+            status=PricingStatus.PRICING_STATUS_PAST
+        ).first()
+        assert_that(active_pricing_3.begins).is_equal_to(date(2022, 1, 1))
+        assert_that(future_pricing_3).is_none()
+        assert_that(past_pricing_3).is_none()


### PR DESCRIPTION
Adds a task which we can run once a day to update reservation unit pricings. Currently based on #607 so I'll update the PR after #607 is merged.