### PR TITLE
TILA-2211: Use fake context in validation

### DIFF
--- a/email_notification/admin.py
+++ b/email_notification/admin.py
@@ -33,6 +33,7 @@ class EmailTemplateAdminForm(ModelForm):
         self.fields["type"].choices = [
             (value, label) for value, label in available_types
         ]
+        self.test_context = EmailNotificationContext.with_mock_data().__dict__
 
     def get_validated_field(self, field):
         data = self.cleaned_data[field]
@@ -41,7 +42,9 @@ class EmailTemplateAdminForm(ModelForm):
                 raise ValidationError(f"Field {field} is required.")
             return data
         try:
-            EmailTemplateValidator().validate_string(data)
+            EmailTemplateValidator().validate_string(
+                data, context_dict=self.test_context
+            )
         except EmailTemplateValidationError as e:
             raise ValidationError(e.message) from e
         return data
@@ -49,7 +52,9 @@ class EmailTemplateAdminForm(ModelForm):
     def validate_uploaded_html_file(self, language: str):
         file = self.cleaned_data[f"html_content_{language}"]
         if file and isinstance(file, InMemoryUploadedFile):
-            EmailTemplateValidator().validate_html_file(file)
+            EmailTemplateValidator().validate_html_file(
+                file, context_dict=self.test_context
+            )
         return file
 
     def clean_subject(self):

--- a/email_notification/sender/email_notification_context.py
+++ b/email_notification/sender/email_notification_context.py
@@ -40,6 +40,49 @@ class EmailNotificationContext:
         return "\n-\n".join(instructions)
 
     @staticmethod
+    def with_mock_data() -> "EmailNotificationContext":
+        """Initialize context with mock data"""
+        context = EmailNotificationContext()
+        context.reservee_name = "Email Test"
+        context.begin_datetime = datetime.datetime(2100, 1, 1, 12, 00)
+        context.end_datetime = datetime.datetime(2100, 1, 1, 13, 15)
+        context.reservation_number = 1234567
+        context.unit_location = "Testikatu 99999 Korvatunturi"
+        context.unit_name = "TOIMIPISTE"
+        context.reservation_name = "TESTIVARAUS"
+        context.reservation_unit_name = "VARAUSYKSIKKÖ"
+        context.price = Decimal("12.30")
+        context.non_subsidised_price = Decimal("15.00")
+        context.subsidised_price = Decimal("5.00")
+        context.tax_percentage = 24
+        context.confirmed_instructions = {
+            "fi": "[lisäohje: hyväksytty]",
+            "sv": "[mer information: bekräftats]",
+            "en": "[additional info: confirmed]",
+        }
+        context.pending_instructions = {
+            "fi": "[lisäohje: käsittelyssä]",
+            "sv": "[mer information: kräver hantering]",
+            "en": "[additional info: requires handling]",
+        }
+        context.cancelled_instructions = {
+            "fi": "[lisäohje: peruttu]",
+            "sv": "[mer information: avbokad]",
+            "en": "[additional info: cancelled]",
+        }
+        context.deny_reason = {
+            "fi": "[syy]",
+            "sv": "[orsak]",
+            "en": "[reason]",
+        }
+        context.cancel_reason = {
+            "fi": "[syy]",
+            "sv": "[orsak]",
+            "en": "[reason]",
+        }
+        return context
+
+    @staticmethod
     def from_reservation(reservation: Reservation) -> "EmailNotificationContext":
         """Build context from reservation"""
         context = EmailNotificationContext()
@@ -142,6 +185,7 @@ class EmailNotificationContext:
         }
         return context
 
+    @staticmethod
     def from_form(form: EmailTestForm) -> "EmailNotificationContext":
         context = EmailNotificationContext()
         context.reservee_name = form.cleaned_data["reservee_name"]

--- a/email_notification/sender/tests/test_email_notification_context.py
+++ b/email_notification/sender/tests/test_email_notification_context.py
@@ -1,3 +1,6 @@
+import datetime
+from decimal import Decimal
+
 from assertpy import assert_that
 from django.test import TestCase
 from django.utils.timezone import get_default_timezone
@@ -32,6 +35,61 @@ class EmailNotificationContextTestCase(TestCase):
             deny_reason=self.deny_reason,
             cancel_reason=self.cancel_reason,
         )
+
+    def test_with_mock_data(self):
+        context = EmailNotificationContext.with_mock_data()
+        assert_that(context.reservee_name).is_equal_to("Email Test")
+        assert_that(context.begin_datetime).is_equal_to(
+            datetime.datetime(2100, 1, 1, 12, 00)
+        )
+        assert_that(context.end_datetime).is_equal_to(
+            datetime.datetime(2100, 1, 1, 13, 15)
+        )
+        assert_that(context.reservation_number).is_equal_to(1234567)
+        assert_that(context.unit_location).is_equal_to("Testikatu 99999 Korvatunturi")
+        assert_that(context.unit_name).is_equal_to("TOIMIPISTE")
+        assert_that(context.reservation_name).is_equal_to("TESTIVARAUS")
+        assert_that(context.reservation_unit_name).is_equal_to("VARAUSYKSIKKÖ")
+        assert_that(context.price).is_equal_to(Decimal("12.30"))
+        assert_that(context.non_subsidised_price).is_equal_to(Decimal("15.00"))
+        assert_that(context.subsidised_price).is_equal_to(Decimal("5.00"))
+        assert_that(context.tax_percentage).is_equal_to(24)
+        assert_that(context.confirmed_instructions).is_equal_to(
+            {
+                "fi": "[lisäohje: hyväksytty]",
+                "sv": "[mer information: bekräftats]",
+                "en": "[additional info: confirmed]",
+            }
+        )
+        assert_that(context.pending_instructions).is_equal_to(
+            {
+                "fi": "[lisäohje: käsittelyssä]",
+                "sv": "[mer information: kräver hantering]",
+                "en": "[additional info: requires handling]",
+            }
+        )
+        assert_that(context.cancelled_instructions).is_equal_to(
+            {
+                "fi": "[lisäohje: peruttu]",
+                "sv": "[mer information: avbokad]",
+                "en": "[additional info: cancelled]",
+            }
+        )
+        assert_that(context.deny_reason).is_equal_to(
+            {
+                "fi": "[syy]",
+                "sv": "[orsak]",
+                "en": "[reason]",
+            }
+        )
+        assert_that(context.cancel_reason).is_equal_to(
+            {
+                "fi": "[syy]",
+                "sv": "[orsak]",
+                "en": "[reason]",
+            }
+        )
+        assert_that(len(context.__dict__.keys())).is_equal_to(17)
 
     def test_from_reservation(self):
         context = EmailNotificationContext.from_reservation(self.reservation)


### PR DESCRIPTION
## Change log
- Added a helper function to create context with mock content
- Use context in email template validation

## Other notes
It looks like email template validation failed because Jinja tried to render the template with an empty context. Now it is using the context I created in the previous ticket and that seems to fix the issue.

## Deployment reminder
- No changes required