### PR TITLE
TILA-2283 | Add hauki_department_id property to unit

### DIFF
--- a/api/graphql/reservation_units/reservation_unit_types.py
+++ b/api/graphql/reservation_units/reservation_unit_types.py
@@ -174,7 +174,7 @@ class ReservationUnitHaukiUrlType(AuthNode, DjangoObjectType):
             return generate_hauki_link(
                 self.uuid,
                 getattr(info.context.user, "email", ""),
-                self.unit.tprek_department_id,
+                self.unit.hauki_department_id,
             )
         return None
 

--- a/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_units_query.py
+++ b/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_units_query.py
@@ -1012,7 +1012,7 @@ snapshots['ReservationUnitQueryTestCase::test_hauki_url_for_admin 1'] = {
     'data': {
         'reservationUnitByPk': {
             'haukiUrl': {
-                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.general%40foo.com&hsa_organization=ORGANISATION&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=cf94d68d518855b144ac5f10b0a8ee7f9ad3dfc14af94333a4d5fe961d65c069'
+                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.general%40foo.com&hsa_organization=tprek%3AORGANISATION&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=ed303be8a365c5f7c13b69135f5306a288103373a6b6932512f352db9daffb42'
             },
             'nameFi': 'test name fi'
         }
@@ -1023,7 +1023,7 @@ snapshots['ReservationUnitQueryTestCase::test_hauki_url_for_unit_manager 1'] = {
     'data': {
         'reservationUnitByPk': {
             'haukiUrl': {
-                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=unit.admin%40foo.com&hsa_organization=ORGANISATION&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=1b61fc678411c21464160a489f22b369c6e2345c1711314dea5f447bd00a3641'
+                'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=unit.admin%40foo.com&hsa_organization=tprek%3AORGANISATION&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=8b9a2bb12d735b498c5b3e2fccb6c56c0fa3d4ef30a891f12f2c2991be7e1432'
             },
             'nameFi': 'test name fi'
         }

--- a/spaces/models.py
+++ b/spaces/models.py
@@ -148,6 +148,10 @@ class Unit(models.Model):
     def hauki_resource_data_source_id(self):
         return "tprek"
 
+    @property
+    def hauki_department_id(self):
+        return f"tprek:{self.tprek_department_id}"
+
     def save(self, *args, **kwargs):
         old_values = Unit.objects.filter(pk=self.pk).first()
         result = super(Unit, self).save(*args, **kwargs)


### PR DESCRIPTION


Refs TILA-2283

## Change log
- When generating hauki link within gql response use prefix "tprek:" in organisation id.

## Other notes
Hauki uses the department id with the prefix of the origin_id. In this department id case it needs to in form "tprek:<id>" to make the link work properly.
This adds computed property called "hauki_department_id" to Unit model which returns the tprek_department id with prefix "tprek:".

