### PR TITLE
Bump pytest, py, pip-compile

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,9 +32,9 @@ isort==5.6.4
 ortools==9.4.1874
 psycopg2==2.8.6
 pydot==1.4.2
-pytest-cov==2.10.1
-pytest-django==4.1.0
-pytest-factoryboy==2.1.0
+pytest-cov
+pytest-django
+pytest-factoryboy
 sentry-sdk==0.19.5
 snapshottest
 social-auth-app-django==5.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -231,7 +231,7 @@ protobuf==4.21.6
     # via ortools
 psycopg2==2.8.6
     # via -r requirements.in
-py==1.10.0
+py==1.11.0
     # via pytest
 pyasn1==0.4.8
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,6 +28,8 @@ billiard==3.6.4.0
     # via celery
 black==20.8b1
     # via -r requirements.in
+build==0.8.0
+    # via pip-tools
 cachetools==4.2.2
     # via django-helusers
 celery==5.2.7
@@ -208,15 +210,16 @@ ortools==9.4.1874
     # via -r requirements.in
 packaging==20.9
     # via
+    #   build
     #   deprecation
     #   pytest
 pathspec==0.8.1
     # via black
 pep517==0.10.0
-    # via pip-tools
+    # via build
 pillow==9.0.1
     # via easy-thumbnails
-pip-tools==6.6.0
+pip-tools==6.9.0
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
@@ -341,7 +344,9 @@ toml==0.10.2
     #   pep517
     #   pytest
 tomli==2.0.1
-    # via coverage
+    # via
+    #   build
+    #   coverage
 typed-ast==1.4.3
     # via black
 typing-extensions==3.10.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -57,7 +57,7 @@ click-plugins==1.1.1
     # via celery
 click-repl==0.2.0
     # via celery
-coverage==6.0b1
+coverage[toml]==6.0b1
     # via pytest-cov
 cryptography==3.4.7
     # via social-auth-core
@@ -261,11 +261,11 @@ pytest==6.1.2
     #   pytest-cov
     #   pytest-django
     #   pytest-factoryboy
-pytest-cov==2.10.1
+pytest-cov==4.0.0
     # via -r requirements.in
-pytest-django==4.1.0
+pytest-django==4.5.2
     # via -r requirements.in
-pytest-factoryboy==2.1.0
+pytest-factoryboy==2.5.0
     # via -r requirements.in
 python-crontab==2.6.0
     # via django-celery-beat
@@ -340,10 +340,14 @@ toml==0.10.2
     #   black
     #   pep517
     #   pytest
+tomli==2.0.1
+    # via coverage
 typed-ast==1.4.3
     # via black
 typing-extensions==3.10.0.0
-    # via black
+    # via
+    #   black
+    #   pytest-factoryboy
 tzdata==2022.2
     # via django-celery-beat
 uritemplate==3.0.1


### PR DESCRIPTION
## Change log
- Remove pins from pytest libaries and bump them to latest
- Bump pip-tools
- Bump py to solve security issue related to it.

