### PR TITLE
TILA-2163: Fix payment product requirement

### DIFF
--- a/api/graphql/reservations/reservation_serializers/confirm_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/confirm_serializers.py
@@ -79,7 +79,7 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
             payment_type = data.get("payment_type", "").upper()
             reservation_unit = self.instance.reservation_unit.first()
 
-            if not reservation_unit.payment_product:
+            if self.instance.price_net > 0 and not reservation_unit.payment_product:
                 raise ValidationErrorWithCode(
                     "Reservation unit is missing payment product",
                     ValidationErrorCodes.MISSING_PAYMENT_PRODUCT,
@@ -87,7 +87,12 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
 
             if not payment_type:
                 data["payment_type"] = self._get_default_payment_type()
-            elif not reservation_unit.payment_types.filter(code=payment_type).exists():
+            elif (
+                self.instance.price_net > 0
+                and not reservation_unit.payment_types.filter(
+                    code=payment_type
+                ).exists()
+            ):
                 allowed_values = list(
                     map(lambda x: x.code, reservation_unit.payment_types.all())
                 )


### PR DESCRIPTION
## Change log
- Fix payment product requirement
- Removed payment_type check when price is zero
- Added tests

## Other notes
Payment product and payment_type check are not required when price of the reservation is zero.

## Deployment reminder
- No changes required