### PR TITLE
TILA-1895 | Remove reservation unit name from instructions in emails

### DIFF
--- a/email_notification/sender/email_notification_builder.py
+++ b/email_notification/sender/email_notification_builder.py
@@ -131,11 +131,9 @@ class ReservationEmailNotificationBuilder:
     def _get_reservation_unit_instruction_field(self, name):
         instructions = []
         for res_unit in self.reservation.reservation_unit.all():
-            instructions.append(
-                f"{self._get_by_language(res_unit, 'name')}: "
-                + self._get_by_language(res_unit, name)
-            )
-        return "\n".join(instructions)
+            instructions.append(self._get_by_language(res_unit, name))
+
+        return "\n-\n".join(instructions)
 
     def _get_deny_reason(self):
         return self._get_by_language(self.reservation.deny_reason, "reason")

--- a/email_notification/tests/test_notification_builders.py
+++ b/email_notification/tests/test_notification_builders.py
@@ -264,3 +264,66 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
         assert_that(self.builder._get_deny_reason()).is_equal_to(
             self.reservation.deny_reason.reason_fi
         )
+
+    def test_confirmed_instructions_renders(self):
+        content = """
+            This is the email message next one up we have confirmed_instructions.
+            {{ confirmed_instructions }}
+
+            Yours truly:
+            system.
+        """
+        compiled_content = f"""
+            This is the email message next one up we have confirmed_instructions.
+            {self.reservation_unit.reservation_confirmed_instructions}
+
+            Yours truly:
+            system.
+        """
+        template = EmailTemplateFactory(
+            type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject"
+        )
+        builder = ReservationEmailNotificationBuilder(self.reservation, template)
+        assert_that(builder.get_content()).is_equal_to(compiled_content)
+
+    def test_pending_instructions_renders(self):
+        content = """
+            This is the email message next one up we have confirmed_instructions.
+            {{ pending_instructions }}
+
+            Yours truly:
+            system.
+        """
+        compiled_content = f"""
+            This is the email message next one up we have confirmed_instructions.
+            {self.reservation_unit.reservation_pending_instructions}
+
+            Yours truly:
+            system.
+        """
+        template = EmailTemplateFactory(
+            type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject"
+        )
+        builder = ReservationEmailNotificationBuilder(self.reservation, template)
+        assert_that(builder.get_content()).is_equal_to(compiled_content)
+
+    def test_cancel_instructions_renders(self):
+        content = """
+            This is the email message next one up we have confirmed_instructions.
+            {{ cancelled_instructions }}
+
+            Yours truly:
+            system.
+        """
+        compiled_content = f"""
+            This is the email message next one up we have confirmed_instructions.
+            {self.reservation_unit.reservation_cancelled_instructions}
+
+            Yours truly:
+            system.
+        """
+        template = EmailTemplateFactory(
+            type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject"
+        )
+        builder = ReservationEmailNotificationBuilder(self.reservation, template)
+        assert_that(builder.get_content()).is_equal_to(compiled_content)


### PR DESCRIPTION
The reservation unit's name was rendered as part of the instructions (cancel, confirm and pending).
This removes the name of the reservation unit (but adds "-" between res units).

Refs TILA-1895