### PR TITLE
TILA-2376 | Make subscriptionId and phone not mandaroy for reading order

### DIFF
--- a/merchants/verkkokauppa/order/test/test_create_order_params.py
+++ b/merchants/verkkokauppa/order/test/test_create_order_params.py
@@ -1,0 +1,88 @@
+from datetime import datetime, timedelta
+from decimal import Decimal
+
+import freezegun
+from assertpy import assert_that
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from django.utils.timezone import get_default_timezone
+
+from applications.models import CUSTOMER_TYPES
+from merchants.tests.factories import PaymentProductFactory
+from merchants.verkkokauppa.helpers import _get_order_params, get_validated_phone_number
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.tests.factories import ReservationFactory
+
+
+class CreateOrderParamsToJsonTestCase(TestCase):
+    @freezegun.freeze_time("2023-01-01 00:00:00")
+    def test_to_json(self):
+        payment_product = PaymentProductFactory()
+        reservation_unit = ReservationUnitFactory(payment_product=payment_product)
+        user = get_user_model().objects.create_user(
+            username="test",
+            email="test@localhost",
+            first_name="First",
+            last_name="Name",
+        )
+
+        reservation = ReservationFactory(
+            reservation_unit=[reservation_unit],
+            user=user,
+            price_net=Decimal("10"),
+            price=Decimal("12.4"),
+            tax_percentage_value=Decimal("24"),
+            reservee_type=CUSTOMER_TYPES.CUSTOMER_TYPE_INDIVIDUAL,
+        )
+        order_params = _get_order_params(reservation)
+
+        json = order_params.to_json()
+
+        assert_that(json["namespace"]).is_equal_to(settings.VERKKOKAUPPA_NAMESPACE)
+        assert_that(json["user"]).is_equal_to(str(reservation.user.uuid))
+        assert_that(json["language"]).is_equal_to(reservation.reservee_language or "fi")
+        assert_that(json["priceNet"]).is_equal_to("10")
+        assert_that(json["priceVat"]).is_equal_to("2.40")
+        assert_that(json["priceTotal"]).is_equal_to("12.40")
+        assert_that(json["customer"]["firstName"]).is_equal_to("First")
+        assert_that(json["customer"]["lastName"]).is_equal_to("Name")
+        assert_that(json["customer"]["email"]).is_equal_to("asdasd@asdasd.fi")
+        assert_that(json["customer"]["phone"]).is_equal_to(
+            get_validated_phone_number(reservation.reservee_phone)
+        )
+        assert_that(json["lastValidPurchaseDateTime"]).is_equal_to(
+            (
+                datetime.now(tz=get_default_timezone())
+                + timedelta(minutes=settings.VERKKOKAUPPA_ORDER_EXPIRATION_MINUTES)
+            ).isoformat()
+        )
+        assert_that(json["items"]).is_length(1)
+        assert_that(json["items"][0]["productId"]).is_equal_to(
+            str(reservation.reservation_unit.first().payment_product.id)
+        )
+        assert_that(json["items"][0]["productName"]).is_equal_to(
+            reservation.reservation_unit.first().name_fi
+        )
+        assert_that(json["items"][0]["quantity"]).is_equal_to(1)
+        assert_that(json["items"][0]["unit"]).is_equal_to("pcs")
+        assert_that(json["items"][0]["rowPriceNet"]).is_equal_to("10")
+        assert_that(json["items"][0]["rowPriceVat"]).is_equal_to("2.40")
+        assert_that(json["items"][0]["rowPriceTotal"]).is_equal_to("12.40")
+        assert_that(json["items"][0]["priceNet"]).is_equal_to("10")
+        assert_that(json["items"][0]["priceVat"]).is_equal_to("2.40")
+        assert_that(json["items"][0]["priceGross"]).is_equal_to("12.40")
+        assert_that(json["items"][0]["vatPercentage"]).is_equal_to(
+            "24"  # Note this needs to be 24, not 24.00.
+        )
+        assert_that(json["items"][0]["meta"]).is_length(2)
+        assert_that(json["items"][0]["meta"][0]["key"]).is_equal_to(
+            "namespaceProductId"
+        )
+        assert_that(json["items"][0]["meta"][0]["value"]).is_equal_to(
+            str(reservation.reservation_unit.first().uuid)
+        )
+        assert_that(json["items"][0]["meta"][0]["label"]).is_none()
+        assert_that(json["items"][0]["meta"][0]["visibleInCheckout"]).is_false()
+        assert_that(json["items"][0]["meta"][0]["ordinal"]).is_equal_to(0)
+        assert_that(json["items"][0]["meta"][1]["key"]).is_equal_to("reservationPeriod")

