### PR TITLE
TILA-2134 | Emailt template context variables; current year and links

### DIFF
--- a/email_notification/sender/email_notification_builder.py
+++ b/email_notification/sender/email_notification_builder.py
@@ -1,3 +1,4 @@
+import datetime
 import os
 import re
 from typing import Dict
@@ -198,6 +199,9 @@ class ReservationEmailNotificationBuilder:
         return self._get_reservation_unit_instruction_field(
             "reservation_confirmed_instructions"
         )
+
+    def _get_current_year(self):
+        return datetime.datetime.now(get_default_timezone()).year
 
     def _get_pending_instructions(self):
         return self._get_reservation_unit_instruction_field(

--- a/email_notification/sender/email_notification_builder.py
+++ b/email_notification/sender/email_notification_builder.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import re
 from typing import Dict
+from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -225,6 +226,33 @@ class ReservationEmailNotificationBuilder:
 
     def _get_cancel_reason(self):
         return self._get_by_language(self.reservation.cancel_reason, "reason")
+
+    def _get_varaamo_ext_link(self):
+        url_base = settings.EMAIL_VARAAMO_EXT_LINK
+
+        if self.language.lower() != "fi":
+            return urljoin(url_base, self.language)
+
+        return url_base
+
+    def _get_my_reservations_ext_link(self):
+        url_base = settings.EMAIL_VARAAMO_EXT_LINK
+
+        if self.language.lower() != "fi":
+            url_base = urljoin(url_base, self.language) + "/"
+
+        return urljoin(url_base, "reservations")
+
+    def _get_feedback_ext_link(self):
+        params = urlencode(
+            {
+                "site": "varaamopalaute",
+                "lang": self.language,
+                "ref": settings.EMAIL_VARAAMO_EXT_LINK,
+            }
+        )
+
+        return f"{settings.EMAIL_FEEDBACK_EXT_LINK}?{params}"
 
     def _get_by_language(self, instance, field):
         return getattr(

--- a/email_notification/tests/base.py
+++ b/email_notification/tests/base.py
@@ -22,8 +22,10 @@ class ReservationEmailBaseTestCase(TestCase):
             type=EmailType.RESERVATION_CONFIRMED,
             content="This is the {{ reservation_number }} content",
             content_en="This is the {{ reservation_number }} content in english",
+            content_sv="Det är {{ reservation_number }} innehållet på svenska",
             subject="Los subjectos {{ name }}",
             subject_en="Los subjectos inglesa {{ name }}",
+            subject_sv="Los subjectos sueca {{ name }}",
         )
 
         cls.unit = UnitFactory(name="The unit")

--- a/email_notification/tests/test_notification_builders.py
+++ b/email_notification/tests/test_notification_builders.py
@@ -180,6 +180,69 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
             self.reservation.cancel_reason.reason_en
         )
 
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_my_reservations_ext_link_fi(self):
+        self.builder._set_language(LANGUAGES.FI)
+        assert_that(self.builder._get_my_reservations_ext_link()).is_equal_to(
+            "https://thesite.com/reservations"
+        )
+
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_my_reservations_ext_link_en(self):
+        self.builder._set_language(LANGUAGES.EN)
+        assert_that(self.builder._get_my_reservations_ext_link()).is_equal_to(
+            "https://thesite.com/en/reservations"
+        )
+
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_my_reservations_ext_link_sv(self):
+        self.builder._set_language(LANGUAGES.SV)
+        assert_that(self.builder._get_my_reservations_ext_link()).is_equal_to(
+            "https://thesite.com/sv/reservations"
+        )
+
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_varaamo_ext_link(self):
+        self.builder._set_language(LANGUAGES.FI)
+        assert_that(self.builder._get_varaamo_ext_link()).is_equal_to(
+            "https://thesite.com"
+        )
+
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_varaamo_ext_link_en(self):
+        self.builder._set_language(LANGUAGES.EN)
+        assert_that(self.builder._get_varaamo_ext_link()).is_equal_to(
+            "https://thesite.com/en"
+        )
+
+    @override_settings(EMAIL_VARAAMO_EXT_LINK="https://thesite.com")
+    def test_get_varaamo_ext_link_sv(self):
+        self.builder._set_language(LANGUAGES.SV)
+        assert_that(self.builder._get_varaamo_ext_link()).is_equal_to(
+            "https://thesite.com/sv"
+        )
+
+    @override_settings(EMAIL_FEEDBACK_EXT_LINK="https://feedback.com/forms/")
+    def get_feedback_ext_link_fi(self):
+        self.builder._set_language(LANGUAGES.FI)
+        assert_that(self.builder._get_feedback_ext_link()).is_equal_to(
+            "https://feedback.com/forms/?site=varaamopalaute&lang=fi&ref=https://tilavaraus.hel.fi"
+        )
+
+    @override_settings(EMAIL_FEEDBACK_EXT_LINK="https://feedback.com/forms/")
+    def get_feedback_ext_link_sv(self):
+        self.builder._set_language(LANGUAGES.SV)
+        assert_that(self.builder._get_feedback_ext_link()).is_equal_to(
+            "https://feedback.com/forms/?site=varaamopalaute&lang=sv&ref=https://tilavaraus.hel.fi"
+        )
+
+    @override_settings(EMAIL_FEEDBACK_EXT_LINK="https://feedback.com/forms/")
+    def get_feedback_ext_link_en(self):
+        self.builder._set_language(LANGUAGES.EN)
+        assert_that(self.builder._get_feedback_ext_link()).is_equal_to(
+            "https://feedback.com/forms/?site=varaamopalaute&lang=en&ref=https://tilavaraus.hel.fi"
+        )
+
     @override_settings(
         EMAIL_TEMPLATE_CONTEXT_VARIABLES=settings.EMAIL_TEMPLATE_CONTEXT_VARIABLES
         + ["imnotdefined"]
@@ -216,6 +279,10 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
         builder = ReservationEmailNotificationBuilder(self.reservation, template)
         assert_that(builder.get_subject()).is_equal_to(compiled_subject)
 
+    @override_settings(
+        EMAIL_FEEDBACK_EXT_LINK="https://feedtheback.com/survey/",
+        EMAIL_VARAAMO_EXT_LINK="https://resourcebooking.com",
+    )
     def test_get_content(self):
         content = """
             Should contain {{ name }} and {{ begin_date }} and {{ begin_time }} and {{ end_date }}
@@ -228,8 +295,15 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
             system.
 
             copyright {{ current_year }}
+            link to varaamo {{ varaamo_ext_link }}
+            link to reservations {{ my_reservations_ext_link }}
+            link to feedback {{ feedback_ext_link }}
         """
         year = datetime.datetime.now(get_default_timezone()).year
+        feedback_url = (
+            "https://feedtheback.com/survey/?site=varaamopalaute&lang=fi"
+            "&ref=https%3A%2F%2Fresourcebooking.com"
+        )
         compiled_content = f"""
             Should contain Dance time! and 9.2.2022 and 10:00 and 9.2.2022
             and 12:00 and of course the {self.reservation.id}
@@ -241,6 +315,9 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
             system.
 
             copyright {year}
+            link to varaamo https://resourcebooking.com
+            link to reservations https://resourcebooking.com/reservations
+            link to feedback {feedback_url}
         """
         template = EmailTemplateFactory(
             type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject"
@@ -283,6 +360,7 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
         )
 
     def test_language_defaults_to_fi_when_content_not_translated(self):
+        self.builder.template.content_sv = None
         self.builder._set_language(LANGUAGES.SV)
         assert_that(self.builder.language).is_equal_to(LANGUAGES.FI)
         assert_that(self.builder._get_deny_reason()).is_equal_to(

--- a/email_notification/tests/test_notification_builders.py
+++ b/email_notification/tests/test_notification_builders.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 from assertpy import assert_that
 from django.conf import settings
 from django.test import override_settings
+from django.utils.timezone import get_default_timezone
 from pytz import UTC
 
 from applications.models import CUSTOMER_TYPES
@@ -120,6 +121,10 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
             self.reservation.tax_percentage_value
         )
 
+    def test_get_current_year(self):
+        now = datetime.datetime.now(get_default_timezone())
+        assert_that(self.builder._get_current_year()).is_equal_to(now.year)
+
     def test_get_confirmed_instructions(self):
         assert_that(self.builder._get_confirmed_instructions()).contains(
             self.reservation.reservation_unit.first().reservation_confirmed_instructions
@@ -221,7 +226,10 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
 
             Yours truly:
             system.
+
+            copyright {{ current_year }}
         """
+        year = datetime.datetime.now(get_default_timezone()).year
         compiled_content = f"""
             Should contain Dance time! and 9.2.2022 and 10:00 and 9.2.2022
             and 12:00 and of course the {self.reservation.id}
@@ -231,6 +239,8 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
 
             Yours truly:
             system.
+
+            copyright {year}
         """
         template = EmailTemplateFactory(
             type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject"

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -351,6 +351,7 @@ EMAIL_TEMPLATE_CONTEXT_VARIABLES = [
     "cancelled_instructions",
     "deny_reason",
     "cancel_reason",
+    "current_year",
 ]
 EMAIL_TEMPLATE_SUPPORTED_EXPRESSIONS = ["if", "elif", "else", "endif"]
 

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -42,7 +42,7 @@ def get_git_revision_hash() -> str:
         git_hash = subprocess.check_output(  # nosec
             ["git", "rev-parse", "HEAD"], stderr=subprocess.DEVNULL, encoding="utf8"
         )
-    # ie. "git" was not found
+    # i.e. "git" was not found
     # should we return a more generic meta hash here?
     # like "undefined"?
     except FileNotFoundError:
@@ -213,6 +213,8 @@ env = environ.Env(
     SEND_RESERVATION_NOTIFICATION_EMAILS=(str, False),
     DEFAULT_FROM_EMAIL=(str, django_default_from_email),
     EMAIL_HTML_MAX_FILE_SIZE=(int, 150000),
+    EMAIL_VARAAMO_EXT_LINK=(str, None),
+    EMAIL_FEEDBACK_EXT_LINK=(str, None),
     # Tprek
     TPREK_UNIT_URL=(str, "https://www.hel.fi/palvelukarttaws/rest/v4/unit/"),
     # GDPR API
@@ -352,12 +354,17 @@ EMAIL_TEMPLATE_CONTEXT_VARIABLES = [
     "deny_reason",
     "cancel_reason",
     "current_year",
+    "varaamo_ext_link",
+    "my_reservations_ext_link",
+    "feedback_ext_link",
 ]
 EMAIL_TEMPLATE_SUPPORTED_EXPRESSIONS = ["if", "elif", "else", "endif"]
 
 SEND_RESERVATION_NOTIFICATION_EMAILS = env("SEND_RESERVATION_NOTIFICATION_EMAILS")
 EMAIL_HTML_MAX_FILE_SIZE = env("EMAIL_HTML_MAX_FILE_SIZE")
 EMAIL_HTML_TEMPLATES_ROOT = "email_html_templates"
+EMAIL_VARAAMO_EXT_LINK = env("EMAIL_VARAAMO_EXT_LINK")
+EMAIL_FEEDBACK_EXT_LINK = env("EMAIL_FEEDBACK_EXT_LINK")
 
 # TPREK
 TPREK_UNIT_URL = env("TPREK_UNIT_URL")
@@ -513,7 +520,7 @@ THUMBNAIL_ALIASES = {
 }
 
 # Do not try to chmod when uploading images.
-# Our environments uses persistent storage for media and operation will not be permitted.
+# Our environments use persistent storage for media and operation will not be permitted.
 # https://dev.azure.com/City-of-Helsinki/devops-guides/_git/devops-handbook?path=/storage.md&_a=preview&anchor=operation-not-permitted
 FILE_UPLOAD_PERMISSIONS = None
 


### PR DESCRIPTION
## Change log
- Adds `current_year` as email template variables
- Adds `varaamo_ext_link`, `my_reservations_ext_link` and `feedback_ext_link` to email template variables
    - Those are to be configured via env variables `EMAIL_VARAAMO_EXT_LINK` and `EMAIL_FEEDBACK_EXT_LINK`

## Other notes
Note to contributor; Remember the steps below 👇 

## Deployment reminder
- [x] PR requires deployment changes
- [x] Pipeline configuration change [PR](https://dev.azure.com/City-of-Helsinki/tilavarauspalvelu/_git/tilavarauspalvelu-pipelines/pullrequest/3101)
- [x] Azure devops library updated if needed
- [x] Pipeline configuration change PR merged