### PR TITLE
TILA-2298 | Add ability to give recurring reservation in staff create

### DIFF
--- a/api/graphql/reservations/reservation_serializers/staff_create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/staff_create_serializers.py
@@ -16,6 +16,7 @@ from reservations.models import RESERVEE_LANGUAGE_CHOICES
 from reservations.models import STATE_CHOICES as ReservationState
 from reservations.models import (
     AgeGroup,
+    RecurringReservation,
     Reservation,
     ReservationPurpose,
     ReservationType,
@@ -27,6 +28,12 @@ DEFAULT_TIMEZONE = get_default_timezone()
 class ReservationStaffCreateSerializer(
     PrimaryKeySerializer, ReservationSchedulingMixin
 ):
+    recurring_reservation_pk = IntegerPrimaryKeyField(
+        queryset=RecurringReservation.objects.all(),
+        source="recurring_reservation",
+        required=False,
+        allow_null=True,
+    )
     reservation_unit_pks = serializers.ListField(
         child=IntegerPrimaryKeyField(queryset=ReservationUnit.objects.all()),
         source="reservation_unit",
@@ -102,6 +109,7 @@ class ReservationStaffCreateSerializer(
             "unit_price",
             "type",
             "working_memo",
+            "recurring_reservation_pk",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/tests/test_reservations/test_reservation_create_staff.py
+++ b/api/graphql/tests/test_reservations/test_reservation_create_staff.py
@@ -20,7 +20,7 @@ from permissions.models import (
 )
 from reservations.models import STATE_CHOICES as ReservationState
 from reservations.models import AgeGroup, Reservation, ReservationType
-from reservations.tests.factories import ReservationFactory
+from reservations.tests.factories import RecurringReservationFactory, ReservationFactory
 
 
 @freezegun.freeze_time("2021-10-12T12:00:00Z")
@@ -34,6 +34,9 @@ class ReservationCreateStaffTestCase(ReservationTestCaseBase):
         GeneralRolePermission.objects.create(
             role=GeneralRoleChoice.objects.get(code="admin"),
             permission="can_create_staff_reservations",
+        )
+        cls.recurring = RecurringReservationFactory(
+            reservation_unit=cls.reservation_unit
         )
 
     def get_create_query(self):
@@ -93,6 +96,7 @@ class ReservationCreateStaffTestCase(ReservationTestCaseBase):
             "purposePk": self.purpose.pk,
             "bufferTimeBefore": "00:30:00",
             "bufferTimeAfter": "00:30:00",
+            "recurringReservationPk": self.recurring.id,
         }
 
     def test_general_admin_can_create(self):
@@ -317,6 +321,7 @@ class ReservationCreateStaffTestCase(ReservationTestCaseBase):
         assert_that(reservation.buffer_time_before).is_equal_to(
             datetime.timedelta(minutes=30)
         )
+        assert_that(reservation.recurring_reservation).is_equal_to(self.recurring)
 
     def test_reservation_overlapping_fails(self):
         self.client.force_login(self.general_admin)


### PR DESCRIPTION


## Change log
- Add recurringReservationPk to `ReservationStaffCreateMutation` 

## Other notes
In staff create reservation there should be possibility to give the recurring reservation within the creation of the reservation.

Refs TILA-2298