### PR TITLE
TILA-1894 | Make email notification builder to respect timezones

### DIFF
--- a/email_notification/sender/email_notification_builder.py
+++ b/email_notification/sender/email_notification_builder.py
@@ -2,6 +2,7 @@ import re
 
 from django.conf import settings
 from django.template import Context, Template
+from django.utils.timezone import get_default_timezone
 
 from applications.models import CUSTOMER_TYPES
 from email_notification.models import EmailTemplate
@@ -56,16 +57,22 @@ class ReservationEmailNotificationBuilder:
         return self.reservation.reservee_organisation_name
 
     def _get_begin_date(self):
-        return self.reservation.begin.strftime("%d.%m.%Y")
+        return self.reservation.begin.astimezone(get_default_timezone()).strftime(
+            "%d.%m.%Y"
+        )
 
     def _get_begin_time(self):
-        return self.reservation.begin.strftime("%H:%M")
+        return self.reservation.begin.astimezone(get_default_timezone()).strftime(
+            "%H:%M"
+        )
 
     def _get_end_date(self):
-        return self.reservation.end.strftime("%d.%m.%Y")
+        return self.reservation.end.astimezone(get_default_timezone()).strftime(
+            "%d.%m.%Y"
+        )
 
     def _get_end_time(self):
-        return self.reservation.end.strftime("%H:%M")
+        return self.reservation.end.astimezone(get_default_timezone()).strftime("%H:%M")
 
     def _get_reservation_number(self):
         return str(self.reservation.pk).zfill(10)

--- a/email_notification/tests/test_notification_builders.py
+++ b/email_notification/tests/test_notification_builders.py
@@ -1,6 +1,9 @@
+import datetime
+
 from assertpy import assert_that
 from django.conf import settings
 from django.test import override_settings
+from pytz import UTC
 
 from applications.models import CUSTOMER_TYPES
 from email_notification.models import EmailTemplate, EmailType
@@ -42,8 +45,38 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
     def test_get_begin_time(self):
         assert_that(self.builder._get_begin_time()).is_equal_to("10:00")
 
+    def test_get_begin_time_respects_timezone(self):
+        self.reservation.begin = datetime.datetime(2022, 2, 28, 23, 00, tzinfo=UTC)
+        self.reservation.save()
+
+        assert_that(self.builder._get_begin_time()).is_equal_to("01:00")
+
     def test_get_begin_date(self):
         assert_that(self.builder._get_begin_date()).is_equal_to("09.02.2022")
+
+    def test_get_begin_date_respects_timezone(self):
+        self.reservation.begin = datetime.datetime(2022, 2, 28, 23, 00, tzinfo=UTC)
+        self.reservation.save()
+
+        assert_that(self.builder._get_begin_date()).is_equal_to("01.03.2022")
+
+    def test_get_end_time(self):
+        assert_that(self.builder._get_end_time()).is_equal_to("12:00")
+
+    def test_get_end_time_respects_timezone(self):
+        self.reservation.end = datetime.datetime(2022, 3, 1, 1, 00, tzinfo=UTC)
+        self.reservation.save()
+
+        assert_that(self.builder._get_end_time()).is_equal_to("03:00")
+
+    def test_get_end_date(self):
+        assert_that(self.builder._get_end_date()).is_equal_to("09.02.2022")
+
+    def test_get_end_date_respects_timezone(self):
+        self.reservation.end = datetime.datetime(2022, 2, 28, 23, 00, tzinfo=UTC)
+        self.reservation.save()
+
+        assert_that(self.builder._get_end_date()).is_equal_to("01.03.2022")
 
     def test_get_reservation_number(self):
         resno = str(self.reservation.id).zfill(10)


### PR DESCRIPTION
Previously the email notification builder was getting times and dates as is withouth taking into consideration the timezone. This changes that so it takes the timezone into account.

Refs TILA-1894