### PR TITLE
TILA-1518: Remove python-dev and upgrade easy-thumbnails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
       - name: psycopg2 and graphviz prerequisites
         run: |
           sudo apt update
-          sudo apt install python-dev libpq-dev gdal-bin graphviz -y
+          sudo apt install libpq-dev gdal-bin graphviz -y
       - name: Install dependencies
         run: |
           python3 -m pip install --upgrade pip

--- a/requirements.in
+++ b/requirements.in
@@ -19,7 +19,7 @@ django-tinymce==3.4.0
 djangorestframework==3.12.2
 drf-oidc-auth==0.10.0
 drf-spectacular==0.24.2
-easy-thumbnails==2.7.1
+easy-thumbnails
 flake8==3.8.4
 graphene-django==3.0.0b7
 graphene_permissions==1.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -128,7 +128,7 @@ drf-oidc-auth==0.10.0
     #   helsinki-profile-gdpr-api
 drf-spectacular==0.24.2
     # via -r requirements.in
-easy-thumbnails==2.7.1
+easy-thumbnails==2.8.3
     # via -r requirements.in
 ecdsa==0.14.1
     # via python-jose


### PR DESCRIPTION
## Change log
- Removed python-dev installation from build.yml
- Upgraded easy-thumbnails to get rid of [vulnerability](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/security/dependabot/12)

## Other notes
Python-dev is not needed anymore. Also, it is not available causing build to fail.

## Deployment reminder
- No changes required