### PR TITLE
TILA-2299 | ReservationUnit published filter and reservation validation adjustments

### DIFF
--- a/api/graphql/reservations/reservation_serializers/mixins.py
+++ b/api/graphql/reservations/reservation_serializers/mixins.py
@@ -3,6 +3,7 @@ import math
 from decimal import Decimal
 from typing import Iterable
 
+from django.utils import timezone
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.validation_errors import ValidationErrorCodes, ValidationErrorWithCode
@@ -184,24 +185,17 @@ class ReservationPriceMixin:
 class ReservationSchedulingMixin:
     """Common mixin class for reservations containing date and scheduling related checks"""
 
-    def check_reservation_time(self, reservation_unit: ReservationUnit):
-        state = reservation_unit.state
-        if (
-            state == ReservationUnitState.DRAFT
-            or state == ReservationUnitState.ARCHIVED
-        ):
-            raise ValidationErrorWithCode(
-                f"Reservation unit is not reservable due to status is {state}.",
-                ValidationErrorCodes.RESERVATION_UNIT_NOT_RESERVABLE,
-            )
-
-        now = datetime.datetime.now(get_default_timezone())
-
-        is_invalid_begin = (
+    @classmethod
+    def _get_invalid_begin(cls, reservation_unit, now: datetime.datetime):
+        return (
             reservation_unit.reservation_begins
             and now < reservation_unit.reservation_begins
         ) or (reservation_unit.publish_begins and now < reservation_unit.publish_begins)
 
+    @classmethod
+    def _get_invalid_end(
+        cls, reservation_unit: ReservationUnit, now: datetime.datetime
+    ):
         reservation_in_reservations_closed_period = (
             reservation_unit.reservation_ends
             and now >= reservation_unit.reservation_ends
@@ -220,11 +214,27 @@ class ReservationSchedulingMixin:
                 or (reservation_unit.publish_begins <= reservation_unit.publish_ends)
             )
         )
-
-        is_invalid_end = (
+        return (
             reservation_in_reservations_closed_period
             or reservation_in_non_published_reservation_unit
         )
+
+    def check_reservation_time(self, reservation_unit: ReservationUnit):
+        state = reservation_unit.state
+        if (
+            state == ReservationUnitState.DRAFT
+            or state == ReservationUnitState.ARCHIVED
+        ):
+            raise ValidationErrorWithCode(
+                f"Reservation unit is not reservable due to status is {state}.",
+                ValidationErrorCodes.RESERVATION_UNIT_NOT_RESERVABLE,
+            )
+
+        now = timezone.now()
+
+        is_invalid_begin = self._get_invalid_begin(reservation_unit, now)
+
+        is_invalid_end = self._get_invalid_end(reservation_unit, now)
 
         if is_invalid_begin or is_invalid_end:
             raise ValidationErrorWithCode(

--- a/api/graphql/tests/test_reservations/test_reservation_create.py
+++ b/api/graphql/tests/test_reservations/test_reservation_create.py
@@ -684,6 +684,46 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
             "RESERVATION_UNIT_NOT_RESERVABLE"
         )
 
+    def test_create_fails_reservation_unit_state_is_archived(
+        self, mock_periods, mock_opening_hours
+    ):
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        self.reservation_unit.is_archived = True
+        self.reservation_unit.save()
+
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            self.get_create_query(), input_data=self.get_valid_input_data()
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+        assert_that(content.get("errors")[0]["message"]).is_equal_to(
+            "Reservation unit is not reservable due to status is ReservationUnitState.ARCHIVED."
+        )
+        assert_that(content.get("errors")[0]["extensions"]["error_code"]).is_equal_to(
+            "RESERVATION_UNIT_NOT_RESERVABLE"
+        )
+
+    def test_create_fails_reservation_unit_state_is_draft(
+        self, mock_periods, mock_opening_hours
+    ):
+        mock_opening_hours.return_value = self.get_mocked_opening_hours()
+        self.reservation_unit.is_draft = True
+        self.reservation_unit.save()
+
+        self.client.force_login(self.regular_joe)
+        response = self.query(
+            self.get_create_query(), input_data=self.get_valid_input_data()
+        )
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+        assert_that(content.get("errors")[0]["message"]).is_equal_to(
+            "Reservation unit is not reservable due to status is ReservationUnitState.DRAFT."
+        )
+        assert_that(content.get("errors")[0]["extensions"]["error_code"]).is_equal_to(
+            "RESERVATION_UNIT_NOT_RESERVABLE"
+        )
+
     def test_create_fails_when_reservation_unit_publish_ends_in_past(
         self, mock_periods, mock_opening_hours
     ):

--- a/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_scheduler.py
@@ -168,7 +168,9 @@ class ReservationUnitSchedulerGetNextAvailableReservationTimeTestCase(TestCase):
     ):
         self.app_round.reservation_period_begin = datetime.date(2022, 1, 1)
         self.app_round.reservation_period_end = datetime.date(2022, 1, 2)
-        self.reservation_unit.reservation_ends = datetime.datetime(2021, 12, 31, 0)
+        self.reservation_unit.reservation_ends = datetime.datetime(
+            2021, 12, 31, 0
+        ).astimezone(DEFAULT_TIMEZONE)
         self.reservation_unit.save()
         self.app_round.set_status(ApplicationRoundStatus.IN_REVIEW)
         self.app_round.save()

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -136,8 +136,11 @@ class ReservationUnitReservationScheduler:
 
         return DEFAULT_TIMEZONE.localize(datetime.datetime.now() + delta)
 
-    def _get_reservation_period_end(self, start: datetime.date) -> datetime.date:
-        if self.reservation_unit.reservation_ends:
+    def _get_reservation_period_end(self, start: datetime.datetime) -> datetime.date:
+        if (
+            self.reservation_unit.reservation_ends
+            and self.reservation_unit.reservation_ends > start
+        ):
             return self.reservation_unit.reservation_ends.date()
 
         delta = 720  # Two years ahead by default.


### PR DESCRIPTION
## Change log
  - Adjust ReservationUnit published gql filter so that it checks between publish ends and begins
  - Scheduler logic change for determining reservation period end date
     - If the ReservatioUnit's reservation_ends is after the reservation start period it uses the the reservation_end date
  - Raise validation error in reservation creation if reservation unit is draft or archived.

Refs TILA-2299