### PR TITLE
TILA-2379: Refund webhook endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,8 +264,14 @@ SENTRY_ENVIRONMENT=local-development-unconfigured
 # URL for the Verkkokauppa payment experience API
 #VERKKOKAUPPA_PAYMENT_API_URL=
 
+# URL for the Verkkokauppa merchant experience API
+#VERKKOKAUPPA_MERCHANT_API_URL=
+
 # Namespace for the Verkkokauppa merchants
 VERKKOKAUPPA_NAMESPACE=tilanvaraus
+
+# Order expiration time
+VERKKOKAUPPA_ORDER_EXPIRATION_MINUTES=5
 
 # Is reservation unit product mapping enabled (uses Celery and Verkkokauppa API)
 # Defaults to false

--- a/api/urls.py
+++ b/api/urls.py
@@ -3,7 +3,11 @@ from django.views.decorators.csrf import csrf_exempt
 from graphene_file_upload.django import FileUploadGraphQLView
 from rest_framework import routers
 
-from api.webhook_api.views import WebhookOrderViewSet, WebhookPaymentViewSet
+from api.webhook_api.views import (
+    WebhookOrderViewSet,
+    WebhookPaymentViewSet,
+    WebhookRefundViewSet,
+)
 
 from .allocation_api import AllocationRequestViewSet
 from .allocation_results_api import AllocationResultViewSet
@@ -126,6 +130,7 @@ router.register(
 router.register(r"parameters/city", CityViewSet, "city")
 router.register(r"webhook/payment", WebhookPaymentViewSet, "payment")
 router.register(r"webhook/order", WebhookOrderViewSet, "order")
+router.register(r"webhook/refund", WebhookRefundViewSet, "refund")
 urlpatterns = [
     path("graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=True))),
     path(


### PR DESCRIPTION
## Change log
- Added missing configs to `.env.example`
- Added a new endpoint that handles refund webhooks from Verkkokauppa

## Notes
Our model is still missing a field that is required a bit later. I left a TODO comment for this. There is already task for it.

## Deployment reminder
- No changes required