### PR TITLE
TILA-2219: Add more logging and better exception handling

### DIFF
--- a/merchants/tests/test_models.py
+++ b/merchants/tests/test_models.py
@@ -114,10 +114,7 @@ class PaymentAccountingTestCase(TestCase):
         self.accounting.refresh_from_db()
         self.accounting.save()
 
-        assert_that(mock_upsert_accounting.mock_calls).is_equal_to(
-            [
-                mock.call(self.reservation_unit_1.pk),
-                mock.call(self.reservation_unit_2.pk),
-            ]
+        assert_that(mock_upsert_accounting.mock_calls).contains_only(
+            mock.call(self.reservation_unit_1.pk), mock.call(self.reservation_unit_2.pk)
         )
         assert_that(mock_upsert_accounting.call_count).is_equal_to(2)

--- a/merchants/verkkokauppa/helpers.py
+++ b/merchants/verkkokauppa/helpers.py
@@ -4,7 +4,7 @@ from typing import Optional
 
 from django.conf import settings
 from django.utils.timezone import get_default_timezone
-from sentry_sdk import capture_message
+from sentry_sdk import capture_exception, capture_message
 
 from api.graphql.validation_errors import ValidationErrorCodes, ValidationErrorWithCode
 from applications.models import CUSTOMER_TYPES
@@ -119,8 +119,9 @@ def create_verkkokauppa_order(reservation: Reservation):
             f"Call to Verkkokauppa Order Experience API failed: {e}",
             level="error",
         )
+        capture_exception(e, {"order_params": order_params})
         raise ValidationErrorWithCode(
             "Upstream service call failed. Unable to confirm the reservation.",
             ValidationErrorCodes.UPSTREAM_CALL_FAILED,
-        )
+        ) from e
     return payment_order

--- a/merchants/verkkokauppa/order/requests.py
+++ b/merchants/verkkokauppa/order/requests.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from requests import RequestException
 from requests import get as _get
 from requests import post as _post
-from sentry_sdk import capture_message
+from sentry_sdk import capture_exception, capture_message
 
 from ..constants import REQUEST_TIMEOUT_SECONDS
 from ..exceptions import VerkkokauppaConfigurationError
@@ -53,7 +53,8 @@ def create_order(params: CreateOrderParams, post=_post) -> Order:
             raise CreateOrderError(f"Order creation failed: {json.get('errors')}")
         return Order.from_json(json)
     except (RequestException, JSONDecodeError, ParseOrderError) as e:
-        raise CreateOrderError(f"Order creation failed: {e}")
+        capture_exception(e)
+        raise CreateOrderError(f"Order creation failed: {e}") from e
 
 
 def get_order(order_id: UUID, user: str, get=_get) -> Order:

--- a/merchants/verkkokauppa/order/types.py
+++ b/merchants/verkkokauppa/order/types.py
@@ -129,10 +129,10 @@ class Order:
                                 order_id=UUID(meta["orderId"]),
                                 key=meta["key"],
                                 value=meta["value"],
-                                label=meta["label"],
-                                visible_in_checkout=meta["visibleInCheckout"]
+                                label=meta.get("label"),
+                                visible_in_checkout=meta.get("visibleInCheckout")
                                 not in [False, "false"],
-                                ordinal=meta["ordinal"],
+                                ordinal=meta.get("ordinal"),
                             )
                             for meta in item["meta"]
                         ],

--- a/merchants/verkkokauppa/order/types.py
+++ b/merchants/verkkokauppa/order/types.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 
+from sentry_sdk import capture_exception
+
 from .exceptions import ParseOrderError
 
 
@@ -162,6 +164,7 @@ class Order:
                 type=json["type"],
             )
         except (KeyError, ValueError) as e:
+            capture_exception(e, {"json": json})
             raise ParseOrderError("Could not parse order") from e
 
 


### PR DESCRIPTION
## Change log
- Use `from` with exceptions to get the previous exception
- Add `capture_exception` calls to get better error reporting in Sentry
- Fix flaky test

## Other notes
Sentry does not show exception stacks when `capture_message` is used. Hopefully `capture_exception` changes that. I also used `from` with exception to capture the parent exception.

This PR is mostly to help me figure out the parsing issue but also to test how Sentry SDK behaves with `capture_exception`. The actual fix to the bug comes later when I figure out what is causing it.

## Deployment reminder
- No changes required