### PR TITLE
TILA-1495: Enable uWSGI stats endpoint

### DIFF
--- a/deploy/uwsgi.yml
+++ b/deploy/uwsgi.yml
@@ -44,3 +44,7 @@ uwsgi:
   ignore-sigpipe: true
   ignore-write-errors: true
   disable-write-exception: true
+
+  # Enable stats endpoint for monitoring
+  stats: 0.0.0.0:1717
+  stats-http: true


### PR DESCRIPTION
## Change log
- Enabled uWSGI statistics endpoint

## Other notes
This is required for monitoring. Stats will be read by [uwsgi-exporter](https://pypi.org/project/uwsgi-exporter/) that will expose the stats in Prometheus format. Then, [Prometheus](https://prometheus.io/) will read the stats from uwsgi-exporter.

## Deployment reminder
- No changes required