### PR TITLE
TILA-1950 | Opening hours client enhancements

### DIFF
--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -14,6 +14,8 @@ class State(Enum):
     ENTER_ONLY = "enter_only"
     EXIT_ONLY = "exit_only"
     WEATHER_PERMITTING = "weather_permitting"
+    NOT_IN_USER = "not_in_use"
+    MAINTENANCE = "maintenance"
 
     class Labels:
         OPEN = pgettext_lazy("State", "Open")
@@ -27,6 +29,8 @@ class State(Enum):
         ENTER_ONLY = pgettext_lazy("State", "Enter only")
         EXIT_ONLY = pgettext_lazy("State", "Exit only")
         WEATHER_PERMITTING = pgettext_lazy("State", "Weather permitting")
+        NOT_IN_USE = pgettext_lazy("State", "Not in use")
+        MAINTENANCE = pgettext_lazy("State", "Maintenance")
 
     @classmethod
     def open_states(cls):

--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -43,6 +43,14 @@ class State(Enum):
             cls.ENTER_ONLY,
         ]
 
+    @classmethod
+    def reservable_states(cls):
+        return [
+            cls.WITH_RESERVATION,
+            cls.OPEN_AND_RESERVABLE,
+            cls.WITH_KEY_AND_RESERVATION,
+        ]
+
 
 class Weekday(Enum):
     MONDAY = 1

--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -10,6 +10,7 @@ from freezegun import freeze_time
 
 from applications.models import ApplicationRoundStatus
 from applications.tests.factories import ApplicationRoundFactory
+from opening_hours.enums import State
 from opening_hours.hours import TimeElement
 from reservation_units.tests.factories import ReservationUnitFactory
 from reservation_units.utils.reservation_unit_reservation_scheduler import (
@@ -73,6 +74,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
                         start_time=datetime.time(hour=10),
                         end_time=datetime.time(hour=22),
                         end_time_on_next_day=False,
+                        resource_state=State.WITH_RESERVATION,
                     ),
                 ],
             },
@@ -86,6 +88,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
                         start_time=datetime.time(hour=10),
                         end_time=datetime.time(hour=22),
                         end_time_on_next_day=False,
+                        resource_state=State.WITH_RESERVATION,
                     ),
                 ],
             },
@@ -99,6 +102,7 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
                         start_time=datetime.time(hour=10),
                         end_time=datetime.time(hour=22),
                         end_time_on_next_day=False,
+                        resource_state=State.WITH_RESERVATION,
                     ),
                 ],
             },

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -54,8 +54,10 @@ class ReservationUnitReservationScheduler:
         self.end_time = self.start_time + datetime.timedelta(
             hours=self.reservation_duration
         )
-        is_reservation_unit_closed = not self.opening_hours_client.is_resource_open(
-            str(self.reservation_unit.uuid), self.start_time, self.end_time
+        is_reservation_unit_closed = (
+            not self.opening_hours_client.is_resource_open_for_reservations(
+                str(self.reservation_unit.uuid), self.start_time, self.end_time
+            )
         )
         open_application_round = self.get_conflicting_open_application_round(
             self.start_time.date(), self.end_time.date()
@@ -95,8 +97,10 @@ class ReservationUnitReservationScheduler:
             open_application_round = self.get_conflicting_open_application_round(
                 self.start_time.date(), self.end_time.date()
             )
-            is_reservation_unit_closed = not self.opening_hours_client.is_resource_open(
-                str(self.reservation_unit.uuid), self.start_time, self.end_time
+            is_reservation_unit_closed = (
+                not self.opening_hours_client.is_resource_open_for_reservations(
+                    str(self.reservation_unit.uuid), self.start_time, self.end_time
+                )
             )
 
             if self.reservation_date_end < self.start_time.date():
@@ -170,7 +174,7 @@ class ReservationUnitReservationScheduler:
     def is_reservation_unit_open(
         self, start: datetime.datetime, end: datetime.datetime
     ):
-        return self.opening_hours_client.is_resource_open(
+        return self.opening_hours_client.is_resource_open_for_reservations(
             str(self.reservation_unit.uuid), start, end
         )
 


### PR DESCRIPTION
## Change log
- Adds new resource states to State enum in openinhours.enum; maintenance, not_in_use
- Add util method to State enum to return states that are to be considered when the reservations are possible
- Make the opening hours client know the usage of `end_time_on_next_day` value
- Make the opening hours client interpret resource to be reservable whole day when start_time and end_time are both nulls.
