### PR TITLE
TILA-1495: Enable prometheus statistics

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,3 +34,4 @@ uWSGI==2.0.19.1
 whitenoise==5.2.0
 graphene-file-upload==1.3.0
 Jinja2
+django-prometheus

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,6 +109,8 @@ django-modeltranslation==0.17.5
     # via -r requirements.in
 django-mptt==0.11.0
     # via -r requirements.in
+django-prometheus==2.2.0
+    # via -r requirements.in
 django-recurrence==1.10.3
     # via -r requirements.in
 django-timezone-field==5.0
@@ -189,6 +191,8 @@ packaging==20.9
     # via deprecation
 pillow==9.3.0
     # via easy-thumbnails
+prometheus-client==0.15.0
+    # via django-prometheus
 promise==2.3
     # via graphene-django
 prompt-toolkit==3.0.23

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -102,9 +102,12 @@ INSTALLED_APPS = [
     "email_notification",
     "django_celery_beat",
     "adminsortable2",
+    "django_prometheus",
 ]
 
 MIDDLEWARE = [
+    # Make sure PrometheusBeforeMiddleware is the first one
+    "django_prometheus.middleware.PrometheusBeforeMiddleware",
     "tilavarauspalvelu.multi_proxy_middleware.MultipleProxyMiddleware",
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
@@ -117,6 +120,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "auditlog.middleware.AuditlogMiddleware",
+    # Make sure PrometheusAfterMiddleware is the last one
+    "django_prometheus.middleware.PrometheusAfterMiddleware",
 ]
 
 ROOT_URLCONF = "tilavarauspalvelu.urls"

--- a/tilavarauspalvelu/urls.py
+++ b/tilavarauspalvelu/urls.py
@@ -20,6 +20,7 @@ urlpatterns = [
     path("pysocial/", include("social_django.urls", namespace="social")),
     path("helauth/", include("helusers.urls")),
     path("tinymce/", include("tinymce.urls")),
+    path("", include("django_prometheus.urls")),
 ]
 urlpatterns.extend(other_patterns)
 


### PR DESCRIPTION
## Change log
- Add [django-prometheus](https://github.com/korfuri/django-prometheus) dependency
- Enable `/metrics` endpoint

## Other notes
`/metrics` endpoint exposes Django internals (and custom metrics in the future) in Prometheus format. This does not yet include database stats. I will investigate how `postgis` engine works with `django_prometheus` a bit later.

Metrics endpoint is open just like any other endpoint. If there is need to secure it somehow, I will investigate that, too, a bit later.

## Deployment reminder
- No changes required