### PR TITLE
 TILA-2378 | Make zero length opening hours to be skipped by opening hours client

### DIFF
--- a/opening_hours/tests/test_opening_hours_client.py
+++ b/opening_hours/tests/test_opening_hours_client.py
@@ -458,3 +458,21 @@ class OpeningHoursClientTestCase(TestCase):
         )
         origin_id = mock.call_args.args[3]
         assert_that(origin_id).is_same_as(self.unit.hauki_resource_data_source_id)
+
+    def test_times_is_not_present_if_length_is_zero(self, mock):
+        data = self.get_mocked_opening_hours()
+        data[0]["times"][0] = TimeElement(
+            start_time=datetime.time(hour=10),
+            end_time=datetime.time(hour=10),
+            end_time_on_next_day=False,
+            resource_state=State.OPEN_AND_RESERVABLE.value,
+        )
+
+        mock.return_value = data
+        client = OpeningHoursClient(
+            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+        )
+        times = client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid), DATES[0]
+        )
+        assert_that(len(times)).is_zero()

--- a/opening_hours/utils/opening_hours_client.py
+++ b/opening_hours/utils/opening_hours_client.py
@@ -81,6 +81,12 @@ class OpeningHours:
             )
         )
 
+        # If the length of opening is zero, return None for helping the UI.
+        if not end_time_on_next_day and (end_time - start_time) == datetime.timedelta(
+            seconds=0
+        ):
+            return None
+
         return OpeningHours(
             start_time=start_time.astimezone(TIMEZONE),
             end_time=end_time.astimezone(TIMEZONE),
@@ -156,7 +162,8 @@ class OpeningHoursClient:
                 opening_times = OpeningHours.get_opening_hours_class_from_time_element(
                     time, date, timezone
                 )
-                opening_hours.append(opening_times)
+                if opening_times:
+                    opening_hours.append(opening_times)
 
             self.opening_hours[res_id][date].extend(opening_hours)
 


### PR DESCRIPTION
When determining opening hours we want to check the length of the opening time not to be zero. If zero not include the time for convenience.

Refs TILA-2378
