### PR TITLE
TILA-1495: Add possibility to override database engine

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -35,3 +35,4 @@ whitenoise==5.2.0
 graphene-file-upload==1.3.0
 Jinja2
 django-prometheus
+certifi==2022.12.7 # Pinned because older version has a vulnerability: https://pyup.io/v/52365/f17/

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,9 @@ celery==5.2.7
     #   -r requirements.in
     #   django-celery-beat
     #   django-celery-results
-certifi==2020.12.5
+certifi==2022.12.7
     # via
+    #   -r requirements.in
     #   requests
     #   sentry-sdk
 cffi==1.14.5

--- a/requirements_dev.in
+++ b/requirements_dev.in
@@ -11,3 +11,4 @@ pygraphviz
 snapshottest
 pip-tools
 requests-mock
+certifi==2022.12.7 # Pinned because older version has a vulnerability: https://pyup.io/v/52365/f17/

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,9 +16,10 @@ black==20.8b1
     # via -r requirements_dev.in
 build==0.9.0
     # via pip-tools
-certifi==2020.12.5
+certifi==2022.12.7
     # via
     #   -c requirements.txt
+    #   -r requirements_dev.in
     #   requests
 chardet==4.0.0
     # via

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -152,6 +152,7 @@ env = environ.Env(
     DEBUG=(bool, False),
     DJANGO_LOG_LEVEL=(str, "DEBUG"),
     CONN_MAX_AGE=(int, 0),
+    DATABASE_ENGINE=(str, ""),
     DATABASE_URL=(str, "sqlite:../db.sqlite3"),
     TOKEN_AUTH_ACCEPTED_AUDIENCE=(str, ""),
     TOKEN_AUTH_SHARED_SECRET=(str, ""),
@@ -268,6 +269,10 @@ DEBUG = env("DEBUG")
 # Database configuration
 DATABASES = {"default": env.db()}
 DATABASES["default"]["CONN_MAX_AGE"] = env("CONN_MAX_AGE")
+
+# Database engine can be overridden for Prometheus monitoring
+if env("DATABASE_ENGINE"):
+    DATABASES["default"]["ENGINE"] = env("DATABASE_ENGINE")
 
 # SECURITY WARNING: keep the secret key used in production secret!
 # Using hard coded in dev environments if not defined.


### PR DESCRIPTION
## Change log
- Use database engine from env if it is defined

## Other notes
Monitoring database requires that we use engine code from django_prometheus package instead of Django's default engine. This way we can configure the db engine via envs without breaking local dev environments.

This is documented in django-prometheus [README](https://github.com/korfuri/django-prometheus#monitoring-your-databases).

Refs TILA-1495


## Deployment reminder
- [x] PR requires deployment changes
- [x] Pipeline configuration change [PR](https://dev.azure.com/City-of-Helsinki/tilavarauspalvelu/_git/tilavarauspalvelu-pipelines/pullrequest/3270)
- [x] Azure devops library updated if needed
- [x] Pipeline configuration change PR merged