### PR TITLE
TILA-2322: Attach HTML content as alternative

### DIFF
--- a/email_notification/sender/email_notification_builder.py
+++ b/email_notification/sender/email_notification_builder.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import re
-from typing import Dict
+from typing import Dict, Optional
 from urllib.parse import urlencode, urljoin
 
 from django.conf import settings
@@ -269,14 +269,14 @@ class ReservationEmailNotificationBuilder:
         return rendered
 
     def get_content(self):
-        html_content = self._get_html_content(self.template)
-        content = (
-            html_content
-            if html_content
-            else self._get_by_language(self.template, "content")
-        )
-        rendered = self.env.from_string(content).render(self.context_attr_map)
-        return rendered
+        content = self._get_by_language(self.template, "content")
+        return self.env.from_string(content).render(self.context_attr_map)
+
+    def get_html_content(self) -> Optional[str]:
+        content = self._get_html_content(self.template)
+        if content:
+            return self.env.from_string(content).render(self.context_attr_map)
+        return None
 
 
 class EmailTemplateValidationError(Exception):

--- a/email_notification/sender/senders.py
+++ b/email_notification/sender/senders.py
@@ -40,15 +40,20 @@ def send_reservation_email_notification(
         reservation, mail_template, language=language, context=context
     )
     subject = message_builder.get_subject()
-    message = message_builder.get_content()
+    text_content = message_builder.get_content()
+    html_content = message_builder.get_html_content()
 
     if recipients is None:
         recipients = [reservation.reservee_email]
 
     email = EmailMultiAlternatives(
         subject=subject,
-        body=message,
+        body=text_content,
         from_email=settings.DEFAULT_FROM_EMAIL,
         bcc=recipients,
     )
+
+    if html_content:
+        email.attach_alternative(html_content, "text/html")
+
     email.send(fail_silently=False)

--- a/email_notification/sender/tests/test_email_notification_builder.py
+++ b/email_notification/sender/tests/test_email_notification_builder.py
@@ -91,9 +91,9 @@ class EmailNotificationBuilderTestCase(TestCase):
             self.reservation, template, "sv"
         )
 
-        assert_that(builder_fi.get_content()).is_equal_to("HTML content FI")
-        assert_that(builder_en.get_content()).is_equal_to("HTML content EN")
-        assert_that(builder_sv.get_content()).is_equal_to("HTML content SV")
+        assert_that(builder_fi.get_html_content()).is_equal_to("HTML content FI")
+        assert_that(builder_en.get_html_content()).is_equal_to("HTML content EN")
+        assert_that(builder_sv.get_html_content()).is_equal_to("HTML content SV")
 
     def test_get_content_with_text_content(self):
         template = EmailTemplateFactory(


### PR DESCRIPTION
## Change log
- Provide text and html contents via separate getters
- Use HTML content as attached alternative
- Update tests

## Other notes
Previously HTML content was rendered as text. Now it is rendered as HTML and email application can decide which version to show.

## Deployment reminder
- No changes required