### PR TITLE
TILA-2166 | Hauki admin url api for mass edits

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -48,6 +48,7 @@ from api.graphql.reservation_units.reservation_unit_types import (
     QualifierType,
     ReservationUnitByPkType,
     ReservationUnitCancellationRuleType,
+    ReservationUnitHaukiUrlType,
     ReservationUnitType,
     ReservationUnitTypeType,
     TaxPercentageType,
@@ -398,6 +399,11 @@ class Query(graphene.ObjectType):
     reservation_unit_cancellation_rules = ReservationUnitCancellationRulesFilter(
         ReservationUnitCancellationRuleType
     )
+    reservation_unit_hauki_url = Field(
+        ReservationUnitHaukiUrlType,
+        pk=graphene.Int(),
+        reservation_units=graphene.List(graphene.Int),
+    )
 
     reservation_unit_types = ReservationUnitTypesFilter(
         ReservationUnitTypeType, filterset_class=ReservationUnitTypeFilterSet
@@ -460,6 +466,18 @@ class Query(graphene.ObjectType):
     def resolve_reservation_unit_by_pk(self, info, **kwargs):
         pk = kwargs.get("pk")
         return get_object_or_404(ReservationUnit, pk=pk)
+
+    def resolve_reservation_unit_hauki_url(self, info, **kwargs):
+        pk = kwargs.get("pk")
+
+        reservation_unit = get_object_or_404(ReservationUnit, pk=pk)
+
+        res_units_to_include = kwargs.get("reservation_units")
+        url_type = ReservationUnitHaukiUrlType(
+            instance=reservation_unit, include_reservation_units=res_units_to_include
+        )
+
+        return url_type
 
     @check_resolver_permission(ResourcePermission)
     def resolve_resource_by_pk(self, info, **kwargs):

--- a/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_unit_hauki_url.py
+++ b/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_unit_hauki_url.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_admin_can_get_the_url 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.general%40foo.com&hsa_organization=tprek%3Adepid&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=46f03c933a0f7e32bce2a79dc7e38df10c513fe439c8fd80cad73a273f476f28&target_resources=origin%3A3774af34-9916-40f2-acc7-68db5a627711'
+        }
+    }
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_getting_url_raises_error_if_one_of_target_reservation_unit_not_exist 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': None
+        }
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 21,
+                    'line': 4
+                }
+            ],
+            'message': 'Wrong identifier for reservation unit in url generation.',
+            'path': [
+                'reservationUnitHaukiUrl',
+                'url'
+            ]
+        }
+    ]
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_getting_url_raises_error_if_reservation_unit_not_exist 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': None
+    },
+    'errors': [
+        {
+            'locations': [
+                {
+                    'column': 17,
+                    'line': 3
+                }
+            ],
+            'message': 'No ReservationUnit matches the given query.',
+            'path': [
+                'reservationUnitHaukiUrl'
+            ]
+        }
+    ]
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_regular_user_gets_none_url 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': None
+        }
+    }
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_service_sector_admin_can_get_the_url 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.dee%40foo.com&hsa_organization=tprek%3Adepid&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=13936b91c1ff3334534b386a807459d6696343c32fe9872ea46e687693378cb2&target_resources=origin%3A3774af34-9916-40f2-acc7-68db5a627711'
+        }
+    }
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_unit_admin_can_get_url 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.dee%40foo.com&hsa_organization=tprek%3Adepid&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=13936b91c1ff3334534b386a807459d6696343c32fe9872ea46e687693378cb2&target_resources=origin%3A3774af34-9916-40f2-acc7-68db5a627711'
+        }
+    }
+}
+
+snapshots['ReservationUnitHaukiUrlTestCase::test_url_does_not_contain_reservation_unit_not_in_same_unit 1'] = {
+    'data': {
+        'reservationUnitHaukiUrl': {
+            'url': 'https://test.com/resource/origin%3A3774af34-9916-40f2-acc7-68db5a627710/?hsa_source=origin&hsa_username=amin.general%40foo.com&hsa_organization=tprek%3Adepid&hsa_created_at=2021-05-03T03%3A00%3A00%2B03%3A00&hsa_valid_until=2021-05-03T03%3A30%3A00%2B03%3A00&hsa_resource=origin%3A3774af34-9916-40f2-acc7-68db5a627710&hsa_has_organization_rights=true&hsa_signature=46f03c933a0f7e32bce2a79dc7e38df10c513fe439c8fd80cad73a273f476f28&target_resources=origin%3A3774af34-9916-40f2-acc7-68db5a627711'
+        }
+    }
+}

