### PR TITLE
TILA-2255 | Check reservation time to current time not reservation begin

### DIFF
--- a/api/graphql/reservations/reservation_serializers/adjust_time_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/adjust_time_serializers.py
@@ -58,7 +58,7 @@ class ReservationAdjustTimeSerializer(
 
         for reservation_unit in self.instance.reservation_unit.all():
             self.check_cancellation_rules(reservation_unit)
-            self.check_reservation_time(reservation_unit, begin, end)
+            self.check_reservation_time(reservation_unit)
             self.check_reservation_overlap(reservation_unit, begin, end)
             self.check_reservation_duration(reservation_unit, begin, end)
             self.check_buffer_times(reservation_unit, begin, end)

--- a/api/graphql/reservations/reservation_serializers/create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/create_serializers.py
@@ -175,7 +175,7 @@ class ReservationCreateSerializer(
 
         sku = None
         for reservation_unit in reservation_units:
-            self.check_reservation_time(reservation_unit, begin, end)
+            self.check_reservation_time(reservation_unit)
             self.check_reservation_overlap(reservation_unit, begin, end)
             self.check_reservation_duration(reservation_unit, begin, end)
             self.check_buffer_times(reservation_unit, begin, end)

--- a/api/graphql/reservations/reservation_serializers/mixins.py
+++ b/api/graphql/reservations/reservation_serializers/mixins.py
@@ -183,19 +183,22 @@ class ReservationPriceMixin:
 class ReservationSchedulingMixin:
     """Common mixin class for reservations containing date and scheduling related checks"""
 
-    def check_reservation_time(self, reservation_unit: ReservationUnit, begin, end):
+    def check_reservation_time(self, reservation_unit: ReservationUnit):
+        now = datetime.datetime.now(get_default_timezone())
+
         is_invalid_begin = (
             reservation_unit.reservation_begins
-            and begin < reservation_unit.reservation_begins
-        )
+            and now < reservation_unit.reservation_begins
+        ) or (reservation_unit.publish_begins and now < reservation_unit.publish_begins)
+
         is_invalid_end = (
             reservation_unit.reservation_ends
-            and end > reservation_unit.reservation_ends
-        )
+            and now >= reservation_unit.reservation_ends
+        ) or (reservation_unit.publish_ends and now >= reservation_unit.publish_ends)
 
         if is_invalid_begin or is_invalid_end:
             raise ValidationErrorWithCode(
-                "Reservation unit is not reservable within this reservation time.",
+                "Reservation unit is not reservable at current time.",
                 ValidationErrorCodes.RESERVATION_UNIT_NOT_RESERVABLE,
             )
 


### PR DESCRIPTION
## Change log
- Reservation validation `check_reservation_time` fix and enchancement

## Other notes
The check reservation_time checker compared reservation begin time to reservation_begins and *_ends rather it should compare against current_time in the making of the reservation.

Also adds checking current time against publish_ends and begins samely as reservation_begins


Refs TILA-2255


[TILA-2255]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