### PR TITLE
TILA-1963 | Alter permission check for space mutations

### DIFF
--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -440,14 +440,20 @@ class SpacePermission(BasePermission):
 
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        unit = None
+
+        space_id = input.get("pk")
         unit_id = input.get("unit_pk")
-        if unit_id:
-            try:
-                unit = Unit.objects.get(id=unit_id)
-            except Unit.DoesNotExist:
-                pass
-            else:
-                return can_manage_units_spaces(info.context.user, unit)
+        operation = getattr(info.operation, "name", None)
+
+        if getattr(operation, "value", None) == "createSpace" and unit_id:
+            unit = Unit.objects.filter(id=unit_id).first()
+        elif space_id:
+            unit = Unit.objects.filter(spaces=space_id).first()
+
+        if unit:
+            return can_manage_units_spaces(info.context.user, unit)
+
         return can_manage_spaces(info.context.user)
 
 


### PR DESCRIPTION
Previously we checked only for unit_pk the unit level permissions when doing unit mutations. This faults in most cases to general permission check and thus the update/create wouldn't work for unit admins not service sector admins.

This changes the permission check logic so that it can handle update/delete/creation for unit admins => checks the permissions from the space itself (space.unit)

Refs TILA-1963
