### PR TITLE
TILA-2038 | Include REQUIRES_HANDLING to going_to_occur qs method

### DIFF
--- a/reservations/models.py
+++ b/reservations/models.py
@@ -174,6 +174,7 @@ class ReservationQuerySet(models.QuerySet):
                 STATE_CHOICES.CREATED,
                 STATE_CHOICES.CONFIRMED,
                 STATE_CHOICES.WAITING_FOR_PAYMENT,
+                STATE_CHOICES.REQUIRES_HANDLING,
             )
         )
 


### PR DESCRIPTION

## Change log
- REQUIRES_HANDLING to `ReservationQueryset.going_to_occur` 

## Long notes
In reservations queryset we have util queryset function to get reservations that are going to occur e.g not cancelled or denied. The method is used in various places and it was lacking the REQUIRES_HANDLING state which also means that the reservation is going to occur.

This adds REQUIRES_HANDLING state to going_to_occur method.

Refs TILA-2038
