### PR TITLE
TILA-2397: Fix invalid reservation time in payment order

### DIFF
--- a/merchants/verkkokauppa/helpers.py
+++ b/merchants/verkkokauppa/helpers.py
@@ -31,10 +31,14 @@ def get_formatted_reservation_time(reservation: Reservation) -> str:
     Weekday is localized based on user's preferred language, but rest
     of the format is always the same: ww dd.mm.yyyy hh:mm-hh:mm
     """
+    begin = reservation.begin.astimezone(get_default_timezone())
+    end = reservation.end.astimezone(get_default_timezone())
+
     preferred_language = reservation.user.preferred_language or "fi"
-    weekday = localized_short_weekday(reservation.begin.weekday(), preferred_language)
-    end_time = reservation.end.strftime("%H:%M")
-    return reservation.begin.strftime(f"{weekday} %d.%m.%Y %H:%M-{end_time}")
+    weekday = localized_short_weekday(begin.weekday(), preferred_language)
+    end_time = end.strftime("%H:%M")
+
+    return begin.strftime(f"{weekday} %d.%m.%Y %H:%M-{end_time}")
 
 
 def get_validated_phone_number(phone_number: str) -> str:

--- a/merchants/verkkokauppa/tests/test_helpers.py
+++ b/merchants/verkkokauppa/tests/test_helpers.py
@@ -4,8 +4,8 @@ from unittest.mock import patch
 from assertpy import assert_that
 from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.utils import timezone
 from freezegun import freeze_time
-from pytz import UTC
 
 from applications.models import CUSTOMER_TYPES
 from merchants.tests.factories import PaymentProductFactory
@@ -33,7 +33,7 @@ class HelpersTestCase(TestCase):
             name_fi="Suomeksi", name_sv="Ruotsiksi", name_en="Englanniksi"
         )
 
-        begin = datetime.now(UTC)
+        begin = datetime.now().astimezone(timezone.get_default_timezone())
         end = begin + timedelta(hours=2)
         self.reservation = ReservationFactory(
             reservation_unit=[self.reservation_unit],


### PR DESCRIPTION
## Change log
- Fixed invalid reservation time in PaymentOrder

## Other notes
The old code didn't use get_default_timezone() so we ended up having different times in our database and in web shop.

## Deployment reminder
- No changes required