### PR TITLE
Fix deprecations

### DIFF
--- a/api/graphql/tests/test_reservations/test_reservation_adjust_time.py
+++ b/api/graphql/tests/test_reservations/test_reservation_adjust_time.py
@@ -244,7 +244,7 @@ class ReservationAdjustTimeTestCase(ReservationTestCaseBase):
 
     def test_reservation_is_already_handled_fails(self, mock_opening_hours):
         mock_opening_hours.return_value = self.get_mocked_opening_hours()
-        self.reservation.handled_at = datetime.datetime.now()
+        self.reservation.handled_at = datetime.datetime.now(tz=DEFAULT_TIMEZONE)
         self.reservation.save()
 
         self.client.force_login(self.regular_joe)

--- a/applications/__init__.py
+++ b/applications/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "applications.apps.ApplicationsConfig"

--- a/users/__init__.py
+++ b/users/__init__.py
@@ -1,1 +1,0 @@
-default_app_config = "users.apps.UsersConfig"

--- a/users/models.py
+++ b/users/models.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from helusers.models import AbstractUser
 
 


### PR DESCRIPTION
## Change log
- Remove deprecated ``default_app_config``
- User ``gettext_lazy`` instead of deprecated ``ugettext_lazy``
- Use timezone aware datetime in adjust time test 