### PR TITLE
TILA-2102 | Add task for deleting recurring reservation without reservations

### DIFF
--- a/reservations/pruning.py
+++ b/reservations/pruning.py
@@ -2,8 +2,9 @@ import datetime
 from logging import getLogger
 
 from dateutil.relativedelta import relativedelta
+from django.utils.timezone import get_default_timezone
 
-from reservations.models import Reservation, ReservationStatistic
+from reservations.models import RecurringReservation, Reservation, ReservationStatistic
 
 logger = getLogger(__name__)
 
@@ -44,3 +45,15 @@ def prune_reservation_statistics(older_than_years: int) -> None:
     ).delete()
 
     logger.info(f"Pruned {num_deleted} reservation statistics.")
+
+
+def prune_recurring_reservations(remove_older_than_days) -> None:
+    """Deletes recurring reservations which does not have any reservations."""
+    created_before = datetime.datetime.now(tz=get_default_timezone()) - relativedelta(
+        days=remove_older_than_days
+    )
+    num_deleted, _ = RecurringReservation.objects.filter(
+        created__lte=created_before, reservations__isnull=True
+    ).delete()
+
+    logger.info(f"Pruned {num_deleted} recurring reservations.")

--- a/reservations/tasks.py
+++ b/reservations/tasks.py
@@ -3,6 +3,7 @@ from tilavarauspalvelu.celery import app
 
 from .pruning import (
     prune_inactive_reservations,
+    prune_recurring_reservations,
     prune_reservation_statistics,
     prune_reservation_with_inactive_payments,
 )
@@ -16,6 +17,8 @@ PRUNE_OLDER_THAN_MINUTES = 20
 PRUNE_WITH_ORDERS_OLDER_THAN_MINUTES = 5
 
 REMOVE_STATS_OLDER_THAN_YEARS = 5
+
+REMOVE_RECURRINGS_OLDER_THAN_DAYS = 1
 
 
 @app.task(name="prune_reservations")
@@ -39,3 +42,8 @@ def setup_periodic_tasks(sender, **kwargs) -> None:
 @app.task(name="prune_reservation_statistics")
 def prune_reservation_statistics_task(older_than_years=REMOVE_STATS_OLDER_THAN_YEARS):
     prune_reservation_statistics(older_than_years=older_than_years)
+
+
+@app.task(name="prune_recurring_reservations")
+def prune_recurring_reservations_task() -> None:
+    prune_recurring_reservations(REMOVE_RECURRINGS_OLDER_THAN_DAYS)


### PR DESCRIPTION
## Change log
- Adds a task called `prune_recurring_reservations` which removes recurring reservations which does not have any reservations

## Deployment reminder
- [ ] Requires to configure the task to every environment when deployed!


Refs TILA-2102