### PR TITLE
TILA-1927 | Remove ReservationPermission check from ReservationUnit type's reservations

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -33,7 +33,6 @@ from permissions.api_permissions.graphene_permissions import (
     EquipmentPermission,
     PurposePermission,
     QualifierPermission,
-    ReservationPermission,
     ReservationUnitCancellationRulePermission,
     ReservationUnitHaukiUrlPermission,
     ReservationUnitPermission,
@@ -476,7 +475,6 @@ class ReservationUnitType(AuthNode, PrimaryKeyObjectType):
     def resolve_payment_types(self, info):
         return self.payment_types.all()
 
-    @check_resolver_permission(ReservationPermission)
     def resolve_reservations(
         self,
         info: ResolveInfo,

--- a/api/graphql/tests/snapshots/snap_test_reservation_units.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_units.py
@@ -7,6 +7,45 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['ReservationUnitQueryTestCase::test_admin_sees_reservations_sensitive_information 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'reservations': [
+                            {
+                                'billingAddressCity': 'city',
+                                'billingAddressStreet': 'addr',
+                                'billingAddressZip': 'zip',
+                                'billingEmail': 'email',
+                                'billingFirstName': 'Joe',
+                                'billingLastName': 'Reggie',
+                                'billingPhone': 'phone',
+                                'cancelDetails': 'cancdetails',
+                                'description': 'description',
+                                'freeOfChargeReason': 'reason',
+                                'reserveeAddressCity': 'city',
+                                'reserveeAddressStreet': 'address',
+                                'reserveeAddressZip': 'zip',
+                                'reserveeEmail': 'email@localhost',
+                                'reserveeFirstName': 'Joe',
+                                'reserveeId': 'residee',
+                                'reserveeLastName': 'Reggie',
+                                'reserveeOrganisationName': 'org name',
+                                'reserveePhone': '123435',
+                                'staffEvent': False,
+                                'user': 'joe.regularl@foo.com',
+                                'workingMemo': 'Working this memo'
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+}
+
 snapshots['ReservationUnitQueryTestCase::test_filter_by_pk_multiple_values 1'] = {
     'data': {
         'reservationUnits': {
@@ -1525,6 +1564,45 @@ snapshots['ReservationUnitQueryTestCase::test_order_by_unit_reverse_order 1'] = 
                             'nameFi': '1',
                             'nameSv': '_'
                         }
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ReservationUnitQueryTestCase::test_other_reservations_does_not_show_sensitive_information 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'reservations': [
+                            {
+                                'billingAddressCity': None,
+                                'billingAddressStreet': None,
+                                'billingAddressZip': None,
+                                'billingEmail': None,
+                                'billingFirstName': None,
+                                'billingLastName': None,
+                                'billingPhone': None,
+                                'cancelDetails': None,
+                                'description': None,
+                                'freeOfChargeReason': None,
+                                'reserveeAddressCity': None,
+                                'reserveeAddressStreet': None,
+                                'reserveeAddressZip': None,
+                                'reserveeEmail': None,
+                                'reserveeFirstName': None,
+                                'reserveeId': None,
+                                'reserveeLastName': None,
+                                'reserveeOrganisationName': None,
+                                'reserveePhone': None,
+                                'staffEvent': None,
+                                'user': None,
+                                'workingMemo': None
+                            }
+                        ]
                     }
                 }
             ]

--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -2166,6 +2166,146 @@ class ReservationUnitQueryTestCase(ReservationUnitQueryTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_other_reservations_does_not_show_sensitive_information(self):
+        self.client.force_login(self.regular_joe)
+
+        ReservationFactory(
+            reservation_unit=[self.reservation_unit],
+            user=self.general_admin,
+            reservee_last_name="Admin",
+            reservee_first_name="General",
+            reservee_phone="123435",
+            working_memo="I should not be visible",
+            staff_event=False,
+            reservee_email="no_visible@localhost",
+            reservee_address_street="not visbile address",
+            reservee_address_city="not visible city",
+            reservee_address_zip="don't show this zip",
+            reservee_organisation_name="don't show org name",
+            free_of_charge_reason="do not display me",
+            billing_first_name="not visible bill first",
+            billing_last_name="not visible bill last",
+            billing_address_street="not visible bill addr",
+            billing_address_city="not visible city",
+            billing_address_zip="not visible billing zip",
+            billing_phone="not visible bill phone",
+            billing_email="not visible bill email",
+            description="not visible description",
+            reservee_id="novisible",
+            cancel_details="not visible cancel_details",
+        )
+
+        response = self.query(
+            """
+            query {
+                reservationUnits {
+                    edges {
+                        node {
+                            reservations {
+                                user
+                                reserveeLastName
+                                reserveeFirstName
+                                reserveePhone
+                                workingMemo
+                                staffEvent
+                                reserveeEmail
+                                reserveeAddressStreet
+                                reserveeAddressCity
+                                reserveeAddressZip
+                                reserveeOrganisationName
+                                freeOfChargeReason
+                                billingFirstName
+                                billingLastName
+                                billingAddressStreet
+                                billingAddressCity
+                                billingAddressZip
+                                billingPhone
+                                billingEmail
+                                description
+                                reserveeId
+                                cancelDetails
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_admin_sees_reservations_sensitive_information(self):
+        self.client.force_login(self.general_admin)
+
+        ReservationFactory(
+            reservation_unit=[self.reservation_unit],
+            user=self.regular_joe,
+            reservee_last_name="Reggie",
+            reservee_first_name="Joe",
+            reservee_phone="123435",
+            working_memo="Working this memo",
+            staff_event=False,
+            reservee_email="email@localhost",
+            reservee_address_street="address",
+            reservee_address_city="city",
+            reservee_address_zip="zip",
+            reservee_organisation_name="org name",
+            free_of_charge_reason="reason",
+            billing_first_name="Joe",
+            billing_last_name="Reggie",
+            billing_address_street="addr",
+            billing_address_city="city",
+            billing_address_zip="zip",
+            billing_phone="phone",
+            billing_email="email",
+            description="description",
+            reservee_id="residee",
+            cancel_details="cancdetails",
+        )
+
+        response = self.query(
+            """
+            query {
+                reservationUnits {
+                    edges {
+                        node {
+                            reservations {
+                                user
+                                reserveeLastName
+                                reserveeFirstName
+                                reserveePhone
+                                workingMemo
+                                staffEvent
+                                reserveeEmail
+                                reserveeAddressStreet
+                                reserveeAddressCity
+                                reserveeAddressZip
+                                reserveeOrganisationName
+                                freeOfChargeReason
+                                billingFirstName
+                                billingLastName
+                                billingAddressStreet
+                                billingAddressCity
+                                billingAddressZip
+                                billingPhone
+                                billingEmail
+                                description
+                                reserveeId
+                                cancelDetails
+                            }
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
 
 class ReservationUnitsFilterTextSearchTestCase(ReservationUnitQueryTestCaseBase):
     def test_filtering_by_type_fi(self):


### PR DESCRIPTION
In ReservationType there is field based field checks that checks should the field be visible or nulled so the reservation check can and should be removed since reservations are to be viewable without logged in

Refs TILA-1927
