### PR TITLE
TILA-2112: Add createAt to reservation orderBy

### DIFF
--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -86,6 +86,7 @@ class ReservationFilterSet(django_filters.FilterSet):
 
     order_by = django_filters.OrderingFilter(
         fields=(
+            "created_at",
             "state",
             "begin",
             "end",

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -894,6 +894,46 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
     }
 }
 
+snapshots['ReservationQueryTestCase::test_order_by_created_at 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'createdAt': '2021-10-12T09:00:00+0000',
+                        'name': 'this should be 1st'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2021-10-12T10:00:00+0000',
+                        'name': 'this should be 2nd'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2021-10-12T11:00:00+0000',
+                        'name': 'this should be 3rd'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2021-10-12T12:00:00+0000',
+                        'name': 'movies'
+                    }
+                },
+                {
+                    'node': {
+                        'createdAt': '2021-10-12T22:00:00+0000',
+                        'name': 'this should be last'
+                    }
+                }
+            ],
+            'totalCount': 5
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_order_by_reservation_unit_name 1'] = {
     'data': {
         'reservations': {


### PR DESCRIPTION
## Change log
- Add `createdAt` to `orderBy` in `reservations` query

## Deployment reminder
- No changes required