### PR TITLE
TILA-2380: Add client for webshop refunds

### DIFF
--- a/merchants/verkkokauppa/payment/exceptions.py
+++ b/merchants/verkkokauppa/payment/exceptions.py
@@ -11,3 +11,11 @@ class ParsePaymentError(PaymentError):
 
 class GetPaymentError(PaymentError):
     pass
+
+
+class ParseRefundError(PaymentError):
+    pass
+
+
+class RefundPaymentError(PaymentError):
+    pass

--- a/merchants/verkkokauppa/payment/requests.py
+++ b/merchants/verkkokauppa/payment/requests.py
@@ -6,13 +6,20 @@ from uuid import UUID
 from django.conf import settings
 from requests import RequestException
 from requests import get as _get
+from requests import post as _post
+from sentry_sdk import capture_exception, capture_message, push_scope
 
 from utils.metrics import ExternalServiceMetric
 
 from ..constants import METRIC_SERVICE_NAME, REQUEST_TIMEOUT_SECONDS
 from ..exceptions import VerkkokauppaConfigurationError
-from .exceptions import GetPaymentError, ParsePaymentError
-from .types import Payment
+from .exceptions import (
+    GetPaymentError,
+    ParsePaymentError,
+    ParseRefundError,
+    RefundPaymentError,
+)
+from .types import Payment, Refund
 
 
 def _get_base_url():
@@ -60,3 +67,49 @@ def get_payment(order_id: UUID, namespace: str, get=_get) -> Optional[Payment]:
         return Payment.from_json(json)
     except (RequestException, JSONDecodeError, ParsePaymentError) as e:
         raise GetPaymentError("Payment retrieval failed") from e
+
+
+def refund_order(order_id: UUID, post=_post) -> Optional[Refund]:
+    try:
+        with ExternalServiceMetric(
+            METRIC_SERVICE_NAME, "POST", f"/refund/instant/{order_id}"
+        ) as metric:
+            response = post(
+                url=urljoin(_get_base_url(), f"refund/instant/{order_id}"),
+                headers={
+                    "api-key": settings.VERKKOKAUPPA_API_KEY,
+                    "namespace": settings.VERKKOKAUPPA_NAMESPACE,
+                },
+                timeout=REQUEST_TIMEOUT_SECONDS,
+            )
+            metric.response_status = response.status_code
+
+        if response.status_code > 200:
+            capture_message(
+                f"Call to Payment Experience API refund endpoint failed with status {response.status_code}. "
+                + f"Response body: {response.text}",
+                level="error",
+            )
+            raise RefundPaymentError(
+                "Payment refund failed: problem with upstream service"
+            )
+        json = response.json()
+        refund_count = len(json["refunds"]) if "refunds" in json else 0
+        if refund_count == 1:
+            return Refund.from_json(json["refunds"][0])
+        else:
+            capture_message(
+                "Call to Payment Experience API refund endpoint failed. "
+                + f"Response contains {refund_count} refunds instead of one. "
+                + f"Response body: {response.text}",
+                level="error",
+            )
+            raise RefundPaymentError(
+                f"Refund response refund count expected to be 1 but was {refund_count}"
+            )
+    except (RequestException, JSONDecodeError, ParseRefundError) as err:
+        with push_scope() as scope:
+            scope.set_extra("details", "Payment refund failed")
+            scope.set_extra("order-id", order_id)
+            capture_exception(err)
+        raise RefundPaymentError(f"Payment refund failed: {str(err)}") from err

