### PR TITLE
TILA-2396: Add refund_id to PaymentOrderType

### DIFF
--- a/api/graphql/merchants/merchant_types.py
+++ b/api/graphql/merchants/merchant_types.py
@@ -48,6 +48,7 @@ class PaymentOrderType(AuthNode, PrimaryKeyObjectType):
     checkout_url = graphene.String()
     receipt_url = graphene.String()
     reservation_pk = graphene.String()
+    refund_id = graphene.String()
 
     class Meta:
         model = PaymentOrder
@@ -59,6 +60,7 @@ class PaymentOrderType(AuthNode, PrimaryKeyObjectType):
             "checkout_url",
             "receipt_url",
             "reservation_pk",
+            "refund_id",
         ]
         interfaces = (graphene.relay.Node,)
         connection_class = TilavarausBaseConnection

--- a/api/graphql/tests/snapshots/snap_test_orders.py
+++ b/api/graphql/tests/snapshots/snap_test_orders.py
@@ -20,6 +20,7 @@ snapshots['OrderQueryTestCase::test_returns_order_when_user_can_handle_reservati
             'orderUuid': 'b3fef99e-6c18-422e-943d-cf00702af53e',
             'paymentType': 'INVOICE',
             'receiptUrl': None,
+            'refundId': None,
             'reservationPk': '1',
             'status': 'DRAFT'
         }
@@ -33,6 +34,21 @@ snapshots['OrderQueryTestCase::test_returns_order_when_user_owns_reservation 1']
             'orderUuid': 'b3fef99e-6c18-422e-943d-cf00702af53e',
             'paymentType': 'INVOICE',
             'receiptUrl': None,
+            'refundId': None,
+            'reservationPk': '1',
+            'status': 'DRAFT'
+        }
+    }
+}
+
+snapshots['OrderQueryTestCase::test_returns_refund_id_when_it_exists 1'] = {
+    'data': {
+        'order': {
+            'checkoutUrl': None,
+            'orderUuid': 'b3fef99e-6c18-422e-943d-cf00702af53e',
+            'paymentType': 'INVOICE',
+            'receiptUrl': None,
+            'refundId': 'd55db3a0-0786-4259-ab9e-c4211cae162e',
             'reservationPk': '1',
             'status': 'DRAFT'
         }

--- a/api/graphql/tests/test_orders.py
+++ b/api/graphql/tests/test_orders.py
@@ -1,6 +1,7 @@
 import json
 from typing import Dict, Optional
 from unittest import mock
+from uuid import UUID
 
 import snapshottest
 from assertpy import assert_that
@@ -50,6 +51,7 @@ class OrderQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
                     receiptUrl
                     checkoutUrl
                     reservationPk
+                    refundId
                 }
             }
             """
@@ -73,6 +75,18 @@ class OrderQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         self.assertMatchSnapshot(content)
 
     def test_returns_order_when_user_can_handle_reservations(self):
+        self.client.force_login(self.general_admin)
+
+        response = self.query(self.get_order_query())
+        assert_that(response.status_code).is_equal_to(200)
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_returns_refund_id_when_it_exists(self):
+        self.order.refund_id = UUID("d55db3a0-0786-4259-ab9e-c4211cae162e")
+        self.order.save()
+
         self.client.force_login(self.general_admin)
 
         response = self.query(self.get_order_query())


### PR DESCRIPTION
## Change log
- Added `refund_id` field to `PaymentOrderType`

## Other notes
PR is failing because there is a CVE in `cryptography` package. #776 upgrades the package so I'll update this one after #776 has been merged

## Deployment reminder
- No changes required