### PR TITLE
TILA-2278: Remove prefix forward slash from the path

### DIFF
--- a/merchants/verkkokauppa/merchants/requests.py
+++ b/merchants/verkkokauppa/merchants/requests.py
@@ -64,7 +64,7 @@ def update_merchant(id: UUID, params: UpdateMerchantParams, post=_post) -> Merch
             response = post(
                 url=urljoin(
                     _get_base_url(),
-                    f"/update/merchant/{settings.VERKKOKAUPPA_NAMESPACE}/{str(id)}",
+                    f"update/merchant/{settings.VERKKOKAUPPA_NAMESPACE}/{str(id)}",
                 ),
                 json=params.to_json(),
                 headers={"api-key": settings.VERKKOKAUPPA_API_KEY},
@@ -93,7 +93,7 @@ def get_merchants(get=_get) -> List[Merchant]:
             response = get(
                 url=urljoin(
                     _get_base_url(),
-                    f"/list/merchants/{settings.VERKKOKAUPPA_NAMESPACE}",
+                    f"list/merchants/{settings.VERKKOKAUPPA_NAMESPACE}",
                 ),
                 headers={"api-key": settings.VERKKOKAUPPA_API_KEY},
                 timeout=REQUEST_TIMEOUT_SECONDS,

--- a/merchants/verkkokauppa/product/requests.py
+++ b/merchants/verkkokauppa/product/requests.py
@@ -62,7 +62,7 @@ def get_product_mapping(product_id: UUID, get=_get) -> Optional[Product]:
             METRIC_SERVICE_NAME, "GET", "/product/{product_id}/mapping"
         ) as metric:
             response = get(
-                url=urljoin(_get_base_url(), f"/{str(product_id)}/mapping"),
+                url=urljoin(_get_base_url(), f"{str(product_id)}/mapping"),
                 headers={"api-key": settings.VERKKOKAUPPA_API_KEY},
                 timeout=REQUEST_TIMEOUT_SECONDS,
             )
@@ -96,7 +96,7 @@ def create_or_update_accounting(
             METRIC_SERVICE_NAME, "POST", "/product/{product_id}/accounting"
         ) as metric:
             response = post(
-                url=urljoin(_get_base_url(), f"/{product_id}/accounting"),
+                url=urljoin(_get_base_url(), f"{product_id}/accounting"),
                 json=params.to_json(),
                 headers={
                     "api-key": settings.VERKKOKAUPPA_API_KEY,


### PR DESCRIPTION
## Change log
- Remove prefix forward slash from the path

## Other notes
Having the prefix slash in the second part overrides the defined path in the base part. This should fix the issue with Verkkokauppa API calls. Learned the hard way how `urljoin` works 😅 

## Deployment reminder
- No changes required