### PR TITLE
TILA-2181 | Don't crop large images; limit only height

### DIFF
--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -519,7 +519,7 @@ THUMBNAIL_ALIASES = {
         # Currently, all custom sized images are wanted to be cropped.
         "small": {"size": (250, 250), "crop": True},
         "medium": {"size": (384, 384), "crop": True},
-        "large": {"size": (728, 728), "crop": True},
+        "large": {"size": (0, 728), "crop": False},
         "purpose_image": {"size": (390, 245), "crop": True},
     },
 }


### PR DESCRIPTION
Refs TILA-2181

## Change log
- Remove cropping the large images
- Only shrink large image height preserving the ratio.

[TILA-2181]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