### PR TITLE
TILA-2100 | Set first res unit to recurring reservation from reservation

### DIFF
--- a/reservations/migrations/0040_recurring_reservation_fields_changes.py
+++ b/reservations/migrations/0040_recurring_reservation_fields_changes.py
@@ -10,7 +10,7 @@ def set_reservation_units(apps, schema_editor):
     for recurring in RecurringReservation.objects.filter(reservation_unit__isnull=True):
         reservation = recurring.reservations.first()
         if reservation:
-            recurring.reservation_unit = reservation.reservation_unit
+            recurring.reservation_unit = reservation.reservation_unit.first()
             recurring.save()
         else:
             recurring.delete()


### PR DESCRIPTION
Previously the recurring migration file, which introduced new fields including reservation_unit to recurring reservation model, blew up because it tried to set reservation_unit_queryset to be fk field. This fixes that by using the first reservation unit from the queryset

Refs TILA-2100

