### PR TITLE
TILA-2057: Add price_net and make handling_details required

### DIFF
--- a/api/graphql/reservations/reservation_serializers.py
+++ b/api/graphql/reservations/reservation_serializers.py
@@ -1062,16 +1062,12 @@ class ReservationApproveSerializer(PrimaryKeySerializer):
         self.fields["state"].read_only = True
         self.fields["handled_at"].read_only = True
         self.fields["price"].required = True
+        self.fields["price_net"].required = True
+        self.fields["handling_details"].required = True
 
     class Meta:
         model = Reservation
-        fields = [
-            "pk",
-            "state",
-            "handling_details",
-            "handled_at",
-            "price",
-        ]
+        fields = ["pk", "state", "handling_details", "handled_at", "price", "price_net"]
 
     @property
     def validated_data(self):
@@ -1088,6 +1084,7 @@ class ReservationApproveSerializer(PrimaryKeySerializer):
                 f"Only reservations with state as {STATE_CHOICES.REQUIRES_HANDLING.upper()} can be approved.",
                 ValidationErrorCodes.APPROVING_NOT_ALLOWED,
             )
+
         data = super().validate(data)
 
         return data


### PR DESCRIPTION
## Change log
- Added `price_net` field to `ReservationApproveSerializer`
- Changed `handling_details` to be required.

## Other notes
In the code we copy `handling_details` to `working_memo`. If `handling_details` is missing, the code will throw a key error exception. Since client is already always sending the field, I just marked it as required.

## Deployment reminder
- No changes needed