### PR TITLE
TILA-2165: Email template test form for Django Admin

### DIFF
--- a/email_notification/email_tester.py
+++ b/email_notification/email_tester.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+from decimal import Decimal
+
+from django import forms
+
+from email_notification.models import EmailTemplate
+
+
+class EmailTestForm(forms.Form):
+    recipient = forms.CharField(
+        initial="", max_length=256, widget=forms.TextInput(attrs={"size": 50})
+    )
+    template = forms.ChoiceField()  # Choices are defined in __init__
+    begin_datetime = forms.SplitDateTimeField(
+        initial=datetime(2100, 1, 1, 12, 00),
+        widget=forms.SplitDateTimeWidget(date_format="%d.%m.%Y", time_format="%H:%M"),
+    )
+    end_datetime = forms.SplitDateTimeField(
+        initial=datetime(2100, 1, 1, 13, 15),
+        widget=forms.SplitDateTimeWidget(date_format="%d.%m.%Y", time_format="%H:%M"),
+    )
+    reservation_number = forms.IntegerField(initial=1234567)
+    reservee_name = forms.CharField(initial="Email Test")
+    reservation_name = forms.CharField(initial="TESTIVARAUS")
+    reservation_unit_name = forms.CharField(initial="VARAUSYKSIKKÖ")
+    unit_name = forms.CharField(initial="TOIMIPISTE")
+    unit_location = forms.CharField(
+        initial="Testikatu 99999 Korvatunturi",
+        widget=forms.TextInput(attrs={"size": 50}),
+    )
+    price = forms.DecimalField(
+        decimal_places=2, initial=Decimal("12.30"), widget=forms.NumberInput()
+    )
+    non_subsidised_price = forms.DecimalField(
+        decimal_places=2, initial=Decimal("15.00"), widget=forms.NumberInput()
+    )
+    subsidised_price = forms.DecimalField(
+        decimal_places=2, initial=Decimal("5.00"), widget=forms.NumberInput
+    )
+    tax_percentage = forms.IntegerField(initial=24, widget=forms.NumberInput)
+    confirmed_instructions_fi = forms.CharField(
+        initial="[lisäohje: hyväksytty]", widget=forms.Textarea
+    )
+    confirmed_instructions_sv = forms.CharField(
+        initial="[mer information: bekräftats]", widget=forms.Textarea
+    )
+    confirmed_instructions_en = forms.CharField(
+        initial="[additional info: confirmed]", widget=forms.Textarea
+    )
+    pending_instructions_fi = forms.CharField(
+        initial="[lisäohje: käsittelyssä]", widget=forms.Textarea
+    )
+    pending_instructions_sv = forms.CharField(
+        initial="[mer information: kräver hantering]", widget=forms.Textarea
+    )
+    pending_instructions_en = forms.CharField(
+        initial="[additional infor: requires handling]", widget=forms.Textarea
+    )
+    cancelled_instructions_fi = forms.CharField(
+        initial="[lisäohje: peruttu]", widget=forms.Textarea
+    )
+    cancelled_instructions_sv = forms.CharField(
+        initial="[mer information: avbokad]", widget=forms.Textarea
+    )
+    cancelled_instructions_en = forms.CharField(
+        initial="[additional infor: cancelled]", widget=forms.Textarea
+    )
+    deny_reason_fi = forms.CharField(initial="[syy]", widget=forms.Textarea)
+    deny_reason_sv = forms.CharField(initial="[orsak]", widget=forms.Textarea)
+    deny_reason_en = forms.CharField(initial="[reason]", widget=forms.Textarea)
+    cancel_reason_fi = forms.CharField(initial="[syy]", widget=forms.Textarea)
+    cancel_reason_sv = forms.CharField(initial="[orsak]", widget=forms.Textarea)
+    cancel_reason_en = forms.CharField(initial="[reason]", widget=forms.Textarea)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+        # Templates are fetched here because calling EmailTemplate.objects.all() in the field
+        # initialization somehow wrecks translation support. I didn't have time figure out
+        # the root cause, but setting the choices here solves the issue
+        template_choices = list(
+            map(
+                lambda template: (template.pk, template.name),
+                EmailTemplate.objects.all(),
+            )
+        )
+        self.fields["template"].choices = template_choices

