### PR TITLE
TILA-2345 | Fix uuid migration

### DIFF
--- a/reservations/migrations/0045_reservee_stats_field_updates.py
+++ b/reservations/migrations/0045_reservee_stats_field_updates.py
@@ -4,6 +4,14 @@ from django.db import migrations, models
 import uuid
 
 
+
+def set_uuids_for_existing(apps, schema_editor):
+    RecurringReservation = apps.get_model("reservations", "RecurringReservation")
+    for recurring in RecurringReservation.objects.all():
+        recurring.uuid = uuid.uuid4()
+        recurring.save(update_fields=["uuid"])
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -14,8 +22,15 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='recurringreservation',
             name='uuid',
-            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True),
+            field=models.UUIDField(null=True, editable=False),
         ),
+        migrations.RunPython(set_uuids_for_existing, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name='recurringreservation',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, editable=False, unique=True, null=False),
+        ),
+        migrations.RunSQL(migrations.RunSQL.noop, reverse_sql='SET CONSTRAINTS ALL IMMEDIATE'),
         migrations.AddField(
             model_name='reservationstatistic',
             name='is_recurring',

--- a/reservations/tests/test_recurring_reservation.py
+++ b/reservations/tests/test_recurring_reservation.py
@@ -1,0 +1,26 @@
+from assertpy import assert_that
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+from django.test import TestCase
+
+from reservations.models import RecurringReservation
+from reservations.tests.factories import RecurringReservationFactory
+
+
+class TestRecurringReservationUUIDMigration(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.rec = RecurringReservationFactory()
+        cls.rec_too = RecurringReservationFactory()
+
+        migration = MigrationExecutor(connection)
+        migration.migrate([("reservations", "0044_recurringreservation_description")])
+
+    def test_uuid_get_value_from_custom_migration(self):
+        migration = MigrationExecutor(connection)
+        migration.migrate([("reservations", "0045_reservee_stats_field_updates")])
+
+        assert_that(
+            RecurringReservation.objects.filter(uuid__isnull=True).exists()
+        ).is_false()
+        assert_that(RecurringReservation.objects.exists()).is_true()


### PR DESCRIPTION
To Recurring reservation was added UUID field which was unique. We must always handle unique field adds afterwards with custom migration code and this wasn't exception. This adds the custom setting up the uuid field for RecurringReservation.

Refs TILA-2345

