### PR TITLE
TILA-2005 | Make get_opening_hours to read null start and end times

### DIFF
--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -144,14 +144,17 @@ def get_opening_hours(
                 "times": [],
             }
             for time_data_in in opening_hours["times"]:
+                start_time = time_data_in.pop("start_time")
+                end_time = time_data_in.pop("end_time")
+
                 day_data_out["times"].append(
                     TimeElement(
-                        start_time=datetime.time.fromisoformat(
-                            time_data_in.pop("start_time")
-                        ),
-                        end_time=datetime.time.fromisoformat(
-                            time_data_in.pop("end_time")
-                        ),
+                        start_time=datetime.time.fromisoformat(start_time)
+                        if start_time
+                        else None,
+                        end_time=datetime.time.fromisoformat(end_time)
+                        if end_time
+                        else None,
                         **time_data_in,
                     )
                 )

--- a/opening_hours/tests/fixtures/hauki_opening_hours_response.json
+++ b/opening_hours/tests/fixtures/hauki_opening_hours_response.json
@@ -1,0 +1,51 @@
+{
+	"count": 1,
+	"next": null,
+	"previous": null,
+	"results": [
+		{
+			"resource": {
+				"id": 1234,
+				"name": {
+					"fi": "Test resource",
+					"sv": null,
+					"en": null
+				},
+				"timezone": "Europe/Helsinki",
+				"origins": [
+					{
+						"data_source": {
+							"id": "tvp",
+							"name": {
+								"fi": "Tilavarauspalvelu",
+								"sv": null,
+								"en": null
+							}
+						},
+						"origin_id": "proper-uuid"
+					}
+				]
+			},
+			"opening_hours": [
+				{
+					"date": "2022-12-12",
+					"times": [
+						{
+							"name": "",
+							"description": "",
+							"start_time": "08:00:00",
+							"end_time": "17:00:00",
+							"end_time_on_next_day": false,
+							"resource_state": "open",
+							"full_day": false,
+							"periods": [
+								1234,
+								1234
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/opening_hours/tests/fixtures/hauki_opening_hours_response_resource_closed.json
+++ b/opening_hours/tests/fixtures/hauki_opening_hours_response_resource_closed.json
@@ -1,0 +1,51 @@
+{
+	"count": 1,
+	"next": null,
+	"previous": null,
+	"results": [
+		{
+			"resource": {
+				"id": 1234,
+				"name": {
+					"fi": "Test resource",
+					"sv": null,
+					"en": null
+				},
+				"timezone": "Europe/Helsinki",
+				"origins": [
+					{
+						"data_source": {
+							"id": "tvp",
+							"name": {
+								"fi": "Tilavarauspalvelu",
+								"sv": null,
+								"en": null
+							}
+						},
+						"origin_id": "proper-uuid"
+					}
+				]
+			},
+			"opening_hours": [
+				{
+					"date": "2022-12-12",
+					"times": [
+						{
+							"name": "",
+							"description": "",
+							"start_time": null,
+							"end_time": null,
+							"end_time_on_next_day": false,
+							"resource_state": "closed",
+							"full_day": false,
+							"periods": [
+								1234,
+								1234
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/opening_hours/tests/test_get_opening_hours.py
+++ b/opening_hours/tests/test_get_opening_hours.py
@@ -1,0 +1,45 @@
+import json
+from unittest import mock
+
+from assertpy import assert_that
+from django.test import TestCase, override_settings
+
+from opening_hours.hours import get_opening_hours
+
+
+@mock.patch("opening_hours.hours.make_hauki_get_request")
+@override_settings(HAUKI_API_URL="asdf")
+class GetOpeningHoursTestCase(TestCase):
+    @classmethod
+    def get_opening_hours(self):
+        with open(
+            "opening_hours/tests/fixtures/hauki_opening_hours_response.json"
+        ) as data:
+            response = json.load(data)
+
+        return response
+
+    @classmethod
+    def get_opening_hours_closed(self):
+        with open(
+            "opening_hours/tests/fixtures/hauki_opening_hours_response_resource_closed.json"
+        ) as data:
+            response = json.load(data)
+
+        return response
+
+    def test_get_opening_hours(self, mock):
+        mock.return_value = self.get_opening_hours()
+
+        data = get_opening_hours("resource_id", "2020-01-01", "2020-01-01")
+        assert_that(data).is_not_empty()
+        assert_that(data[0]["times"]).is_not_empty()
+
+    def test_get_opening_hours_null_start_end_ok(self, mock):
+        mock.return_value = self.get_opening_hours_closed()
+
+        data = get_opening_hours("resource_id", "2020-01-01", "2020-01-01")
+        assert_that(data).is_not_empty()
+        assert_that(data[0]["times"]).is_not_empty()
+        assert_that(data[0]["times"][0].start_time).is_none()
+        assert_that(data[0]["times"][0].end_time).is_none()

--- a/opening_hours/tests/test_opening_hours_client.py
+++ b/opening_hours/tests/test_opening_hours_client.py
@@ -84,6 +84,48 @@ class OpeningHoursClientTestCase(TestCase):
         )
         assert_that(len(times)).is_greater_than(0)
 
+    def test_opening_hours_start_end_null_works(self, mock):
+        resource_id = f"{settings.HAUKI_ORIGIN_ID}:{self.reservation_unit.uuid}"
+        data = [
+            {
+                "timezone": DEFAULT_TIMEZONE,
+                "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
+                "date": DATES[0],
+                "times": [
+                    TimeElement(
+                        start_time=None,
+                        end_time=None,
+                        end_time_on_next_day=False,
+                        resource_state=State.CLOSED.value,
+                    ),
+                ],
+            },
+            {
+                "timezone": DEFAULT_TIMEZONE,
+                "resource_id": resource_id,
+                "origin_id": str(self.reservation_unit.uuid),
+                "date": DATES[1],
+                "times": [
+                    TimeElement(
+                        start_time=None,
+                        end_time=None,
+                        end_time_on_next_day=False,
+                        resource_state=State.CLOSED.value,
+                    ),
+                ],
+            },
+        ]
+        mock.return_value = data
+        resources = [str(self.reservation_unit.uuid)]
+        client = OpeningHoursClient(resources, DATES[0], DATES[1])
+
+        assert_that(client).is_not_none()
+        times = client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid), DATES[0]
+        )
+        assert_that(times).is_not_empty()
+
     def test_refresh_opening_hours(self, mock):
         mock.return_value = self.get_mocked_opening_hours()
         client = OpeningHoursClient(


### PR DESCRIPTION
Previously it failed to do so since the fromisoformat fails. Fixes that to checking the data before parsing.

Refs TILA-2005