--- a/email_notification/sender/email_notification_context.py
+++ b/email_notification/sender/email_notification_context.py
@@ -1,0 +1,184 @@
+import datetime
+from decimal import Decimal
+from typing import Dict
+
+from django.utils.timezone import get_default_timezone
+
+from applications.models import CUSTOMER_TYPES
+from email_notification.email_tester import EmailTestForm
+from reservations.models import Reservation
+
+
+class EmailNotificationContext:
+    reservee_name: str
+    begin_datetime: datetime.datetime
+    end_datetime: datetime.datetime
+    reservation_number: int
+    unit_location: str
+    unit_name: str
+    reservation_name: str
+    reservation_unit_name: str
+    price: Decimal
+    non_subsidised_price: Decimal
+    subsidised_price: Decimal
+    tax_percentage: int
+    confirmed_instructions: Dict[str, str]
+    pending_instructions: Dict[str, str]
+    cancelled_instructions: Dict[str, str]
+    deny_reason: Dict[str, str]
+    cancel_reason: Dict[str, str]
+    reservee_language: str
+
+    def _get_by_language(self, instance, field, language):
+        return getattr(instance, f"{field}_{language}", getattr(instance, field, ""))
+
+    def _get_reservation_unit_instruction_field(self, reservation, name, language):
+        instructions = []
+        for res_unit in reservation.reservation_unit.all():
+            instructions.append(self._get_by_language(res_unit, name, language))
+
+        return "\n-\n".join(instructions)
+
+    @staticmethod
+    def from_reservation(reservation: Reservation) -> "EmailNotificationContext":
+        """Build context from reservation"""
+        context = EmailNotificationContext()
+
+        if (
+            not reservation.reservee_type
+            or reservation.reservee_type == CUSTOMER_TYPES.CUSTOMER_TYPE_INDIVIDUAL
+        ):
+            context.reservee_name = (
+                f"{reservation.reservee_first_name} {reservation.reservee_last_name}"
+            )
+        else:
+            context.reservee_name = reservation.reservee_organisation_name
+
+        context.begin_datetime = reservation.begin.astimezone(get_default_timezone())
+        context.end_datetime = reservation.end.astimezone(get_default_timezone())
+        context.reservation_number = reservation.id
+
+        res_unit = reservation.reservation_unit.filter(unit__isnull=False).first()
+        location = getattr(res_unit.unit, "location", None)
+        if location:
+            context.unit_location = f"{location.address_street} {location.address_zip} {location.address_city}"
+        else:
+            context.unit_location = None
+
+        if res_unit:
+            context.unit_name = res_unit.unit.name
+
+        context.reservation_name = reservation.name
+
+        if reservation.reservation_unit.count() > 1:
+            context.reservation_unit_name = ", ".join(
+                reservation.reservation_unit.values_list("name", flat=True)
+            )
+        else:
+            context.reservation_unit_name = reservation.reservation_unit.first().name
+
+        context.price = reservation.price
+        context.non_subsidised_price = reservation.non_subsidised_price
+
+        if not reservation.applying_for_free_of_charge:
+            context.subsidised_price = reservation.price
+        else:
+            from api.graphql.reservations.reservation_serializers.mixins import (
+                ReservationPriceMixin,
+            )
+
+            calculator = ReservationPriceMixin()
+            prices = calculator.calculate_price(
+                reservation.begin,
+                reservation.end,
+                reservation.reservation_unit.all(),
+            )
+            context.subsidised_price = prices.subsidised_price
+
+        context.tax_percentage = reservation.tax_percentage_value
+        context.reservee_language = reservation.reservee_language
+        context.confirmed_instructions = {
+            "fi": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_confirmed_instructions", "fi"
+            ),
+            "sv": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_confirmed_instructions", "sv"
+            ),
+            "en": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_confirmed_instructions", "en"
+            ),
+        }
+        context.pending_instructions = {
+            "fi": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_pending_instructions", "fi"
+            ),
+            "sv": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_pending_instructions", "sv"
+            ),
+            "en": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_pending_instructions", "en"
+            ),
+        }
+        context.cancelled_instructions = {
+            "fi": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_cancelled_instructions", "fi"
+            ),
+            "sv": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_cancelled_instructions", "sv"
+            ),
+            "en": context._get_reservation_unit_instruction_field(
+                reservation, "reservation_cancelled_instructions", "en"
+            ),
+        }
+        context.deny_reason = {
+            "fi": context._get_by_language(reservation.deny_reason, "reason", "fi"),
+            "sv": context._get_by_language(reservation.deny_reason, "reason", "sv"),
+            "en": context._get_by_language(reservation.deny_reason, "reason", "en"),
+        }
+        context.cancel_reason = {
+            "fi": context._get_by_language(reservation.cancel_reason, "reason", "fi"),
+            "sv": context._get_by_language(reservation.cancel_reason, "reason", "sv"),
+            "en": context._get_by_language(reservation.cancel_reason, "reason", "en"),
+        }
+        return context
+
+    def from_form(form: EmailTestForm) -> "EmailNotificationContext":
+        context = EmailNotificationContext()
+        context.reservee_name = form.cleaned_data["reservee_name"]
+        context.begin_datetime = form.cleaned_data["begin_datetime"]
+        context.end_datetime = form.cleaned_data["end_datetime"]
+        context.reservation_number = form.cleaned_data["reservation_number"]
+        context.unit_location = form.cleaned_data["unit_location"]
+        context.unit_name = form.cleaned_data["unit_name"]
+        context.reservation_name = form.cleaned_data["reservation_name"]
+        context.reservation_unit_name = form.cleaned_data["reservation_unit_name"]
+        context.price = form.cleaned_data["price"]
+        context.non_subsidised_price = form.cleaned_data["non_subsidised_price"]
+        context.subsidised_price = form.cleaned_data["subsidised_price"]
+        context.tax_percentage = form.cleaned_data["tax_percentage"]
+        context.confirmed_instructions = {
+            "fi": form.cleaned_data["confirmed_instructions_fi"],
+            "sv": form.cleaned_data["confirmed_instructions_sv"],
+            "en": form.cleaned_data["confirmed_instructions_en"],
+        }
+        context.pending_instructions = {
+            "fi": form.cleaned_data["pending_instructions_fi"],
+            "sv": form.cleaned_data["pending_instructions_sv"],
+            "en": form.cleaned_data["pending_instructions_en"],
+        }
+        context.cancelled_instructions = {
+            "fi": form.cleaned_data["cancelled_instructions_fi"],
+            "sv": form.cleaned_data["cancelled_instructions_sv"],
+            "en": form.cleaned_data["cancelled_instructions_en"],
+        }
+        context.deny_reason = {
+            "fi": form.cleaned_data["deny_reason_fi"],
+            "sv": form.cleaned_data["deny_reason_sv"],
+            "en": form.cleaned_data["deny_reason_en"],
+        }
+        context.cancel_reason = {
+            "fi": form.cleaned_data["cancel_reason_fi"],
+            "sv": form.cleaned_data["cancel_reason_sv"],
+            "en": form.cleaned_data["cancel_reason_en"],
+        }
+        return context

