### PR TITLE
TILA-2029: Reservation - add sorting by order status and rename order status filter

### DIFF
--- a/api/graphql/merchants/merchant_mutations.py
+++ b/api/graphql/merchants/merchant_mutations.py
@@ -4,7 +4,7 @@ from graphene import relay
 from graphene_permissions.mixins import AuthMutation
 from sentry_sdk import capture_message
 
-from merchants.models import PaymentOrder, PaymentStatus
+from merchants.models import OrderStatus, PaymentOrder
 from merchants.verkkokauppa.payment.exceptions import GetPaymentError
 from merchants.verkkokauppa.payment.requests import get_payment
 from permissions.api_permissions.graphene_permissions import OrderRefreshPermission
@@ -58,16 +58,16 @@ class RefreshOrderMutation(relay.ClientIDMutation, AuthMutation):
 
         if (
             payment.status == "payment_cancelled"
-            and payment_order.status is not PaymentStatus.CANCELLED
+            and payment_order.status is not OrderStatus.CANCELLED
         ):
-            payment_order.status = PaymentStatus.CANCELLED
+            payment_order.status = OrderStatus.CANCELLED
             payment_order.save()
 
         if (
             payment.status == "payment_paid_online"
-            and payment_order.status is not PaymentStatus.PAID
+            and payment_order.status is not OrderStatus.PAID
         ):
-            payment_order.status = PaymentStatus.PAID
+            payment_order.status = OrderStatus.PAID
             payment_order.save()
 
             if payment_order.reservation.state == STATE_CHOICES.WAITING_FOR_PAYMENT:

--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -70,7 +70,7 @@ class ReservationFilterSet(django_filters.FilterSet):
 
     text_search = django_filters.CharFilter(method="get_text_search")
 
-    payment_status = django_filters.MultipleChoiceFilter(
+    order_status = django_filters.MultipleChoiceFilter(
         field_name="payment_order__status",
         lookup_expr="iexact",
         choices=tuple(

--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -100,6 +100,7 @@ class ReservationFilterSet(django_filters.FilterSet):
             ("reservation_unit__unit__name_en", "unit_name_en"),
             ("reservation_unit__unit__name_sv", "unit_name_sv"),
             "reservee_name",
+            ("payment_order__status", "order_status"),
         )
     )
 

--- a/api/graphql/reservations/reservation_filtersets.py
+++ b/api/graphql/reservations/reservation_filtersets.py
@@ -8,7 +8,7 @@ from django.db.models import When
 from django.db.models.functions import Concat
 
 from applications.models import CUSTOMER_TYPES
-from merchants.models import PaymentStatus
+from merchants.models import OrderStatus
 from permissions.helpers import (
     get_service_sectors_where_can_view_reservations,
     get_units_where_can_view_reservations,
@@ -78,10 +78,10 @@ class ReservationFilterSet(django_filters.FilterSet):
                 key,
                 value,
             )
-            for key, value in PaymentStatus.choices
+            for key, value in OrderStatus.choices
         ),
         label="PaymentOrder's statuses; %s"
