### PR TITLE
TILA-1986 | Add permissions to roles in userType

### DIFF
--- a/api/graphql/permissions/permission_types.py
+++ b/api/graphql/permissions/permission_types.py
@@ -2,6 +2,7 @@ import graphene
 from django.conf import settings
 from graphene_permissions.mixins import AuthNode
 from graphene_permissions.permissions import AllowAny
+from rest_framework.exceptions import PermissionDenied
 
 from api.graphql.base_connection import TilavarausBaseConnection
 from api.graphql.base_type import PrimaryKeyObjectType
@@ -12,7 +13,15 @@ from permissions.api_permissions.graphene_permissions import (
     ServiceSectorRolePermission,
     UnitRolePermission,
 )
-from permissions.models import GeneralRole, ServiceSectorRole, UnitRole
+from permissions.helpers import can_view_users
+from permissions.models import GeneralRole
+from permissions.models import GeneralRolePermission as GeneralRolePermissionModel
+from permissions.models import ServiceSectorRole
+from permissions.models import (
+    ServiceSectorRolePermission as ServiceSectorRolePermissionModel,
+)
+from permissions.models import UnitRole
+from permissions.models import UnitRolePermission as UnitRolePermissionModel
 
 
 class RoleType(graphene.ObjectType):
@@ -23,7 +32,39 @@ class RoleType(graphene.ObjectType):
     verbose_name_en = graphene.String()
 
 
-class GeneralRoleType(AuthNode, PrimaryKeyObjectType):
+class IncludePermissionsMixin:
+    def resolve_permissions(self, info: graphene.ResolveInfo):
+        if info.context.user == self.user or can_view_users(info.context.user):
+            return self.role.permissions.all()
+
+        raise PermissionDenied("No permission to view permissions.")
+
+
+class GeneralRolePermissionType(graphene.ObjectType):
+    permission = graphene.String()
+
+    class Meta:
+        model = GeneralRolePermissionModel
+        fields = ["permission"]
+
+
+class ServiceSectorRolePermissionType(graphene.ObjectType):
+    permission = graphene.String()
+
+    class Meta:
+        model = ServiceSectorRolePermissionModel
+        fields = ["permission"]
+
+
+class UnitRolePermissionType(graphene.ObjectType):
+    permission = graphene.String()
+
+    class Meta:
+        model = UnitRolePermissionModel
+        fields = ["permission"]
+
+
+class GeneralRoleType(AuthNode, PrimaryKeyObjectType, IncludePermissionsMixin):
     permission_classes = (
         (GeneralRolePermission,)
         if not settings.TMP_PERMISSIONS_DISABLED
@@ -31,6 +72,7 @@ class GeneralRoleType(AuthNode, PrimaryKeyObjectType):
     )
 
     role = graphene.Field(RoleType)
+    permissions = graphene.List(GeneralRolePermissionType)
 
     class Meta:
         model = GeneralRole
@@ -42,7 +84,7 @@ class GeneralRoleType(AuthNode, PrimaryKeyObjectType):
         connection_class = TilavarausBaseConnection
 
 
-class ServiceSectorRoleType(AuthNode, PrimaryKeyObjectType):
+class ServiceSectorRoleType(AuthNode, PrimaryKeyObjectType, IncludePermissionsMixin):
     permission_classes = (
         (ServiceSectorRolePermission,)
         if not settings.TMP_PERMISSIONS_DISABLED
@@ -51,6 +93,7 @@ class ServiceSectorRoleType(AuthNode, PrimaryKeyObjectType):
 
     role = graphene.Field(RoleType)
     service_sector = graphene.Field(ServiceSectorType)
+    permissions = graphene.List(ServiceSectorRolePermissionType)
 
     class Meta:
         model = ServiceSectorRole
@@ -63,7 +106,7 @@ class ServiceSectorRoleType(AuthNode, PrimaryKeyObjectType):
         connection_class = TilavarausBaseConnection
 
 
-class UnitRoleType(AuthNode, PrimaryKeyObjectType):
+class UnitRoleType(AuthNode, PrimaryKeyObjectType, IncludePermissionsMixin):
     permission_classes = (
         (UnitRolePermission,) if not settings.TMP_PERMISSIONS_DISABLED else (AllowAny,)
     )
@@ -71,6 +114,7 @@ class UnitRoleType(AuthNode, PrimaryKeyObjectType):
     role = graphene.Field(RoleType)
     units = graphene.List(UnitType)
     unit_groups = graphene.List(UnitGroupType)
+    permissions = graphene.List(UnitRolePermissionType)
 
     class Meta:
         model = UnitRole

--- a/api/graphql/tests/snapshots/snap_test_users.py
+++ b/api/graphql/tests/snapshots/snap_test_users.py
@@ -25,6 +25,11 @@ snapshots['UserQueryTestCase::test_show_general_roles 1'] = {
         'currentUser': {
             'generalRoles': [
                 {
+                    'permissions': [
+                        {
+                            'permission': 'can_do_stuff'
+                        }
+                    ],
                     'role': {
                         'code': 'general_role',
                         'verboseName': ''
@@ -74,6 +79,11 @@ snapshots['UserQueryTestCase::test_show_service_sector_roles 1'] = {
         'currentUser': {
             'serviceSectorRoles': [
                 {
+                    'permissions': [
+                        {
+                            'permission': 'can_do_service_sector_things'
+                        }
+                    ],
                     'role': {
                         'code': 'TEST_SERVICE_SECTOR_ROLE',
                         'verboseName': 'Test Service Sector Role'
@@ -93,6 +103,11 @@ snapshots['UserQueryTestCase::test_show_unit_roles 1'] = {
         'currentUser': {
             'unitRoles': [
                 {
+                    'permissions': [
+                        {
+                            'permission': 'can_do_unit_things'
+                        }
+                    ],
                     'role': {
                         'code': 'TEST_UNIT_ROLE',
                         'verboseName': 'Test Unit Role'
@@ -196,4 +211,24 @@ snapshots['UsersQueryTestCase::test_unit_admin_can_read_other 1'] = {
             'username': 'non_staff_admin'
         }
     }
+}
+
+snapshots['UsersQueryTestCase::test_unit_admin_cant_read_permissions 1'] = {
+    'data': {
+        'user': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 17,
+                    'line': 3
+                }
+            ],
+            'message': 'No permissions to this operation.',
+            'path': [
+                'user'
+            ]
+        }
+    ]
 }


### PR DESCRIPTION


## Change log
- Adds permissions to role types in gql api
- Means that in apis using userType the user can query permissions




Refs TILA-1986