--- a/email_notification/sender/senders.py
+++ b/email_notification/sender/senders.py
@@ -6,6 +6,7 @@ from sentry_sdk import capture_message
 
 from email_notification.models import EmailTemplate, EmailType
 from email_notification.sender.email_notification_builder import (
+    EmailNotificationContext,
     ReservationEmailNotificationBuilder,
 )
 from reservations.models import Reservation
@@ -15,11 +16,15 @@ def send_reservation_email_notification(
     email_type: EmailType,
     reservation: Reservation,
     recipients: Optional[List[str]] = None,
+    context: Optional[EmailNotificationContext] = None,
 ):
     if recipients is not None and len(recipients) > settings.EMAIL_MAX_RECIPIENTS:
         raise Exception(
             f"Refusing to notify more than {settings.EMAIL_MAX_RECIPIENTS} users. Email type: %s. Reservation: %s"
-            % (email_type, reservation.pk)
+            % (
+                email_type,
+                reservation.pk if reservation else context.reservation_number,
+            )
         )
 
     mail_template = EmailTemplate.objects.filter(type=email_type).first()
@@ -28,8 +33,11 @@ def send_reservation_email_notification(
             f"Tried to send '{email_type}' notification but no template was defined",
             level="error",
         )
+    language = (
+        reservation.reservee_language if reservation else context.reservee_language
+    )
     message_builder = ReservationEmailNotificationBuilder(
-        reservation, mail_template, language=reservation.reservee_language
+        reservation, mail_template, language=language, context=context
     )
     subject = message_builder.get_subject()
     message = message_builder.get_content()

