### PR TITLE
TILA-2124: Add handled_at field to ReservationType

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -143,6 +143,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     type = graphene.String()
     order_uuid = graphene.String()
     order_status = graphene.String()
+    handled_at = graphene.DateTime()
 
     class Meta:
         model = Reservation
@@ -193,6 +194,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             "type",
             "order_uuid",
             "order_status",
+            "handled_at",
         ]
         filter_fields = {
             "state": ["exact"],
@@ -258,6 +260,11 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     def resolve_type(self, info: ResolveInfo) -> Optional[str]:
         if can_handle_reservation(info.context.user, self):
             return self.type
+        return None
+
+    def resolve_handled_at(self, info: ResolveInfo) -> Optional[str]:
+        if can_handle_reservation(info.context.user, self):
+            return self.handled_at
         return None
 
     @reservation_non_public_field

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -822,6 +822,38 @@ snapshots['ReservationQueryTestCase::test_getting_reservation_with_fields_requir
     }
 }
 
+snapshots['ReservationQueryTestCase::test_handled_at_not_visible_without_permissions 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'handledAt': None,
+                        'name': 'movies'
+                    }
+                }
+            ],
+            'totalCount': 1
+        }
+    }
+}
+
+snapshots['ReservationQueryTestCase::test_handled_at_visible_with_permissions 1'] = {
+    'data': {
+        'reservations': {
+            'edges': [
+                {
+                    'node': {
+                        'handledAt': '2021-10-12T09:00:00+00:00',
+                        'name': 'movies'
+                    }
+                }
+            ],
+            'totalCount': 1
+        }
+    }
+}
+
 snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 1'] = {
     'data': {
         'reservations': {


### PR DESCRIPTION
## Change log
- Add `handled_at` field to `ReservationType`

## Deployment reminder
- No changes required