-        % ", ".join([k for k, v in PaymentStatus.choices]),
+        % ", ".join([k for k, v in OrderStatus.choices]),
     )
 
     order_by = django_filters.OrderingFilter(

--- a/api/graphql/reservations/reservation_mutations.py
+++ b/api/graphql/reservations/reservation_mutations.py
@@ -21,7 +21,7 @@ from api.graphql.reservations.reservation_serializers import (
 )
 from api.graphql.reservations.reservation_types import ReservationType
 from api.graphql.validation_errors import ValidationErrorCodes, ValidationErrorWithCode
-from merchants.models import PaymentOrder, PaymentStatus
+from merchants.models import OrderStatus, PaymentOrder
 from merchants.verkkokauppa.order.exceptions import CancelOrderError
 from merchants.verkkokauppa.order.requests import cancel_order
 from permissions.api_permissions.graphene_permissions import (
@@ -148,7 +148,7 @@ class ReservationDeleteMutation(AuthDeleteMutation, ClientIDMutation):
                 )
 
                 if webshop_order and webshop_order.status == "cancelled":
-                    payment_order.status = PaymentStatus.CANCELLED
+                    payment_order.status = OrderStatus.CANCELLED
                     payment_order.save()
             except CancelOrderError as err:
                 capture_message(

--- a/api/graphql/reservations/reservation_serializers/confirm_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/confirm_serializers.py
@@ -3,7 +3,7 @@ from api.graphql.reservations.reservation_serializers.update_serializers import 
     ReservationUpdateSerializer,
 )
 from api.graphql.validation_errors import ValidationErrorCodes, ValidationErrorWithCode
-from merchants.models import Language, PaymentOrder, PaymentStatus
+from merchants.models import Language, OrderStatus, PaymentOrder
 from merchants.verkkokauppa.helpers import create_verkkokauppa_order
 from reservation_units.models import PaymentType
 from reservations.email_utils import send_confirmation_email
@@ -125,7 +125,7 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
             if payment_type == PaymentType.ON_SITE:
                 PaymentOrder.objects.create(
                     payment_type=payment_type,
-                    status=PaymentStatus.PAID_MANUALLY,
+                    status=OrderStatus.PAID_MANUALLY,
                     language=self.instance.reservee_language or Language.FI,
                     price_net=price_net,
                     price_vat=price_vat,
@@ -136,7 +136,7 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
                 payment_order = create_verkkokauppa_order(self.instance)
                 PaymentOrder.objects.create(
                     payment_type=payment_type,
-                    status=PaymentStatus.DRAFT,
+                    status=OrderStatus.DRAFT,
                     language=self.instance.reservee_language or Language.FI,
                     price_net=price_net,
                     price_vat=price_vat,

--- a/api/graphql/tests/test_orders.py
+++ b/api/graphql/tests/test_orders.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient
 
 from api.graphql.tests.base import GrapheneTestCaseBase
-from merchants.models import PaymentOrder, PaymentStatus
+from merchants.models import OrderStatus, PaymentOrder
 from merchants.tests.factories import PaymentOrderFactory
 from merchants.verkkokauppa.payment.exceptions import GetPaymentError
 from merchants.verkkokauppa.payment.test.factories import PaymentFactory
@@ -99,7 +99,7 @@ class RefreshOrderMutationTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         cls.payment_order = PaymentOrderFactory.create(
             reservation=cls.reservation,
             remote_id="b3fef99e-6c18-422e-943d-cf00702af53e",
-            status=PaymentStatus.DRAFT,
+            status=OrderStatus.DRAFT,
             reservation_user_uuid=cls.regular_joe.uuid,
         )
 
@@ -205,7 +205,7 @@ class RefreshOrderMutationTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         self.assertMatchSnapshot(content)
 
         order = PaymentOrder.objects.get(pk=self.payment_order.pk)
-        assert_that(order.status).is_equal_to(PaymentStatus.CANCELLED)
+        assert_that(order.status).is_equal_to(OrderStatus.CANCELLED)
 
     @mock.patch("api.graphql.merchants.merchant_mutations.send_confirmation_email")
     @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
@@ -229,7 +229,7 @@ class RefreshOrderMutationTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         assert_that(mock_send_email.called).is_false()
 
         order = PaymentOrder.objects.get(pk=self.payment_order.pk)
-        assert_that(order.status).is_equal_to(PaymentStatus.PAID)
+        assert_that(order.status).is_equal_to(OrderStatus.PAID)
 
     @mock.patch("api.graphql.merchants.merchant_mutations.send_confirmation_email")
     @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
@@ -256,7 +256,7 @@ class RefreshOrderMutationTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         assert_that(mock_send_email.called).is_true()
 
         order = PaymentOrder.objects.get(pk=self.payment_order.pk)
-        assert_that(order.status).is_equal_to(PaymentStatus.PAID)
+        assert_that(order.status).is_equal_to(OrderStatus.PAID)
 
     @mock.patch("api.graphql.merchants.merchant_mutations.capture_message")
     @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -712,7 +712,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group
     }
 }
 
-snapshots['ReservationQueryTestCase::test_filter_payment_status_multiple_values 1'] = {
+snapshots['ReservationQueryTestCase::test_filter_order_status_multiple_values 1'] = {
     'data': {
         'reservations': {
             'edges': [
@@ -733,7 +733,7 @@ snapshots['ReservationQueryTestCase::test_filter_payment_status_multiple_values 
     }
 }
 
-snapshots['ReservationQueryTestCase::test_filter_payment_status_single_value 1'] = {
+snapshots['ReservationQueryTestCase::test_filter_order_status_single_value 1'] = {
     'data': {
         'reservations': {
             'edges': [

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -966,6 +966,58 @@ snapshots['ReservationQueryTestCase::test_order_by_created_at 1'] = {
     }
 }
 
+snapshots['ReservationQueryTestCase::test_order_by_order_status 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'name': 'this should be 1st',
+                        'orderStatus': 'CANCELLED'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'this should be 2nd',
+                        'orderStatus': 'DRAFT'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'this should be 3rd',
+                        'orderStatus': 'EXPIRED'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'this should be 4th',
+                        'orderStatus': 'PAID'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'this should be 5th',
+                        'orderStatus': 'PAID_MANUALLY'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'this should be 6th',
+                        'orderStatus': 'REFUNDED'
+                    }
+                },
+                {
+                    'node': {
+                        'name': 'movies',
+                        'orderStatus': None
+                    }
+                }
+            ],
+            'totalCount': 7
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_order_by_reservation_unit_name 1'] = {
     'data': {
         'reservations': {

--- a/api/graphql/tests/test_reservations/test_reservation_confirm.py
+++ b/api/graphql/tests/test_reservations/test_reservation_confirm.py
@@ -14,7 +14,7 @@ from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
 from applications.models import City
 from email_notification.models import EmailType
 from email_notification.tests.factories import EmailTemplateFactory
-from merchants.models import PaymentOrder, PaymentStatus, PaymentType
+from merchants.models import OrderStatus, PaymentOrder, PaymentType
 from merchants.tests.factories import PaymentOrderFactory
 from merchants.verkkokauppa.order.test.factories import OrderFactory
 from opening_hours.tests.test_get_periods import get_mocked_periods
@@ -331,7 +331,7 @@ class ReservationConfirmTestCase(ReservationTestCaseBase):
         assert_that(mock_create_vk_order.called).is_false()
         assert_that(local_order).is_not_none()
         assert_that(local_order.payment_type).is_equal_to(PaymentType.ON_SITE)
-        assert_that(local_order.status).is_equal_to(PaymentStatus.PAID_MANUALLY)
+        assert_that(local_order.status).is_equal_to(OrderStatus.PAID_MANUALLY)
         assert_that(local_order.created_at.strftime("%Y%m%d%H%:M:%S")).is_equal_to(
             datetime.datetime.now().strftime("%Y%m%d%H%:M:%S")
         )

--- a/api/graphql/tests/test_reservations/test_reservation_delete.py
+++ b/api/graphql/tests/test_reservations/test_reservation_delete.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
-from merchants.models import PaymentStatus
+from merchants.models import OrderStatus
 from merchants.tests.factories import PaymentOrderFactory
 from merchants.verkkokauppa.order.exceptions import CancelOrderError
 from merchants.verkkokauppa.order.test.factories import OrderFactory
@@ -122,7 +122,7 @@ class ReservationDeleteTestCase(ReservationTestCaseBase):
         self.reservation.save()
 
         payment_order = PaymentOrderFactory.create(
-            remote_id=uuid4(), reservation=self.reservation, status=PaymentStatus.DRAFT
+            remote_id=uuid4(), reservation=self.reservation, status=OrderStatus.DRAFT
         )
 
         self.client.force_login(self.regular_joe)
@@ -137,7 +137,7 @@ class ReservationDeleteTestCase(ReservationTestCaseBase):
         assert_that(mock_cancel_order.called).is_true()
 
         payment_order.refresh_from_db()
-        assert_that(payment_order.status).is_equal_to(PaymentStatus.CANCELLED)
+        assert_that(payment_order.status).is_equal_to(OrderStatus.CANCELLED)
 
     @mock.patch("api.graphql.reservations.reservation_mutations.cancel_order")
     def test_do_not_mark_order_cancelled_if_webshop_call_fails(self, mock_cancel_order):
@@ -147,7 +147,7 @@ class ReservationDeleteTestCase(ReservationTestCaseBase):
         self.reservation.save()
 
         payment_order = PaymentOrderFactory.create(
-            remote_id=uuid4(), reservation=self.reservation, status=PaymentStatus.DRAFT
+            remote_id=uuid4(), reservation=self.reservation, status=OrderStatus.DRAFT
         )
 
         self.client.force_login(self.regular_joe)
@@ -162,7 +162,7 @@ class ReservationDeleteTestCase(ReservationTestCaseBase):
         assert_that(mock_cancel_order.called).is_true()
 
         payment_order.refresh_from_db()
-        assert_that(payment_order.status).is_equal_to(PaymentStatus.DRAFT)
+        assert_that(payment_order.status).is_equal_to(OrderStatus.DRAFT)
 
     @mock.patch("api.graphql.reservations.reservation_mutations.capture_message")
     @mock.patch("api.graphql.reservations.reservation_mutations.cancel_order")

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -296,7 +296,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
-    def test_filter_payment_status_single_value(self):
+    def test_filter_order_status_single_value(self):
         self.maxDiff = None
         self.client.force_login(self.general_admin)
         metadata = ReservationMetadataSetFactory()
@@ -311,7 +311,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         response = self.query(
             """
             query {
-                reservations(paymentStatus: "DRAFT") {
+                reservations(orderStatus: "DRAFT") {
                     edges {
                         node {
                             state
@@ -327,7 +327,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
-    def test_filter_payment_status_multiple_values(self):
+    def test_filter_order_status_multiple_values(self):
         self.maxDiff = None
         self.client.force_login(self.general_admin)
         metadata = ReservationMetadataSetFactory()
@@ -364,7 +364,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         response = self.query(
             """
             query {
-                reservations(paymentStatus: ["PAID", "REFUNDED"]) {
+                reservations(orderStatus: ["PAID", "REFUNDED"]) {
                     edges {
                         node {
                             state

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -1252,6 +1252,45 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_order_by_order_status(self):
+        res1 = ReservationFactory(name="this should be 1st")
+        PaymentOrderFactory(status=PaymentStatus.CANCELLED, reservation=res1)
+
+        res2 = ReservationFactory(name="this should be 2nd")
+        PaymentOrderFactory(status=PaymentStatus.DRAFT, reservation=res2)
+
+        res3 = ReservationFactory(name="this should be 3rd")
+        PaymentOrderFactory(status=PaymentStatus.EXPIRED, reservation=res3)
+
+        res4 = ReservationFactory(name="this should be 4th")
+        PaymentOrderFactory(status=PaymentStatus.PAID, reservation=res4)
+
+        res5 = ReservationFactory(name="this should be 5th")
+        PaymentOrderFactory(status=PaymentStatus.PAID_MANUALLY, reservation=res5)
+
+        res6 = ReservationFactory(name="this should be 6th")
+        PaymentOrderFactory(status=PaymentStatus.REFUNDED, reservation=res6)
+
+        self.client.force_login(self.general_admin)
+        response = self.query(
+            """
+            query {
+                reservations(orderBy:"orderStatus") {
+                    totalCount
+                    edges {
+                        node {
+                            name
+                            orderStatus
+                        }
+                    }
+                }
+            }
+            """
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
     def test_getting_reservation_with_fields_requiring_special_permissions(self):
         self.client.force_login(self.general_admin)
         response = self.query(

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -9,7 +9,7 @@ from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
 from applications.models import CUSTOMER_TYPES, City
-from merchants.models import PaymentStatus
+from merchants.models import OrderStatus
 from merchants.tests.factories import PaymentOrderFactory
 from reservation_units.models import ReservationUnit
 from reservation_units.tests.factories import (
@@ -340,7 +340,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             begin=datetime.datetime.now(tz=get_default_timezone())
             + datetime.timedelta(days=2),
         )
-        PaymentOrderFactory(reservation=res, status=PaymentStatus.PAID)
+        PaymentOrderFactory(reservation=res, status=OrderStatus.PAID)
         res_too = ReservationFactory(
             state=STATE_CHOICES.CANCELLED,
             reservation_unit=[res_unit],
@@ -349,7 +349,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             begin=datetime.datetime.now(tz=get_default_timezone())
             + datetime.timedelta(days=1),
         )
-        PaymentOrderFactory(reservation=res_too, status=PaymentStatus.REFUNDED)
+        PaymentOrderFactory(reservation=res_too, status=OrderStatus.REFUNDED)
 
         ReservationFactory(
             state=STATE_CHOICES.WAITING_FOR_PAYMENT,
@@ -359,7 +359,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
             begin=datetime.datetime.now(tz=get_default_timezone())
             + datetime.timedelta(days=1),
         )
-        PaymentOrderFactory(reservation=res_too, status=PaymentStatus.EXPIRED)
+        PaymentOrderFactory(reservation=res_too, status=OrderStatus.EXPIRED)
 
         response = self.query(
             """
@@ -1254,22 +1254,22 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
 
     def test_order_by_order_status(self):
         res1 = ReservationFactory(name="this should be 1st")
-        PaymentOrderFactory(status=PaymentStatus.CANCELLED, reservation=res1)
+        PaymentOrderFactory(status=OrderStatus.CANCELLED, reservation=res1)
 
         res2 = ReservationFactory(name="this should be 2nd")
-        PaymentOrderFactory(status=PaymentStatus.DRAFT, reservation=res2)
+        PaymentOrderFactory(status=OrderStatus.DRAFT, reservation=res2)
 
         res3 = ReservationFactory(name="this should be 3rd")
-        PaymentOrderFactory(status=PaymentStatus.EXPIRED, reservation=res3)
+        PaymentOrderFactory(status=OrderStatus.EXPIRED, reservation=res3)
 
         res4 = ReservationFactory(name="this should be 4th")
-        PaymentOrderFactory(status=PaymentStatus.PAID, reservation=res4)
+        PaymentOrderFactory(status=OrderStatus.PAID, reservation=res4)
 
         res5 = ReservationFactory(name="this should be 5th")
-        PaymentOrderFactory(status=PaymentStatus.PAID_MANUALLY, reservation=res5)
+        PaymentOrderFactory(status=OrderStatus.PAID_MANUALLY, reservation=res5)
 
         res6 = ReservationFactory(name="this should be 6th")
-        PaymentOrderFactory(status=PaymentStatus.REFUNDED, reservation=res6)
+        PaymentOrderFactory(status=OrderStatus.REFUNDED, reservation=res6)
 
         self.client.force_login(self.general_admin)
         response = self.query(
@@ -1412,7 +1412,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
         PaymentOrderFactory(
             reservation=self.reservation,
             remote_id="626c0cf7-3628-4ff5-aa9c-1b4e70dedc89",
-            status=PaymentStatus.PAID,
+            status=OrderStatus.PAID,
         )
 
         response = self.query(

--- a/merchants/models.py
+++ b/merchants/models.py
@@ -58,7 +58,7 @@ class PaymentType(models.TextChoices):
     INVOICE = "INVOICE", _("Invoice")
 
 
-class PaymentStatus(models.TextChoices):
+class OrderStatus(models.TextChoices):
     DRAFT = "DRAFT", _("Draft")
     EXPIRED = "EXPIRED", _("Expired")
     CANCELLED = "CANCELLED", _("Cancelled")
@@ -108,7 +108,7 @@ class PaymentOrder(models.Model):
         blank=False,
         null=False,
         max_length=128,
-        choices=PaymentStatus.choices,
+        choices=OrderStatus.choices,
     )
     price_net = models.DecimalField(
         verbose_name=_("Net amount"),

--- a/merchants/tests/factories.py
+++ b/merchants/tests/factories.py
@@ -5,7 +5,7 @@ from factory import SubFactory, post_generation
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
-from merchants.models import Language, PaymentStatus, PaymentType
+from merchants.models import Language, OrderStatus, PaymentType
 
 
 class PaymentMerchantFactory(DjangoModelFactory):
@@ -39,5 +39,5 @@ class PaymentOrderFactory(DjangoModelFactory):
     price_vat = Decimal("2.0")
     price_total = Decimal("12.0")
     payment_type = PaymentType.INVOICE
-    status = PaymentStatus.DRAFT
+    status = OrderStatus.DRAFT
     language = Language.FI


### PR DESCRIPTION
## Change log
- Add `order_status` to Reservation `order_by` fields
- Refactoring: renamed `payment_status` filter to `order_status` (see notes)

## Other notes
`ReservationType` has a field called `order_status` but the related filter was called `payment_status` which led a bit confusing queries. I renamed the filter so that now everything - field, filter and order_by - is using the same naming convention.

Filter is already used on the admin client, so this requires some syncing with the frontend code. @wuahi will work on this on the frontend side.

## Deployment reminder
- No changes required