### PR TITLE
TILA-1978 | Add new fields to reservation unit exporter

### DIFF
--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -683,7 +683,13 @@ class ReservationUnit(models.Model):
             refresh_reservation_unit_product_mapping.delay(self.pk)
 
 
+class ReservationUnitPricingManager(models.QuerySet):
+    def active(self):
+        return self.filter(status=PricingStatus.PRICING_STATUS_ACTIVE).first()
+
+
 class ReservationUnitPricing(models.Model):
+    objects = ReservationUnitPricingManager.as_manager()
 
     begins = models.DateField(
         verbose_name=_("Date when price is activated"),

--- a/reservation_units/tests/factories.py
+++ b/reservation_units/tests/factories.py
@@ -20,6 +20,7 @@ class EquipmentFactory(DjangoModelFactory):
     class Meta:
         model = "reservation_units.Equipment"
 
+    name = FuzzyText()
     category = SubFactory(EquipmentCategoryFactory)
 
 
@@ -106,6 +107,14 @@ class ReservationUnitFactory(DjangoModelFactory):
 
         for equipment in equipments:
             self.equipments.add(equipment)
+
+    @post_generation
+    def qualifiers(self, create, qualifiers, **kwargs):
+        if not create or not qualifiers:
+            return
+
+        for qualifier in qualifiers:
+            self.qualifiers.add(qualifier)
 
 
 class ReservationUnitImageFactory(DjangoModelFactory):

--- a/reservation_units/utils/export_data.py
+++ b/reservation_units/utils/export_data.py
@@ -4,6 +4,7 @@ from typing import List
 
 from django.conf import settings
 from django.utils import timezone
+from django.utils.timezone import get_default_timezone
 
 from ..models import ReservationUnit
 
@@ -28,6 +29,7 @@ class ReservationUnitExporter:
                 cls._write_header_row(reservations_writer)
 
                 for reservation_unit in reservation_units:
+                    pricing = reservation_unit.pricings.active()
                     reservations_writer.writerow(
                         [
                             reservation_unit.id,
@@ -50,6 +52,89 @@ class ReservationUnitExporter:
                             reservation_unit.is_draft,
                             reservation_unit.publish_begins,
                             reservation_unit.publish_ends,
+                            ", ".join(
+                                reservation_unit.spaces.values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
+                            ", ".join(
+                                reservation_unit.resources.values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
+                            ", ".join(
+                                reservation_unit.qualifiers.all().values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
+                            getattr(reservation_unit.payment_terms, "name", ""),
+                            getattr(reservation_unit.cancellation_terms, "name", ""),
+                            getattr(reservation_unit.pricing_terms, "name", ""),
+                            getattr(reservation_unit.cancellation_rule, "name", ""),
+                            pricing.price_unit,
+                            pricing.lowest_price,
+                            pricing.highest_price,
+                            pricing.tax_percentage,
+                            reservation_unit.reservation_begins.astimezone(
+                                get_default_timezone()
+                            ).strftime("%d:%m:%Y %H:%M")
+                            if reservation_unit.reservation_begins
+                            else "",
+                            reservation_unit.reservation_ends.astimezone(
+                                get_default_timezone()
+                            ).strftime("%d:%m:%Y %H:%M")
+                            if reservation_unit.reservation_ends
+                            else "",
+                            getattr(reservation_unit.metadata_set, "name", ""),
+                            reservation_unit.require_reservation_handling,
+                            reservation_unit.authentication,
+                            reservation_unit.reservation_kind,
+                            pricing.pricing_type,
+                            ", ".join(
+                                reservation_unit.payment_types.values_list(
+                                    "code", flat=True
+                                )
+                            ),
+                            reservation_unit.can_apply_free_of_charge,
+                            reservation_unit.reservation_pending_instructions_fi,
+                            reservation_unit.reservation_pending_instructions_sv,
+                            reservation_unit.reservation_pending_instructions_en,
+                            reservation_unit.reservation_confirmed_instructions_fi,
+                            reservation_unit.reservation_confirmed_instructions_sv,
+                            reservation_unit.reservation_confirmed_instructions_en,
+                            reservation_unit.reservation_cancelled_instructions_fi,
+                            reservation_unit.reservation_cancelled_instructions_sv,
+                            reservation_unit.reservation_cancelled_instructions_en,
+                            reservation_unit.max_reservation_duration,
+                            reservation_unit.min_reservation_duration,
+                            reservation_unit.max_persons,
+                            reservation_unit.min_persons,
+                            reservation_unit.surface_area,
+                            reservation_unit.buffer_time_before,
+                            reservation_unit.buffer_time_after,
+                            reservation_unit.hauki_resource_id,
+                            reservation_unit.reservation_start_interval,
+                            reservation_unit.reservations_max_days_before,
+                            reservation_unit.reservations_min_days_before,
+                            reservation_unit.max_reservations_per_user,
+                            reservation_unit.allow_reservations_without_opening_hours,
+                            reservation_unit.is_archived,
+                            ", ".join(
+                                reservation_unit.services.all().values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
+                            ", ".join(
+                                reservation_unit.purposes.all().values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
+                            reservation_unit.require_introduction,
+                            ", ".join(
+                                reservation_unit.equipments.all().values_list(
+                                    "name_fi", flat=True
+                                )
+                            ),
                         ]
                     )
 
@@ -78,5 +163,52 @@ class ReservationUnitExporter:
                 "Is this in draft state",
                 "Publish begins",
                 "Publish ends",
+                "Spaces",
+                "Resources",
+                "Qualifiers",
+                "Payment terms",
+                "Cancellation terms",
+                "Pricing terms",
+                "Cancellation rule",
+                "Price unit",
+                "Lowest price",
+                "Highest price",
+                "Tax percentage",
+                "Reservation begins",
+                "Reservation ends",
+                "Reservation metadata set",
+                "Require a handling",
+                "Authentication",
+                "Reservation kind",
+                "Pricing types",
+                "Payment type",
+                "Can apply free of charge",
+                "Additional instructions for pending reservation [fi]",
+                "Additional instructions for pending reservation [sv]",
+                "Additional instructions for pending reservation [en]",
+                "Additional instructions for confirmed reservation [fi]",
+                "Additional instructions for confirmed reservation [sv]",
+                "Additional instructions for confirmed reservation [en]",
+                "Additional instructions for cancelled reservations [fi]",
+                "Additional instructions for cancelled reservations [sv]",
+                "Additional instructions for cancelled reservations [en]",
+                "Maximum reservation duration",
+                "Minimum reservation duration",
+                "Maximum number of persons",
+                "Minimum number of persons",
+                "Surface area",
+                "Buffer time before reservation",
+                "Buffer time after reservation",
+                "Hauki resource id",
+                "Reservation start interval",
+                "Maximum number of days before reservations can be made",
+                "Minimum days before reservations can be made",
+                "Maximum number of active reservations per user",
+                "Allow reservations without opening hours",
+                "Is reservation unit archived",
+                "Services",
+                "Purposes",
+                "Require introduction",
+                "Equipments",
             ]
         )


### PR DESCRIPTION
## Change log
- Adds bunch of new fields to `ReservationUnit` exporter

## Other notes
These fields were already on previous tag (0.17.1) but not in main since that version of the tag there weren't yet pricing fields.