--- a/api/graphql/tests/test_reservation_units/test_reservation_unit_hauki_url.py
+++ b/api/graphql/tests/test_reservation_units/test_reservation_unit_hauki_url.py
@@ -1,0 +1,162 @@
+import json
+
+import snapshottest
+from assertpy import assert_that
+from django.test import override_settings
+from freezegun import freeze_time
+
+from api.graphql.tests.base import GrapheneTestCaseBase
+from permissions.models import (
+    GeneralRoleChoice,
+    GeneralRolePermission,
+    ServiceSectorRoleChoice,
+    ServiceSectorRolePermission,
+    UnitRoleChoice,
+    UnitRolePermission,
+)
+from reservation_units.tests.factories import ReservationUnitFactory
+from spaces.tests.factories import ServiceSectorFactory, UnitFactory
+
+
+@override_settings(
+    HAUKI_SECRET="HAUKISECRET",
+    HAUKI_ADMIN_UI_URL="https://test.com",
+    HAUKI_ORIGIN_ID="origin",
+)
+@freeze_time("2021-05-03")
+class ReservationUnitHaukiUrlTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        GeneralRolePermission.objects.create(
+            role=GeneralRoleChoice.objects.get(code="admin"),
+            permission="can_manage_units",
+        )
+
+        cls.unit = UnitFactory(tprek_department_id="depid")
+        cls.reservation_unit = ReservationUnitFactory(
+            unit=cls.unit, uuid="3774af34-9916-40f2-acc7-68db5a627710"
+        )
+        cls.target_runit = ReservationUnitFactory(
+            unit=cls.unit, uuid="3774af34-9916-40f2-acc7-68db5a627711"
+        )
+        cls.target_reservation_unit_ids = [str(cls.target_runit.id)]
+        cls.service_sector = ServiceSectorFactory(units=[cls.unit])
+
+    def get_query(self, res_unit_id=None, target_reservation_unit_ids=None):
+        target_reservation_unit_ids = (
+            target_reservation_unit_ids or self.target_reservation_unit_ids
+        )
+
+        target_res_units = ",".join([r for r in target_reservation_unit_ids])
+
+        res_unit_id = res_unit_id or self.reservation_unit.id
+
+        return """
+            query {
+                reservationUnitHaukiUrl(pk: %s reservationUnits: [%s]) {
+                    url
+                }
+            }
+        """ % (
+            res_unit_id,
+            target_res_units,
+        )
+
+    def test_admin_can_get_the_url(self):
+        self.maxDiff = None
+        self.client.force_login(self.general_admin)
+
+        response = self.query(self.get_query())
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_unit_admin_can_get_url(self):
+        self.client.force_login(self.create_unit_admin(self.unit))
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="admin"),
+            permission="can_manage_units",
+        )
+
+        response = self.query(self.get_query())
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_service_sector_admin_can_get_the_url(self):
+        self.client.force_login(
+            self.create_service_sector_admin(service_sector=self.service_sector)
+        )
+        ServiceSectorRolePermission.objects.create(
+            role=ServiceSectorRoleChoice.objects.get(code="admin"),
+            permission="can_manage_units",
+        )
+
+        response = self.query(self.get_query())
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)
+
+    def test_getting_url_raises_error_if_reservation_unit_not_exist(self):
+        self.client.force_login(self.general_admin)
+        response = self.query(self.get_query(res_unit_id="666"))
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_not_none()
+
+        self.assertMatchSnapshot(content)  # data should be None.
+
+    def test_getting_url_raises_error_if_one_of_target_reservation_unit_not_exist(self):
+        self.client.force_login(self.general_admin)
+        response = self.query(self.get_query(target_reservation_unit_ids=["666"]))
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_not_none()
+
+        self.assertMatchSnapshot(content)  # data should be None.
+
+    def test_url_does_not_contain_reservation_unit_not_in_same_unit(self):
+        self.client.force_login(self.general_admin)
+        res_unit = ReservationUnitFactory(unit=UnitFactory())
+        target_res_units = self.target_reservation_unit_ids + [str(res_unit.id)]
+        response = self.query(
+            self.get_query(target_reservation_unit_ids=target_res_units)
+        )
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        url = content.get("data").get("reservationUnitHaukiUrl").get("url")
+        assert_that(url).is_not_empty()
+
+        assert_that(url).does_not_contain(str(res_unit.uuid))
+        assert_that(url).contains(str(self.target_runit.uuid))
+
+        assert_that(content.get(""))
+
+        self.assertMatchSnapshot(content)
+
+    def test_regular_user_gets_none_url(self):
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(self.get_query())
+
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        self.assertMatchSnapshot(content)  # data should be None.

--- a/opening_hours/hauki_link_generator.py
+++ b/opening_hours/hauki_link_generator.py
@@ -2,7 +2,7 @@ import datetime
 import hashlib
 import hmac
 from datetime import timedelta
-from typing import Union
+from typing import List, Union
 from urllib.parse import quote_plus, urlencode
 from uuid import UUID
 
@@ -11,7 +11,7 @@ from django.utils.timezone import get_default_timezone
 
 
 def generate_hauki_link(
-    uuid: UUID, username: str, organization_id: str
+    uuid: UUID, username: str, organization_id: str, target_resources: List[UUID] = None
 ) -> Union[None, str]:
     if not (
         settings.HAUKI_ADMIN_UI_URL
@@ -63,6 +63,14 @@ def generate_hauki_link(
     ).hexdigest()
 
     get_parameters_dict["hsa_signature"] = calculated_signature
+
+    if target_resources:
+        target_resources = [
+            f"{settings.HAUKI_ORIGIN_ID}:{uuid}" for uuid in target_resources
+        ]
+        target_resources = ",".join(target_resources)
+        get_parameters_dict["target_resources"] = target_resources
+
     parameters = urlencode(get_parameters_dict)
     base_url = f"{settings.HAUKI_ADMIN_UI_URL}/resource"
     resource_url = quote_plus(f"{settings.HAUKI_ORIGIN_ID}:{uuid}")


### PR DESCRIPTION
## Change log
- Changes the hauki url generation to create mass-edit url (with target_resources) if needed
- adds GQL api query for getting hauki url wth option to give other reservation units to edit aside with the "main" one.