--- a/merchants/verkkokauppa/order/test/test_order_from_json.py
+++ b/merchants/verkkokauppa/order/test/test_order_from_json.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from decimal import Decimal
+from uuid import UUID
+
+from assertpy import assert_that
+from django.test import TestCase
+
+from merchants.verkkokauppa.order.types import Order
+
+order_json = {
+    "orderId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "namespace": "tilavaraus",
+    "user": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "createdAt": "2021-02-25T10:22:59.000",
+    "items": [
+        {
+            "orderItemId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+            "orderId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+            "productId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+            "productName": "Tilavarauspalvelu",
+            "quantity": 1,
+            "unit": "pcs",
+            "rowPriceNet": "10",
+            "rowPriceVat": "2.4",
+            "rowPriceTotal": "12.4",
+            "priceNet": "10",
+            "priceGross": "12.4",
+            "priceVat": "2.4",
+            "vatPercentage": "24",
+            "meta": [
+                {
+                    "orderItemMetaId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+                    "orderItemId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+                    "orderId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+                    "key": "reservation_id",
+                    "value": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+                    "label": "Varaus",
+                    "visible_in_checkout": True,
+                    "ordinal": 1,
+                }
+            ],
+            "periodFrequency": None,
+            "periodUnit": None,
+            "periodCount": None,
+            "startDate": None,
+            "billingStartDate": None,
+        }
+    ],
+    "priceNet": "10",
+    "priceVat": "2.4",
+    "priceTotal": "12.4",
+    "checkoutUrl": "https://checkout.url",
+    "receiptUrl": "https://receipt.url",
+    "customer": {"firstName": "Foo", "lastName": "Bar", "email": "", "phone": "123456"},
+    "status": "pending",
+    "subscriptionId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "type": "reservation",
+}
+
+
+class OrderFromJsonTestCase(TestCase):
+    def test_order_from_json(self):
+        order = Order.from_json(order_json)
+        assert_that(order.order_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(order.namespace).is_equal_to("tilavaraus")
+        assert_that(order.user).is_equal_to("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        assert_that(order.created_at).is_equal_to(datetime(2021, 2, 25, 10, 22, 59))
+        assert_that(order.items[0].order_item_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(order.items[0].order_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(order.items[0].product_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(order.items[0].product_name).is_equal_to("Tilavarauspalvelu")
+        assert_that(order.items[0].quantity).is_equal_to(1)
+        assert_that(order.items[0].unit).is_equal_to("pcs")
+        assert_that(order.items[0].row_price_net).is_equal_to(Decimal("10"))
+        assert_that(order.items[0].row_price_vat).is_equal_to(Decimal("2.4"))
+        assert_that(order.items[0].row_price_total).is_equal_to(Decimal("12.4"))
+        assert_that(order.items[0].price_net).is_equal_to(Decimal("10"))
+        assert_that(order.items[0].price_gross).is_equal_to(Decimal("12.4"))
+        assert_that(order.items[0].price_vat).is_equal_to(Decimal("2.4"))
+        assert_that(order.items[0].vat_percentage).is_equal_to(Decimal("24"))
+        assert_that(order.items[0].meta[0].order_item_meta_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6"),
+        )
+        assert_that(order.subscription_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6"),
+        )
+
+    def test_phone_not_included(self):
+        data = order_json.copy()
+        data["customer"].pop("phone")
+        order = Order.from_json(data)
+
+        assert_that(order.customer.phone).is_equal_to("")
+
+    def test_subscription_id_not_included(self):
+        data = order_json.copy()
+        data.pop("subscriptionId")
+        order = Order.from_json(data)
+
+        assert_that(order.subscription_id).is_none()

--- a/merchants/verkkokauppa/order/types.py
+++ b/merchants/verkkokauppa/order/types.py
@@ -205,7 +205,7 @@ class CreateOrderParams:
                     "priceNet": str(item.price_net),
                     "priceGross": str(item.price_gross),
                     "priceVat": str(item.price_vat),
-                    "vatPercentage": str(item.vat_percentage),
+                    "vatPercentage": str(int(item.vat_percentage)),
                     "meta": [
                         {
                             "key": meta.key,

--- a/merchants/verkkokauppa/order/types.py
+++ b/merchants/verkkokauppa/order/types.py
@@ -101,6 +101,12 @@ class Order:
     def from_json(cls, json: Dict[str, Any]) -> "Order":
         from ..helpers import parse_datetime
 
+        subscription_id = json.get("subscriptionId")
+        try:
+            subscription_id = UUID(subscription_id)
+        except (TypeError, ValueError):
+            subscription_id = None
+
         try:
             return Order(
                 order_id=UUID(json["orderId"]),
@@ -155,12 +161,10 @@ class Order:
                     first_name=json["customer"]["firstName"],
                     last_name=json["customer"]["lastName"],
                     email=json["customer"]["email"],
-                    phone=json["customer"]["phone"],
+                    phone=json["customer"].get("phone", ""),
                 ),
                 status=json["status"],
-                subscription_id=UUID(json["subscriptionId"])
-                if json["subscriptionId"]
-                else None,
+                subscription_id=subscription_id if subscription_id else None,
                 type=json["type"],
             )
         except (KeyError, ValueError) as err:


### PR DESCRIPTION
## CHANGES
 - Order from_json method had an expectation that subscriptionId would be always present. This isn't the case and this adds handling for non existent subscription ids. Same goes for the phone.
 - Send tax percentage value without comma to verkkokauppa

Refs TILA-2376
