### PR TITLE
TILA-2325: Add reservation unit selection to the email testing form

### DIFF
--- a/email_notification/email_tester.py
+++ b/email_notification/email_tester.py
@@ -4,6 +4,21 @@ from decimal import Decimal
 from django import forms
 
 from email_notification.models import EmailTemplate
+from reservation_units.models import ReservationUnit
+
+
+class ReservationUnitSelectForm(forms.Form):
+    reservation_unit = forms.ChoiceField()
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        runit_choices = list(
+            map(
+                lambda runit: (runit.pk, runit.name),
+                ReservationUnit.objects.all().order_by("name_fi"),
+            )
+        )
+        self.fields["reservation_unit"].choices = runit_choices
 
 
 class EmailTestForm(forms.Form):

--- a/email_notification/sender/senders.py
+++ b/email_notification/sender/senders.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from sentry_sdk import capture_message
 
+from email_notification.email_tester import EmailTestForm
 from email_notification.models import EmailTemplate, EmailType
 from email_notification.sender.email_notification_builder import (
     EmailNotificationContext,
@@ -14,7 +15,7 @@ from reservations.models import Reservation
 
 def send_reservation_email_notification(
     email_type: EmailType,
-    reservation: Reservation,
+    reservation: Optional[Reservation],
     recipients: Optional[List[str]] = None,
     context: Optional[EmailNotificationContext] = None,
 ):
@@ -52,3 +53,15 @@ def send_reservation_email_notification(
         bcc=recipients,
     )
     email.send(fail_silently=False)
+
+
+def send_test_emails(template: EmailTemplate, form: EmailTestForm):
+    context = EmailNotificationContext.from_form(form)
+    for language in ["fi", "sv", "en"]:
+        context.reservee_language = language
+        send_reservation_email_notification(
+            template.type,
+            None,
+            recipients=[form.cleaned_data["recipient"]],
+            context=context,
+        )

--- a/email_notification/templates/email_tester.html
+++ b/email_notification/templates/email_tester.html
@@ -4,12 +4,28 @@ Fooo
 {% block content %}
 <h1 id="site-name">Email Template Testing</h1>
 
-<form method="post" novalidate>
-    {% csrf_token %}
-    <table>
-    {{ form.as_table }}
-    </table>
-    
-    <button>Send Test Emails</button>
-</form>
+<div style="display: flex; flex-direction: row-reverse; flex-wrap: wrap; justify-content: flex-end; gap: 40px 10px">
+
+    <form method="get" novalidate>
+        <table>
+            {{ runit_form.as_table }}
+            <tr>
+                <td></td>
+                <td><button>Fill form with Reservation Unit data</button></td>
+            </tr>
+        </table>
+        
+        
+    </form>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+        <table>
+        {{ form.as_table }}
+        </table>
+        
+        <button>Send Test Emails</button>
+    </form>
+
+</div>
 {% endblock %}

--- a/email_notification/tests/test_admin.py
+++ b/email_notification/tests/test_admin.py
@@ -1,0 +1,132 @@
+from assertpy import assert_that
+from django.contrib.auth.models import User
+from django.test.client import RequestFactory
+from django.test.testcases import TestCase
+
+from email_notification.admin import get_initial_values
+from reservation_units.tests.factories import ReservationUnitFactory
+from spaces.tests.factories import LocationFactory, UnitFactory
+
+
+class GetInitialValuesTestCase(TestCase):
+    def setUp(self) -> None:
+        self.user = User()
+        self.user.email = "test@example.com"
+
+        self.unit = UnitFactory.create(name="Test unit")
+        self.location = LocationFactory.create(
+            address_street="Test street 15",
+            address_zip="01000",
+            address_city="Helsinki",
+            unit=self.unit,
+        )
+        self.reservation_unit = ReservationUnitFactory.create(
+            name="Test reservation unit",
+            reservation_confirmed_instructions_fi="Confirmed FI",
+            reservation_confirmed_instructions_en="Confirmed EN",
+            reservation_confirmed_instructions_sv="Confirmed SV",
+            reservation_pending_instructions_fi="Pending FI",
+            reservation_pending_instructions_en="Pending EN",
+            reservation_pending_instructions_sv="Pending SV",
+            reservation_cancelled_instructions_fi="Cancelled FI",
+            reservation_cancelled_instructions_en="Cancelled EN",
+            reservation_cancelled_instructions_sv="Cancelled SV",
+            unit=self.unit,
+        )
+
+    def test_get_initial_values_collects_all_data(self):
+        request = RequestFactory().get(
+            "/",
+            {
+                "recipient": "test@example.com",
+                "reservation_unit": self.reservation_unit.pk,
+            },
+        )
+
+        request.user = self.user
+        assert_that(get_initial_values(request)).is_equal_to(
+            {
+                "recipient": "test@example.com",
+                "reservation_unit_name": "Test reservation unit",
+                "unit_name": "Test unit",
+                "unit_location": "Test street 15 01000 Helsinki",
+                "confirmed_instructions_fi": "Confirmed FI",
+                "confirmed_instructions_en": "Confirmed EN",
+                "confirmed_instructions_sv": "Confirmed SV",
+                "pending_instructions_fi": "Pending FI",
+                "pending_instructions_en": "Pending EN",
+                "pending_instructions_sv": "Pending SV",
+                "cancelled_instructions_fi": "Cancelled FI",
+                "cancelled_instructions_en": "Cancelled EN",
+                "cancelled_instructions_sv": "Cancelled SV",
+            }
+        )
+
+    def test_get_initial_values_with_location_missing(self):
+        self.location.delete()
+
+        request = RequestFactory().get(
+            "/",
+            {
+                "recipient": "test@example.com",
+                "reservation_unit": self.reservation_unit.pk,
+            },
+        )
+
+        request.user = self.user
+        assert_that(get_initial_values(request)).is_equal_to(
+            {
+                "recipient": "test@example.com",
+                "reservation_unit_name": "Test reservation unit",
+                "unit_name": "Test unit",
+                "confirmed_instructions_fi": "Confirmed FI",
+                "confirmed_instructions_en": "Confirmed EN",
+                "confirmed_instructions_sv": "Confirmed SV",
+                "pending_instructions_fi": "Pending FI",
+                "pending_instructions_en": "Pending EN",
+                "pending_instructions_sv": "Pending SV",
+                "cancelled_instructions_fi": "Cancelled FI",
+                "cancelled_instructions_en": "Cancelled EN",
+                "cancelled_instructions_sv": "Cancelled SV",
+            }
+        )
+
+    def test_get_initial_values_with_unit_missing(self):
+        self.reservation_unit.unit = None
+        self.reservation_unit.save()
+
+        request = RequestFactory().get(
+            "/",
+            {
+                "recipient": "test@example.com",
+                "reservation_unit": self.reservation_unit.pk,
+            },
+        )
+
+        request.user = self.user
+        assert_that(get_initial_values(request)).is_equal_to(
+            {
+                "recipient": "test@example.com",
+                "reservation_unit_name": "Test reservation unit",
+                "unit_name": "",
+                "confirmed_instructions_fi": "Confirmed FI",
+                "confirmed_instructions_en": "Confirmed EN",
+                "confirmed_instructions_sv": "Confirmed SV",
+                "pending_instructions_fi": "Pending FI",
+                "pending_instructions_en": "Pending EN",
+                "pending_instructions_sv": "Pending SV",
+                "cancelled_instructions_fi": "Cancelled FI",
+                "cancelled_instructions_en": "Cancelled EN",
+                "cancelled_instructions_sv": "Cancelled SV",
+            }
+        )
+
+    def test_get_initial_values_with_reservation_unit_missing(self):
+        request = RequestFactory().get(
+            "/", {"recipient": "test@example.com", "reservation_unit": 99999}
+        )
+
+        request.user = self.user
+        assert_that(get_initial_values(request)).is_equal_to(
+            {"recipient": "test@example.com"}
+        )

--- a/email_notification/tests/test_email_tester.py
+++ b/email_notification/tests/test_email_tester.py
@@ -1,0 +1,46 @@
+from assertpy import assert_that
+from django.test.testcases import TestCase
+
+from email_notification.email_tester import EmailTestForm, ReservationUnitSelectForm
+from email_notification.models import EmailType
+from email_notification.tests.factories import EmailTemplateFactory
+from reservation_units.tests.factories import ReservationUnitFactory
+
+
+class ReservationUnitSelectFormTestCase(TestCase):
+    def test_constructor(self):
+        runit1 = ReservationUnitFactory.create(name_fi="Test reservation unit 1")
+        runit2 = ReservationUnitFactory.create(name_fi="Test reservation unit 2")
+        runit3 = ReservationUnitFactory.create(name_fi="Test reservation unit 3")
+
+        form = ReservationUnitSelectForm()
+        assert_that(form.fields["reservation_unit"].choices).is_equal_to(
+            [
+                (runit1.pk, runit1.name_fi),
+                (runit2.pk, runit2.name_fi),
+                (runit3.pk, runit3.name_fi),
+            ]
+        )
+
+
+class EmailTestFormTestCase(TestCase):
+    def test_constructor(self):
+
+        template1 = EmailTemplateFactory.create(
+            name="Template 1", type=EmailType.RESERVATION_CONFIRMED
+        )
+        template2 = EmailTemplateFactory.create(
+            name="Template 2", type=EmailType.RESERVATION_CANCELLED
+        )
+        template3 = EmailTemplateFactory.create(
+            name="Template 3", type=EmailType.RESERVATION_REJECTED
+        )
+
+        form = EmailTestForm()
+        assert_that(form.fields["template"].choices).is_equal_to(
+            [
+                (template1.pk, template1.name),
+                (template2.pk, template2.name),
+                (template3.pk, template3.name),
+            ]
+        )

--- a/email_notification/tests/test_senders.py
+++ b/email_notification/tests/test_senders.py
@@ -1,11 +1,19 @@
+import datetime
+from decimal import Decimal
+from unittest.mock import patch
+
 from assertpy import assert_that
 from django.conf import settings
 from django.core import mail
 from django.test import override_settings
 
 from email_notification.models import EmailType
-from email_notification.sender.senders import send_reservation_email_notification
+from email_notification.sender.senders import (
+    send_reservation_email_notification,
+    send_test_emails,
+)
 from email_notification.tests.base import ReservationEmailBaseTestCase
+from email_notification.tests.factories import EmailTemplateFactory
 
 
 @override_settings(EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend")
@@ -74,3 +82,56 @@ class SendReservationEmailNotificationTestCase(ReservationEmailBaseTestCase):
         assert_that(mail.outbox[0].subject).is_equal_to(should_be_subject)
         assert_that(mail.outbox[0].body).is_equal_to(should_be_body)
         assert_that(mail.outbox[0].bcc).is_equal_to([self.reservation.reservee_email])
+
+    @patch("email_notification.email_tester.EmailTestForm")
+    def test_send_test_emails(self, mock_form):
+        template = EmailTemplateFactory.create(
+            name="Test template",
+            subject_fi="Otsikko",
+            subject_en="Subject",
+            subject_sv="Ämne",
+            content_fi="Sisältö",
+            content_en="Content",
+            content_sv="Innehåll",
+        )
+        mock_form.cleaned_data = {
+            "recipient": "test@example.com",
+            "reservee_name": "Test Name",
+            "begin_datetime": datetime.datetime(2023, 2, 1, 12, 00, 00),
+            "end_datetime": datetime.datetime(2023, 2, 1, 13, 00, 00),
+            "reservation_number": 123,
+            "unit_location": "Test location",
+            "unit_name": "Test unit",
+            "reservation_name": "Test reservation",
+            "reservation_unit_name": "Test reservation unit",
+            "price": Decimal("10.00"),
+            "non_subsidised_price": Decimal("10.00"),
+            "subsidised_price": Decimal("5.00"),
+            "tax_percentage": 24,
+            "confirmed_instructions_fi": "Confirmed FI",
+            "confirmed_instructions_en": "Confirmed EN",
+            "confirmed_instructions_sv": "Confirmed SV",
+            "pending_instructions_fi": "Pending FI",
+            "pending_instructions_en": "Pending EN",
+            "pending_instructions_sv": "Pending SV",
+            "cancelled_instructions_fi": "Cancelled FI",
+            "cancelled_instructions_en": "Cancelled EN",
+            "cancelled_instructions_sv": "Cancelled SV",
+            "deny_reason_fi": "Deny reason FI",
+            "deny_reason_en": "Deny reason EN",
+            "deny_reason_sv": "Deny reason SV",
+            "cancel_reason_fi": "Cancel reason FI",
+            "cancel_reason_en": "Cancel reason EN",
+            "cancel_reason_sv": "Cancel reason SV",
+        }
+        send_test_emails(template, mock_form)
+        assert_that(len(mail.outbox)).is_equal_to(3)
+        assert_that(mail.outbox[0].subject).is_equal_to("Otsikko")
+        assert_that(mail.outbox[0].body).is_equal_to("Sisältö")
+        assert_that(mail.outbox[0].bcc).is_equal_to(["test@example.com"])
+        assert_that(mail.outbox[1].subject).is_equal_to("Ämne")
+        assert_that(mail.outbox[1].body).is_equal_to("Innehåll")
+        assert_that(mail.outbox[1].bcc).is_equal_to(["test@example.com"])
+        assert_that(mail.outbox[2].subject).is_equal_to("Subject")
+        assert_that(mail.outbox[2].body).is_equal_to("Content")
+        assert_that(mail.outbox[2].bcc).is_equal_to(["test@example.com"])


### PR DESCRIPTION
## Change log
- Add a new sub-form for selecting a reservation unit
- Fill the form with reservation unit data if it is selected

## Other notes
This is not the prettiest or most user-friendly implementation, but it does the job. This was requested yesterday in the meeting.

## Deployment reminder
- No changes required