### PR TITLE
TILA-2033: Add webshop order cancellation support

### DIFF
--- a/api/graphql/tests/test_reservations/test_reservation_delete.py
+++ b/api/graphql/tests/test_reservations/test_reservation_delete.py
@@ -1,11 +1,17 @@
 import datetime
 import json
+from unittest import mock
+from uuid import uuid4
 
 from assertpy import assert_that
 from django.contrib.auth import get_user_model
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
+from merchants.models import PaymentStatus
+from merchants.tests.factories import PaymentOrderFactory
+from merchants.verkkokauppa.order.exceptions import CancelOrderError
+from merchants.verkkokauppa.order.test.factories import OrderFactory
 from reservations.models import STATE_CHOICES as ReservationState
 from reservations.models import Reservation
 from reservations.tests.factories import ReservationFactory
@@ -105,6 +111,87 @@ class ReservationDeleteTestCase(ReservationTestCaseBase):
         assert_that(
             Reservation.objects.filter(pk=self.reservation.pk).exists()
         ).is_false()
+
+    @mock.patch("api.graphql.reservations.reservation_mutations.cancel_order")
+    def test_call_webshop_cancel_and_mark_order_cancelled_on_delete(
+        self, mock_cancel_order
+    ):
+        mock_cancel_order.return_value = OrderFactory(status="cancelled")
+
+        self.reservation.state = ReservationState.WAITING_FOR_PAYMENT
+        self.reservation.save()
+
+        payment_order = PaymentOrderFactory.create(
+            remote_id=uuid4(), reservation=self.reservation, status=PaymentStatus.DRAFT
+        )
+
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(
+            self.get_delete_query(), input_data=self.get_delete_input_data()
+        )
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(mock_cancel_order.called).is_true()
+
+        payment_order.refresh_from_db()
+        assert_that(payment_order.status).is_equal_to(PaymentStatus.CANCELLED)
+
+    @mock.patch("api.graphql.reservations.reservation_mutations.cancel_order")
+    def test_do_not_mark_order_cancelled_if_webshop_call_fails(self, mock_cancel_order):
+        mock_cancel_order.return_value = OrderFactory(status="draft")
+
+        self.reservation.state = ReservationState.WAITING_FOR_PAYMENT
+        self.reservation.save()
+
+        payment_order = PaymentOrderFactory.create(
+            remote_id=uuid4(), reservation=self.reservation, status=PaymentStatus.DRAFT
+        )
+
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(
+            self.get_delete_query(), input_data=self.get_delete_input_data()
+        )
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        assert_that(mock_cancel_order.called).is_true()
+
+        payment_order.refresh_from_db()
+        assert_that(payment_order.status).is_equal_to(PaymentStatus.DRAFT)
+
+    @mock.patch("api.graphql.reservations.reservation_mutations.capture_message")
+    @mock.patch("api.graphql.reservations.reservation_mutations.cancel_order")
+    def test_log_error_on_cancel_order_failure(
+        self, mock_cancel_order, mock_capture_message
+    ):
+        mock_cancel_order.side_effect = CancelOrderError("mock-error")
+
+        self.reservation.state = ReservationState.WAITING_FOR_PAYMENT
+        self.reservation.save()
+
+        PaymentOrderFactory.create(remote_id=uuid4(), reservation=self.reservation)
+
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(
+            self.get_delete_query(), input_data=self.get_delete_input_data()
+        )
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")[0]["message"]).is_equal_to(
+            "Unable to cancel the order: problem with external service"
+        )
+        assert_that(content.get("errors")[0]["extensions"]["error_code"]).is_equal_to(
+            "EXTERNAL_SERVICE_ERROR"
+        )
+        assert_that(mock_cancel_order.called).is_true()
+        assert_that(mock_capture_message.called).is_true()
 
     def test_cannot_delete_when_status_not_created_nor_waiting_for_payment(self):
         self.client.force_login(self.general_admin)

--- a/merchants/verkkokauppa/order/exceptions.py
+++ b/merchants/verkkokauppa/order/exceptions.py
@@ -15,3 +15,7 @@ class ParseOrderError(OrderError):
 
 class GetOrderError(OrderError):
     pass
+
+
+class CancelOrderError(OrderError):
+    pass


### PR DESCRIPTION
## Change log
- Added support for webshop order cancellation
- Cancel webshop order when reservation is deleted
  - If cancellation is successful, also cancel our PaymentOrder

## Other notes
I just realized order status are still plain strings. I'll do a separate refactoring PR when I will change them to enums 🛠️ 

## Deployment reminder
- No changes required