### PR TITLE
TILA-1518: Update vulnerable py package by updating pytest

### DIFF
--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -1113,6 +1113,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         self.assertMatchSnapshot(content)
 
     def test_filter_by_multiple_reservation_unit(self):
+        self.maxDiff = None  # TODO: Remove when flakines is fixed
         other_unit = ReservationUnitFactory(
             spaces=[self.space],
             unit=self.unit,

--- a/requirements.in
+++ b/requirements.in
@@ -32,6 +32,7 @@ isort==5.6.4
 ortools==9.4.1874
 psycopg2==2.8.6
 pydot==1.4.2
+pytest
 pytest-cov
 pytest-django
 pytest-factoryboy

--- a/requirements.txt
+++ b/requirements.txt
@@ -259,8 +259,9 @@ pyparsing==2.4.7
     #   pydot
 pyrsistent==0.17.3
     # via jsonschema
-pytest==6.1.2
+pytest==7.1.3
     # via
+    #   -r requirements.in
     #   pytest-cov
     #   pytest-django
     #   pytest-factoryboy
@@ -342,11 +343,11 @@ toml==0.10.2
     # via
     #   black
     #   pep517
-    #   pytest
 tomli==2.0.1
     # via
     #   build
     #   coverage
+    #   pytest
 typed-ast==1.4.3
     # via black
 typing-extensions==3.10.0.0


### PR DESCRIPTION
## Change log
- Added pytest to `requirements.in`
- Updated `requirements.txt` with `pip-compile && pip-sync`
- Set `maxDiff` to `None` in the flaky test :rage1:  

## Other notes
We have a [dependobot alert](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/security/dependabot/11) from `py` library. Looks like your previous testing library bump didn't update `pytest` to the latest version so I added it to `requirements.in` file. I ran the tests on my machine and everything seems to work fine 👍 