### PR TITLE
TILA-1971: Payment webhook endpoint to REST API

### DIFF
--- a/api/tests/test_webhook_api.py
+++ b/api/tests/test_webhook_api.py
@@ -1,0 +1,188 @@
+import dataclasses
+from datetime import datetime
+from decimal import Decimal
+from unittest import mock
+from uuid import uuid4
+
+from assertpy import assert_that
+from django.test import TestCase, override_settings
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from merchants.models import PaymentStatus
+from merchants.tests.factories import PaymentOrderFactory
+from merchants.verkkokauppa.payment.exceptions import GetPaymentError
+from merchants.verkkokauppa.payment.types import Payment
+from reservations.models import STATE_CHOICES
+from reservations.tests.factories import ReservationFactory
+
+
+@mock.patch("api.webhook_api.views.get_payment")
+@override_settings(VERKKOKAUPPA_NAMESPACE="tilanvaraus")
+class WebhookPaymentAPITestCase(TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.reservation = ReservationFactory.create(
+            state=STATE_CHOICES.WAITING_FOR_PAYMENT
+        )
+        self.payment_order = PaymentOrderFactory.create(
+            reservation=self.reservation, status=PaymentStatus.DRAFT
+        )
+        self.verkkokauppa_payment = Payment(
+            payment_id=uuid4(),
+            namespace="tilanvaraus",
+            order_id=self.payment_order.remote_id,
+            user_id=uuid4(),
+            status="payment_paid_online",
+            payment_method="creditcards",
+            payment_type="order",
+            total_excl_tax=Decimal("100"),
+            total=Decimal("124"),
+            tax_amount=Decimal("24"),
+            description=None,
+            additional_info='{"payment_method": creditcards}',
+            token=uuid4(),
+            timestamp=datetime.now(),
+            payment_method_label="Visa",
+        )
+
+    def get_client(self):
+        return APIClient()
+
+    def get_valid_data(self):
+        return {
+            "paymentId": self.verkkokauppa_payment.payment_id,
+            "orderId": self.verkkokauppa_payment.order_id,
+            "namespace": self.verkkokauppa_payment.namespace,
+            "type": "PAYMENT_PAID",
+            "timestamp": self.verkkokauppa_payment.timestamp.isoformat(),
+        }
+
+    @mock.patch("api.webhook_api.views.send_confirmation_email")
+    def test_returns_200_without_body_on_success(
+        self, mock_send_confirmation_email, mock_get_payment
+    ):
+        mock_get_payment.return_value = self.verkkokauppa_payment
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=self.get_valid_data(),
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        assert_that(response.data).is_none()
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(PaymentStatus.PAID)
+        assert_that(self.payment_order.payment_id).is_equal_to(
+            str(self.verkkokauppa_payment.payment_id)
+        )
+
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
+        assert_that(mock_send_confirmation_email.called).is_true()
+
+    def test_returns_200_without_body_on_order_already_paid(self, mock_get_payment):
+        self.payment_order.status = PaymentStatus.PAID
+        self.payment_order.save()
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=self.get_valid_data(),
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(200)
+        assert_that(response.data).is_none()
+
+    def test_returns_400_with_error_on_invalid_payload(self, mock_get_payment):
+        data = self.get_valid_data()
+        data.pop("type")
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=data,
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(400)
+
+        expected_error = {"status": 400, "message": "Required field missing: type"}
+        assert_that(response.data).is_equal_to(expected_error)
+
+    def test_returns_400_with_error_on_invalid_namespace(self, mock_get_payment):
+        data = self.get_valid_data()
+        data["namespace"] = "invalid"
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=data,
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(400)
+
+        expected_error = {"status": 400, "message": "Invalid namespace"}
+        assert_that(response.data).is_equal_to(expected_error)
+
+    @mock.patch("api.webhook_api.views.capture_message")
+    def test_returns_400_with_error_on_invalid_payment_state(
+        self, mock_capture_message, mock_get_payment
+    ):
+        self.verkkokauppa_payment = dataclasses.replace(
+            self.verkkokauppa_payment, status="something_else"
+        )
+        mock_get_payment.return_value = self.verkkokauppa_payment
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=self.get_valid_data(),
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(400)
+
+        expected_error = {"status": 400, "message": "Invalid payment state"}
+        assert_that(response.data).is_equal_to(expected_error)
+        assert_that(mock_capture_message.called).is_true()
+
+    def test_returns_404_with_error_on_order_not_found(self, mock_get_payment):
+        data = self.get_valid_data()
+        data["orderId"] = uuid4()
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=data,
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(404)
+
+        expected_error = {"status": 404, "message": "Order not found"}
+        assert_that(response.data).is_equal_to(expected_error)
+
+    @mock.patch("api.webhook_api.views.capture_message")
+    def test_returns_500_with_error_on_payment_fetch_failure(
+        self, mock_capture_message, mock_get_payment
+    ):
+        mock_get_payment.side_effect = GetPaymentError("Mock error")
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=self.get_valid_data(),
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(500)
+
+        expected_error = {"status": 500, "message": "Problem with upstream service"}
+        assert_that(response.data).is_equal_to(expected_error)
+        assert_that(mock_capture_message.called).is_true()
+
+    def test_returns_501_with_error_on_invalid_type(self, mock_get_payment):
+        data = self.get_valid_data()
+        data["type"] = "invalid"
+
+        response = self.client.post(
+            reverse("payment-list"),
+            data=data,
+            format="json",
+        )
+        assert_that(response.status_code).is_equal_to(501)
+
+        expected_error = {"status": 501, "message": "Unsupported type"}
+        assert_that(response.data).is_equal_to(expected_error)

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,6 +3,8 @@ from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 from rest_framework import routers
 
+from api.webhook_api.views import WebhookPaymentViewSet
+
 from .allocation_api import AllocationRequestViewSet
 from .allocation_results_api import AllocationResultViewSet
 from .application_round_api import ApplicationRoundViewSet
@@ -122,8 +124,7 @@ router.register(
     "equipment",
 )
 router.register(r"parameters/city", CityViewSet, "city")
-
-
+router.register(r"webhook/payment", WebhookPaymentViewSet, "payment")
 urlpatterns = [
     path("graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))),
     path(

--- a/api/webhook_api/views.py
+++ b/api/webhook_api/views.py
@@ -1,0 +1,125 @@
+from datetime import datetime
+from typing import Dict
+
+from django.conf import settings
+from django.utils.timezone import get_default_timezone
+from drf_spectacular.utils import OpenApiResponse, extend_schema, inline_serializer
+from rest_framework import serializers, viewsets
+from rest_framework.exceptions import APIException
+from rest_framework.response import Response
+from sentry_sdk import capture_message
+
+from merchants.models import PaymentOrder, PaymentStatus
+from merchants.verkkokauppa.payment.exceptions import GetPaymentError
+from merchants.verkkokauppa.payment.requests import get_payment
+from permissions.api_permissions.drf_permissions import WebhookPermission
+from reservations.email_utils import send_confirmation_email
+from reservations.models import STATE_CHOICES, Reservation
+
+
+class WebhookError(APIException):
+    def __init__(self, message: str, status_code: int):
+        self.status_code = status_code
+        self.detail = message
+
+    def to_json(self) -> Dict[str, any]:
+        return {"status": self.status_code, "message": self.detail}
+
+
+class WebhookPaymentViewSet(viewsets.GenericViewSet):
+    permission_classes = [WebhookPermission]
+
+    def validate_request(self, request):
+        required_field = ["paymentId", "orderId", "namespace", "type", "timestamp"]
+        for field in required_field:
+            if field not in request.data:
+                raise WebhookError(
+                    message=f"Required field missing: {field}", status_code=400
+                )
+
+        namespace = request.data.get("namespace", None)
+        type = request.data.get("type", None)
+
+        if namespace != settings.VERKKOKAUPPA_NAMESPACE:
+            raise WebhookError(message="Invalid namespace", status_code=400)
+
+        if type != "PAYMENT_PAID":
+            raise WebhookError(message="Unsupported type", status_code=501)
+
+    @extend_schema(
+        request=inline_serializer(
+            name="WebhookPaymentPayload",
+            fields={
+                "paymentId": serializers.UUIDField(),
+                "orderId": serializers.UUIDField(),
+                "namespace": serializers.CharField(),
+                "type": serializers.ChoiceField(
+                    choices=[("PAYMENT_PAID", "PAYMENT_PAID")]
+                ),
+                "timestamp": serializers.DateTimeField(),
+            },
+        ),
+        responses={
+            200: OpenApiResponse(description="OK"),
+            400: OpenApiResponse(description="Invalid payload, namespace or type"),
+            404: OpenApiResponse(description="Order not found"),
+            500: OpenApiResponse(
+                description="Internal server error or problem with upstream service"
+            ),
+            501: OpenApiResponse(description="Unsupported type"),
+        },
+    )
+    def create(self, request):
+        needs_update_statuses = [
+            PaymentStatus.DRAFT,
+            PaymentStatus.EXPIRED,
+            PaymentStatus.CANCELLED,
+        ]
+        try:
+            self.validate_request(request)
+
+            remote_id = request.data.get("orderId", "")
+            payment_id = request.data.get("paymentId", "")
+
+            payment_order = PaymentOrder.objects.filter(remote_id=remote_id).first()
+            if not payment_order:
+                raise WebhookError(message="Order not found", status_code=404)
+
+            # Order is already in a state where no updates are needed
+            if payment_order.status not in needs_update_statuses:
+                return Response(status=200)
+
+            # Check payment status from the API
+            payment = get_payment(remote_id, settings.VERKKOKAUPPA_NAMESPACE)
+            payment_status = getattr(payment, "status", "payment_not_found")
+
+            if payment_status != "payment_paid_online":
+                capture_message(
+                    f"Received payment webhook for order {remote_id} that is not paid: {payment_status}",
+                    level="warning",
+                )
+                raise WebhookError(message="Invalid payment state", status_code=400)
+
+            if payment_order.status in needs_update_statuses:
+                payment_order.status = PaymentStatus.PAID
+                payment_order.payment_id = payment_id
+                payment_order.processed_at = datetime.now().astimezone(
+                    get_default_timezone()
+                )
+                payment_order.save()
+
+            reservation: Reservation = payment_order.reservation
+            if reservation.state == STATE_CHOICES.WAITING_FOR_PAYMENT:
+                reservation.state = STATE_CHOICES.CONFIRMED
+                reservation.save()
+                send_confirmation_email(reservation)
+
+            return Response(status=200)
+        except WebhookError as e:
+            return Response(data=e.to_json(), status=e.status_code)
+        except GetPaymentError as e:
+            capture_message(f"Checking order payment failed: {str(e)}", level="error")
+            return Response(
+                data={"status": 500, "message": "Problem with upstream service"},
+                status=500,
+            )

--- a/merchants/verkkokauppa/payment/requests.py
+++ b/merchants/verkkokauppa/payment/requests.py
@@ -1,4 +1,5 @@
 from json import JSONDecodeError
+from typing import Optional
 from urllib.parse import urljoin
 from uuid import UUID
 
@@ -22,14 +23,29 @@ def _get_base_url():
     return f"{settings.VERKKOKAUPPA_PAYMENT_API_URL}/"
 
 
-def get_payment(order_id: UUID, namespace: str, get=_get) -> Payment:
+def get_payment(order_id: UUID, namespace: str, get=_get) -> Optional[Payment]:
     try:
         response = get(
             url=urljoin(_get_base_url(), f"admin/{order_id}"),
             headers={"api-key": settings.VERKKOKAUPPA_API_KEY, "namespace": namespace},
             timeout=REQUEST_TIMEOUT_SECONDS,
         )
+
         json = response.json()
+
+        # Endpoint returns 200 with empty body is payment does not exists
+        # TODO: This will change to 500 with the following body:
+        # {
+        #     "errors": [
+        #         {
+        #             "code": "failed-to-get-payment-for-order",
+        #             "message": "Failed to get payment for order"
+        #         }
+        #     ]
+        # }
+        if response.status_code == 200 and json == {}:
+            return None
+
         if response.status_code != 200:
             raise GetPaymentError(f"Payment creation failed: {json.get('errors')}")
         return Payment.from_json(json)

--- a/permissions/api_permissions/drf_permissions.py
+++ b/permissions/api_permissions/drf_permissions.py
@@ -469,3 +469,14 @@ class UserPermission(permissions.BasePermission):
         return (
             request.user.is_authenticated and request.method in permissions.SAFE_METHODS
         )
+
+
+class WebhookPermission(permissions.BasePermission):
+    def has_object_permission(self, request, view, reservation_unit):
+        return True
+
+    def has_permission(self, request, view):
+        if request.method == "POST":
+            return True
+
+        return False

--- a/requirements.in
+++ b/requirements.in
@@ -18,7 +18,7 @@ django-recurrence==1.10.3
 django-tinymce==3.4.0
 djangorestframework==3.12.2
 drf-oidc-auth==0.10.0
-drf-spectacular==0.13.0
+drf-spectacular==0.24.2
 easy-thumbnails==2.7.1
 flake8==3.8.4
 graphene-django==3.0.0b7

--- a/requirements.txt
+++ b/requirements.txt
@@ -126,7 +126,7 @@ drf-oidc-auth==0.10.0
     # via
     #   -r requirements.in
     #   helsinki-profile-gdpr-api
-drf-spectacular==0.13.0
+drf-spectacular==0.24.2
     # via -r requirements.in
 easy-thumbnails==2.7.1
     # via -r requirements.in

--- a/reservations/email_utils.py
+++ b/reservations/email_utils.py
@@ -1,0 +1,103 @@
+from email_notification.models import EmailType
+from email_notification.tasks import (
+    send_reservation_email_task,
+    send_staff_reservation_email_task,
+)
+from reservations.models import STATE_CHOICES, Reservation
+from users.models import ReservationNotification
+
+RESERVATION_STATE_EMAIL_TYPE_MAP = {
+    STATE_CHOICES.CONFIRMED: EmailType.RESERVATION_CONFIRMED,
+    STATE_CHOICES.REQUIRES_HANDLING: EmailType.HANDLING_REQUIRED_RESERVATION,
+    STATE_CHOICES.CANCELLED: EmailType.RESERVATION_CANCELLED,
+    STATE_CHOICES.DENIED: EmailType.RESERVATION_REJECTED,
+    "APPROVED": EmailType.RESERVATION_HANDLED_AND_CONFIRMED,
+    "NEEDS_PAYMENT": EmailType.RESERVATION_NEEDS_TO_BE_PAID,
+}
+
+
+def send_confirmation_email(reservation: Reservation):
+    if reservation.state in RESERVATION_STATE_EMAIL_TYPE_MAP.keys():
+        send_reservation_email_task.delay(
+            reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP[reservation.state]
+        )
+
+    if reservation.state == STATE_CHOICES.REQUIRES_HANDLING:
+        send_staff_reservation_email_task.delay(
+            reservation.id,
+            EmailType.STAFF_NOTIFICATION_RESERVATION_REQUIRES_HANDLING,
+            [
+                ReservationNotification.ALL,
+                ReservationNotification.ONLY_HANDLING_REQUIRED,
+            ],
+        )
+    elif reservation.state == STATE_CHOICES.CONFIRMED:
+        send_staff_reservation_email_task.delay(
+            reservation.id,
+            EmailType.STAFF_NOTIFICATION_RESERVATION_MADE,
+            [ReservationNotification.ALL],
+        )
+
+
+def send_cancellation_email(reservation: Reservation):
+    if reservation.state in RESERVATION_STATE_EMAIL_TYPE_MAP.keys():
+        send_reservation_email_task.delay(
+            reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP[reservation.state]
+        )
+
+
+def send_deny_email(reservation: Reservation):
+    if reservation.state in RESERVATION_STATE_EMAIL_TYPE_MAP.keys():
+        send_reservation_email_task.delay(
+            reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP[reservation.state]
+        )
+
+
+def send_approve_email(reservation: Reservation):
+    if reservation.state == STATE_CHOICES.CONFIRMED:
+        if reservation.price > 0:
+            send_reservation_email_task.delay(
+                reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP["NEEDS_PAYMENT"]
+            )
+        else:
+            send_reservation_email_task.delay(
+                reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP["APPROVED"]
+            )
+
+    if reservation.state == STATE_CHOICES.CONFIRMED:
+        send_staff_reservation_email_task.delay(
+            reservation.id,
+            EmailType.STAFF_NOTIFICATION_RESERVATION_MADE,
+            [ReservationNotification.ALL],
+        )
+
+
+def send_requires_handling_email(reservation: Reservation):
+    if reservation.state in RESERVATION_STATE_EMAIL_TYPE_MAP.keys():
+        send_reservation_email_task.delay(
+            reservation.id, RESERVATION_STATE_EMAIL_TYPE_MAP[reservation.state]
+        )
+
+    if reservation.state == STATE_CHOICES.REQUIRES_HANDLING:
+        send_staff_reservation_email_task.delay(
+            reservation.id,
+            EmailType.STAFF_NOTIFICATION_RESERVATION_REQUIRES_HANDLING,
+            [
+                ReservationNotification.ALL,
+                ReservationNotification.ONLY_HANDLING_REQUIRED,
+            ],
+        )
+
+
+def send_reservation_modified_email(reservation: Reservation):
+    send_reservation_email_task.delay(reservation.id, EmailType.RESERVATION_MODIFIED)
+
+    if reservation.state == STATE_CHOICES.REQUIRES_HANDLING:
+        send_staff_reservation_email_task.delay(
+            reservation.id,
+            EmailType.STAFF_NOTIFICATION_RESERVATION_REQUIRES_HANDLING,
+            [
+                ReservationNotification.ALL,
+                ReservationNotification.ONLY_HANDLING_REQUIRED,
+            ],
+        )


### PR DESCRIPTION
## Change log
- Updated `drf-spectacular` package
- Updated `Payment API` client to be up-to-date with the latest implementation
- Extracted reservation email sending to own file
- Added a new payment webhook endpoint to REST API
- Moar tests

## Other notes
There are some known changes coming to Payment Experience API but since those are not yet deployed, I added a TODO comment as a reminder. I'll update the code as soon as I get an update from the Verkkokauppa team. 

## Deployment reminder
- No changes required