--- a/merchants/verkkokauppa/payment/test/test_refund_from_json.py
+++ b/merchants/verkkokauppa/payment/test/test_refund_from_json.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from unittest import mock
+from uuid import UUID
+
+from assertpy import assert_that
+from django.test import TestCase
+from pytest import raises
+
+from merchants.verkkokauppa.payment.exceptions import ParseRefundError
+from merchants.verkkokauppa.payment.types import Refund
+
+refund_json = {
+    "refundId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "orderId": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "namespace": "tilavaraus",
+    "user": "b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6",
+    "createdAt": "2021-02-25T10:22:59.000",
+    "status": "confirmed",
+    "customerFirstName": "First",
+    "customerLastName": "Last",
+    "customerEmail": "test@example.com",
+    "customerPhone": "+358 50 123 4567",
+    "refundReason": "Test reason",
+    "items": [],  # Not useful for us, ignored
+    "payment": {},  # Not useful for us, ignored
+}
+
+
+class RefundFromJsonTestCase(TestCase):
+    def test_refund_from_json(self):
+        refund = Refund.from_json(refund_json)
+        assert_that(refund.refund_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(refund.order_id).is_equal_to(
+            UUID("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        )
+        assert_that(refund.namespace).is_equal_to("tilavaraus")
+        assert_that(refund.user).is_equal_to("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        assert_that(refund.created_at).is_equal_to(datetime(2021, 2, 25, 10, 22, 59))
+        assert_that(refund.status).is_equal_to("confirmed")
+        assert_that(refund.customer_first_name).is_equal_to("First")
+        assert_that(refund.customer_last_name).is_equal_to("Last")
+        assert_that(refund.customer_email).is_equal_to("test@example.com")
+        assert_that(refund.customer_phone).is_equal_to("+358 50 123 4567")
+        assert_that(refund.refund_reason).is_equal_to("Test reason")
+
+    def test_optional_fields_not_included(self):
+        data = refund_json.copy()
+        data.pop("customerFirstName")
+        data.pop("customerLastName")
+        data.pop("customerEmail")
+        data.pop("customerPhone")
+        data.pop("refundReason")
+        refund = Refund.from_json(data)
+
+        assert_that(refund.namespace).is_equal_to("tilavaraus")
+        assert_that(refund.user).is_equal_to("b6b6b6b6-b6b6-b6b6-b6b6-b6b6b6b6b6b6")
+        assert_that(refund.created_at).is_equal_to(datetime(2021, 2, 25, 10, 22, 59))
+        assert_that(refund.status).is_equal_to("confirmed")
+        assert_that(refund.customer_first_name).is_none()
+        assert_that(refund.customer_last_name).is_none()
+        assert_that(refund.customer_email).is_none()
+        assert_that(refund.customer_phone).is_none()
+        assert_that(refund.refund_reason).is_none()
+
+    @mock.patch("merchants.verkkokauppa.payment.types.capture_exception")
+    def test_parsing_fails(self, mock_capture_exception):
+        with raises(ParseRefundError) as ex:
+            data = refund_json.copy()
+            data["refundId"] = "not-a-uuid"
+            Refund.from_json(data)
+
+        assert_that(str(ex.value)).is_equal_to(
+            "Could not parse refund: badly formed hexadecimal UUID string"
+        )
+        assert_that(mock_capture_exception.called).is_true()

--- a/merchants/verkkokauppa/payment/types.py
+++ b/merchants/verkkokauppa/payment/types.py
@@ -5,7 +5,9 @@ from enum import Enum
 from typing import Any, Dict, Optional
 from uuid import UUID
 
-from ..payment.exceptions import ParsePaymentError
+from sentry_sdk import capture_exception, push_scope
+
+from ..payment.exceptions import ParsePaymentError, ParseRefundError
 
 
 class PaymentStatus(Enum):
@@ -65,3 +67,43 @@ class Payment:
     @classmethod
     def _parse_datetime(cls, string: str) -> datetime:
         return datetime.strptime(string, "%Y%m%d-%H%M%S")
+
+
+@dataclass(frozen=True)
+class Refund:
+    refund_id: UUID
+    order_id: UUID
+    namespace: str
+    user: str
+    created_at: datetime
+    status: str
+    customer_first_name: Optional[str]
+    customer_last_name: Optional[str]
+    customer_email: Optional[str]
+    customer_phone: Optional[str]
+    refund_reason: Optional[str]
+
+    @classmethod
+    def from_json(cls, json: Dict[str, Any]) -> "Refund":
+        from ..helpers import parse_datetime
+
+        try:
+            return Refund(
+                refund_id=UUID(json["refundId"]),
+                order_id=UUID(json["orderId"]),
+                namespace=json["namespace"],
+                user=json["user"],
+                created_at=parse_datetime(json["createdAt"]),
+                status=json["status"],
+                customer_first_name=json.get("customerFirstName"),
+                customer_last_name=json.get("customerLastName"),
+                customer_email=json.get("customerEmail"),
+                customer_phone=json.get("customerPhone"),
+                refund_reason=json.get("refundReason"),
+            )
+        except (KeyError, ValueError) as err:
+            with push_scope() as scope:
+                scope.set_extra("details", "Parsing refund failed")
+                scope.set_extra("json", json)
+                capture_exception(err)
+            raise ParseRefundError(f"Could not parse refund: {str(err)}") from err

--- a/merchants/verkkokauppa/tests/test_payment_requests.py
+++ b/merchants/verkkokauppa/tests/test_payment_requests.py
@@ -1,17 +1,21 @@
+from copy import deepcopy
+from typing import Any, Dict
+from unittest import mock
 from unittest.mock import Mock
 from urllib.parse import urljoin
 from uuid import UUID
 
 from assertpy import assert_that
 from django.conf import settings
+from django.test.testcases import TestCase
 from pytest import raises
 from requests import Timeout
 
 from ..constants import REQUEST_TIMEOUT_SECONDS
-from ..payment.exceptions import GetPaymentError
-from ..payment.requests import get_payment
-from ..payment.types import Payment
-from .mocks import mock_get
+from ..payment.exceptions import GetPaymentError, RefundPaymentError
+from ..payment.requests import get_payment, refund_order
+from ..payment.types import Payment, Refund
+from .mocks import mock_get, mock_post
 
 
 def test_get_payment_makes_valid_request(get_payment_response):
@@ -58,3 +62,80 @@ def test_get_payment_raises_exception_on_timeout(get_payment_response):
     namespace = get_payment_response["namespace"]
     with raises(GetPaymentError):
         get_payment(order_id, namespace, Mock(side_effect=Timeout()))
+
+
+class RefundPaymentRequestsTestCase(TestCase):
+    refund_response: Dict[str, Any] = {
+        "refunds": [
+            {
+                "refundId": "6a8f7829-b6c7-4bbd-add2-0a200298a691",
+                "orderId": "019c85c4-0887-4199-8440-b129bb3ba10f",
+                "namespace": "tilanvaraus",
+                "user": "test-user",
+                "createdAt": "2021-11-12T12:40:41.873597",
+                "status": "confirmed",
+                "customerFirstName": "First",
+                "customerLastName": "Last",
+                "customerEmail": "test@example.com",
+                "customerPhone": "+358 50 123 4567",
+                "refundReason": "Test reason",
+                "items": [],
+                "payment": {},
+            }
+        ],
+        "errors": [],
+    }
+
+    def test_refund_order_returns_refund(self):
+        order_id = UUID(self.refund_response["refunds"][0]["orderId"])
+        post = mock_post(self.refund_response, status_code=200)
+        refund = refund_order(order_id, post)
+        expected = Refund.from_json(self.refund_response["refunds"][0])
+        assert_that(refund).is_equal_to(expected)
+
+    @mock.patch("merchants.verkkokauppa.payment.requests.capture_message")
+    def test_refund_order_raises_exception_on_non_200_status_code(self, mock_capture):
+        order_id = UUID(self.refund_response["refunds"][0]["orderId"])
+        post = mock_post({}, status_code=500)
+
+        with raises(RefundPaymentError) as ex:
+            refund_order(order_id, post)
+
+        assert_that(str(ex.value)).is_equal_to(
+            "Payment refund failed: problem with upstream service"
+        )
+        assert_that(mock_capture.called).is_true()
+
+    @mock.patch("merchants.verkkokauppa.payment.requests.capture_message")
+    def test_refund_order_raises_exception_on_multi_refund_response(self, mock_capture):
+        order_id = UUID(self.refund_response["refunds"][0]["orderId"])
+
+        response = deepcopy(self.refund_response)
+        response["refunds"].append({})
+
+        post = mock_post(response, status_code=200)
+
+        with raises(RefundPaymentError) as ex:
+            refund_order(order_id, post)
+
+        assert_that(str(ex.value)).is_equal_to(
+            "Refund response refund count expected to be 1 but was 2"
+        )
+        assert_that(mock_capture.called).is_true()
+
+    @mock.patch("merchants.verkkokauppa.payment.requests.capture_exception")
+    def test_refund_order_raises_exception_on_invalid_response(self, mock_capture):
+        order_id = UUID(self.refund_response["refunds"][0]["orderId"])
+
+        response = deepcopy(self.refund_response)
+        response["refunds"][0]["refundId"] = "not-a-uuid"
+
+        post = mock_post(response, status_code=200)
+
+        with raises(RefundPaymentError) as ex:
+            refund_order(order_id, post)
+
+        assert_that(str(ex.value)).is_equal_to(
+            "Payment refund failed: Could not parse refund: badly formed hexadecimal UUID string"
+        )
+        assert_that(mock_capture.called).is_true()

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
 celery==5.2.7
-Django==3.2.16
+Django==3.2.18
 django-auditlog==2.2.0
 django-admin-sortable2==1.0.4 # Pin to this since the latest has dropped django 3.2 support.
 django-celery-beat==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ defusedxml==0.7.1
     #   social-auth-core
 deprecation==2.1.0
     # via django-helusers
-django==3.2.16
+django==3.2.18
     # via
     #   -r requirements.in
     #   django-admin-sortable2
@@ -156,7 +156,7 @@ graphene-file-upload==1.3.0
 graphene-permissions==1.1.4
     # via -r requirements.in
 graphql-core==3.2.3
-    # viapip i
+    # via
     #   graphene
     #   graphene-django
     #   graphql-relay


### PR DESCRIPTION
## Change log
- Added client for the new webshop instant refund endpoint
- Updated Django version because of [CVE](https://pyup.io/v/52945/f17/)

## Other notes
The response from webshop contains a lot more fields and data than what we need. I chose to just ignore those fields instead of writing unnecessary complex parsers.

## Deployment reminder
- No changes required