--- a/email_notification/sender/tests/test_email_notification_context.py
+++ b/email_notification/sender/tests/test_email_notification_context.py
@@ -1,0 +1,118 @@
+from assertpy import assert_that
+from django.test import TestCase
+from django.utils.timezone import get_default_timezone
+
+from applications.models import CUSTOMER_TYPES
+from email_notification.sender.email_notification_context import (
+    EmailNotificationContext,
+)
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import (
+    ReservationCancelReasonFactory,
+    ReservationDenyReasonFactory,
+    ReservationFactory,
+)
+from spaces.tests.factories import LocationFactory, UnitFactory
+
+
+class EmailNotificationContextTestCase(TestCase):
+    def setUp(self) -> None:
+        self.unit = UnitFactory.create(name="Test unit")
+        self.location = LocationFactory.create(
+            unit=self.unit,
+            address_street="Street",
+            address_zip="0100",
+            address_city="Rovaniemi",
+        )
+        self.reservation_unit = ReservationUnitFactory.create(unit=self.unit)
+        self.deny_reason = ReservationDenyReasonFactory.create()
+        self.cancel_reason = ReservationCancelReasonFactory.create()
+        self.reservation = ReservationFactory.create(
+            reservation_unit=[self.reservation_unit],
+            deny_reason=self.deny_reason,
+            cancel_reason=self.cancel_reason,
+        )
+
+    def test_from_reservation(self):
+        context = EmailNotificationContext.from_reservation(self.reservation)
+
+        assert_that(context.reservee_name).is_equal_to(
+            f"{self.reservation.reservee_first_name} {self.reservation.reservee_last_name}"
+        )
+        assert_that(context.reservation_name).is_equal_to(self.reservation.name)
+        assert_that(context.begin_datetime).is_equal_to(
+            self.reservation.begin.astimezone(get_default_timezone())
+        )
+        assert_that(context.end_datetime).is_equal_to(
+            self.reservation.end.astimezone(get_default_timezone())
+        )
+        assert_that(context.reservation_number).is_equal_to(self.reservation.id)
+        assert_that(context.unit_location).is_equal_to(
+            f"{self.location.address_street} {self.location.address_zip} {self.location.address_city}"
+        )
+        assert_that(context.unit_name).is_equal_to(self.unit.name)
+        assert_that(context.price).is_equal_to(self.reservation.price)
+        assert_that(context.non_subsidised_price).is_equal_to(
+            self.reservation.non_subsidised_price
+        )
+        assert_that(context.subsidised_price).is_equal_to(self.reservation.price)
+        assert_that(context.tax_percentage).is_equal_to(
+            self.reservation.tax_percentage_value
+        )
+        assert_that(context.reservee_language).is_equal_to(
+            self.reservation.reservee_language
+        )
+        assert_that(context.confirmed_instructions["fi"]).is_equal_to(
+            self.reservation_unit.reservation_confirmed_instructions_fi
+        )
+        assert_that(context.confirmed_instructions["sv"]).is_equal_to(
+            self.reservation_unit.reservation_confirmed_instructions_sv
+        )
+        assert_that(context.confirmed_instructions["en"]).is_equal_to(
+            self.reservation_unit.reservation_confirmed_instructions_en
+        )
+        assert_that(context.pending_instructions["fi"]).is_equal_to(
+            self.reservation_unit.reservation_pending_instructions_fi
+        )
+        assert_that(context.pending_instructions["sv"]).is_equal_to(
+            self.reservation_unit.reservation_pending_instructions_sv
+        )
+        assert_that(context.pending_instructions["en"]).is_equal_to(
+            self.reservation_unit.reservation_pending_instructions_en
+        )
+        assert_that(context.cancelled_instructions["fi"]).is_equal_to(
+            self.reservation_unit.reservation_cancelled_instructions_fi
+        )
+        assert_that(context.cancelled_instructions["sv"]).is_equal_to(
+            self.reservation_unit.reservation_cancelled_instructions_sv
+        )
+        assert_that(context.cancelled_instructions["en"]).is_equal_to(
+            self.reservation_unit.reservation_cancelled_instructions_en
+        )
+        assert_that(context.deny_reason["fi"]).is_equal_to(self.deny_reason.reason_fi)
+        assert_that(context.deny_reason["sv"]).is_equal_to(self.deny_reason.reason_sv)
+        assert_that(context.deny_reason["en"]).is_equal_to(self.deny_reason.reason_en)
+        assert_that(context.cancel_reason["fi"]).is_equal_to(
+            self.cancel_reason.reason_fi
+        )
+        assert_that(context.cancel_reason["sv"]).is_equal_to(
+            self.cancel_reason.reason_sv
+        )
+        assert_that(context.cancel_reason["en"]).is_equal_to(
+            self.cancel_reason.reason_en
+        )
+
+    def test_from_reservation_organisation_name(self):
+        self.reservation.reservee_type = CUSTOMER_TYPES.CUSTOMER_TYPE_BUSINESS
+        self.reservation.reservee_organisation_name = "Business"
+        self.reservation.save()
+
+        context = EmailNotificationContext.from_reservation(self.reservation)
+        assert_that(context.reservee_name).is_equal_to(
+            self.reservation.reservee_organisation_name
+        )
+
+    def test_from_reservation_no_location(self):
+        self.location.delete()
+        context = EmailNotificationContext.from_reservation(self.reservation)
+        assert_that(context.unit_location).is_none()

