### PR TITLE
TILA-1975 | Round resrevation prices using Decimal class quantize

### DIFF
--- a/api/graphql/tests/test_reservation_units.py
+++ b/api/graphql/tests/test_reservation_units.py
@@ -3584,9 +3584,11 @@ class ReservationUnitCreateAsNotDraftTestCase(ReservationUnitMutationsTestCaseBa
         )
         assert_that(pricing.pricing_type).is_equal_to(pricing_data["pricingType"])
         assert_that(pricing.price_unit).is_equal_to(pricing_data["priceUnit"])
-        assert_that(pricing.lowest_price).is_close_to(pricing_data["lowestPrice"], 0.01)
+        assert_that(pricing.lowest_price).is_close_to(
+            pricing_data["lowestPrice"], 0.001
+        )
         assert_that(pricing.highest_price).is_close_to(
-            pricing_data["highestPrice"], 0.01
+            pricing_data["highestPrice"], 0.001
         )
         assert_that(pricing.tax_percentage).is_equal_to(tax_percentage)
         assert_that(pricing.status).is_equal_to(pricing_data["status"])

--- a/reservation_units/utils/reservation_unit_pricing_helper.py
+++ b/reservation_units/utils/reservation_unit_pricing_helper.py
@@ -1,3 +1,4 @@
+import decimal
 from datetime import date, datetime
 from decimal import Decimal
 from typing import Any, Dict, List, Optional
@@ -115,14 +116,12 @@ class ReservationUnitPricingHelper:
                 pricing["highest_price"] = highest_price_net
                 pricing["lowest_price"] = lowest_price_net
             else:
-                pricing["highest_price"] = round(
-                    Decimal(highest_price_net * (1 + tax_percentage.decimal)),
-                    2,
-                )
-                pricing["lowest_price"] = round(
-                    Decimal(lowest_price_net * (1 + tax_percentage.decimal)),
-                    2,
-                )
+                pricing["highest_price"] = Decimal(
+                    highest_price_net * (1 + tax_percentage.decimal)
+                ).quantize(Decimal("1.00"), rounding=decimal.ROUND_HALF_UP)
+                pricing["lowest_price"] = Decimal(
+                    lowest_price_net * (1 + tax_percentage.decimal)
+                ).quantize(Decimal("1.00"), rounding=decimal.ROUND_HALF_UP)
 
         return pricings
 


### PR DESCRIPTION
This was originally introduced using built-in round which does not comply the rounding specs.

Refs TILA-1975