--- a/email_notification/templates/email_tester.html
+++ b/email_notification/templates/email_tester.html
@@ -1,0 +1,15 @@
+{% extends "admin/base_site.html" %}
+Fooo
+
+{% block content %}
+<h1 id="site-name">Email Template Testing</h1>
+
+<form method="post" novalidate>
+    {% csrf_token %}
+    <table>
+    {{ form.as_table }}
+    </table>
+    
+    <button>Send Test Emails</button>
+</form>
+{% endblock %}

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-extra-fields==3.0.2
 django-filter==2.4.0
 django-graphql-jwt
 django-helusers==0.6.0
-django-modeltranslation==0.17.5
+django-modeltranslation
 django-mptt==0.11.0
 django-recurrence==1.10.3
 django-tinymce==3.4.0
@@ -36,3 +36,4 @@ graphene-file-upload==1.3.0
 Jinja2
 django-prometheus
 certifi==2022.12.7 # Pinned because older version has a vulnerability: https://pyup.io/v/52365/f17/
+django-admin-extra-buttons

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,6 +76,8 @@ django==3.2.16
     #   easy-thumbnails
     #   graphene-django
     #   helsinki-profile-gdpr-api
+django-admin-extra-buttons==1.5.5
+    # via -r requirements.in
 django-admin-sortable2==1.0.4
     # via -r requirements.in
 django-auditlog==2.2.0
@@ -106,7 +108,7 @@ django-helusers==0.6.0
     #   helsinki-profile-gdpr-api
 django-js-asset==1.2.2
     # via django-mptt
-django-modeltranslation==0.17.5
+django-modeltranslation==0.18.7
     # via -r requirements.in
 django-mptt==0.11.0
     # via -r requirements.in
@@ -260,7 +262,6 @@ sentry-sdk==0.19.5
 six==1.15.0
     # via
     #   click-repl
-    #   django-modeltranslation
     #   ecdsa
     #   graphene-file-upload
     #   jsonschema
@@ -276,6 +277,8 @@ sqlparse==0.4.2
     # via django
 text-unidecode==1.3
     # via graphene-django
+typing-extensions==4.4.0
+    # via django-modeltranslation
 tzdata==2022.2
     # via django-celery-beat
 uritemplate==3.0.1

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -103,6 +103,7 @@ INSTALLED_APPS = [
     "django_celery_beat",
     "adminsortable2",
     "django_prometheus",
+    "admin_extra_buttons",
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Change log
- Added [django-admin-extra-button](https://github.com/saxix/django-admin-extra-buttons) package
- Remove pinned version from `django-modeltranslation`
- Added `EmailNotificationContext` that contains all supported email template fields
- Updated `ReservationEmailNotificationBuilder` to support context
- Added new button to `EmailTemplate` list view that open testing form
- Created a custom testing form that sends emails in all three languages
- Updated tests to match the changes

## Other notes
I was surprised how tricky it is to add custom functionality to Django Admin without marrying the code to a specific Django version. Some people did the same by overriding Django's templates, but that felt even more complex and requires understanding of Django's internal implementation. Django's templates seem to change quite often with versions so this route felt like a maintenance nightmare.

That being said, I'm not sure at all if this is the best way to do this. Because I had to learn so much new stuff, the solution might have a lot of details that could be improved. So keep'em comments coming! 😄 

## Deployment reminder
- No changes required.