### PR TITLE
TILA-2377 | Make hauki reader handle unknown resource states

### DIFF
--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -51,6 +51,13 @@ class State(Enum):
             cls.WITH_KEY_AND_RESERVATION,
         ]
 
+    @classmethod
+    def get(cls, state):
+        try:
+            return State(state)
+        except ValueError:
+            return State.UNDEFINED
+
 
 class Weekday(Enum):
     MONDAY = 1

--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -14,7 +14,7 @@ class State(Enum):
     ENTER_ONLY = "enter_only"
     EXIT_ONLY = "exit_only"
     WEATHER_PERMITTING = "weather_permitting"
-    NOT_IN_USER = "not_in_use"
+    NOT_IN_USE = "not_in_use"
     MAINTENANCE = "maintenance"
 
     class Labels:

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -126,6 +126,7 @@ def get_opening_hours(
             for time_data_in in opening_hours["times"]:
                 start_time = time_data_in.pop("start_time")
                 end_time = time_data_in.pop("end_time")
+                state = time_data_in.pop("resource_state", None)
 
                 day_data_out["times"].append(
                     TimeElement(
@@ -135,6 +136,7 @@ def get_opening_hours(
                         end_time=datetime.time.fromisoformat(end_time)
                         if end_time
                         else None,
+                        resource_state=State.get(state),
                         **time_data_in,
                     )
                 )

--- a/opening_hours/tests/test_get_opening_hours.py
+++ b/opening_hours/tests/test_get_opening_hours.py
@@ -4,6 +4,7 @@ from unittest import mock
 from assertpy import assert_that
 from django.test import TestCase, override_settings
 
+from opening_hours.enums import State
 from opening_hours.hours import get_opening_hours
 
 
@@ -43,3 +44,27 @@ class GetOpeningHoursTestCase(TestCase):
         assert_that(data[0]["times"]).is_not_empty()
         assert_that(data[0]["times"][0].start_time).is_none()
         assert_that(data[0]["times"][0].end_time).is_none()
+
+    def test_get_opening_hours_with_non_defined_state_is_undefined(self, mock):
+        hours_data = self.get_opening_hours()
+        hours_data["results"][0]["opening_hours"][0]["times"][0][
+            "resource_state"
+        ] = "some_funky_state"
+        mock.return_value = hours_data
+
+        data = get_opening_hours("resource_id", "2020-01-01", "2020-01-01")
+        assert_that(data).is_not_empty()
+        assert_that(data[0]["times"]).is_not_empty()
+        assert_that(data[0]["times"][0].resource_state).is_equal_to(State.UNDEFINED)
+
+    def test_get_opening_hours_with_resource_state_is_none_is_undefined(self, mock):
+        hours_data = self.get_opening_hours()
+        hours_data["results"][0]["opening_hours"][0]["times"][0][
+            "resource_state"
+        ] = None
+        mock.return_value = hours_data
+
+        data = get_opening_hours("resource_id", "2020-01-01", "2020-01-01")
+        assert_that(data).is_not_empty()
+        assert_that(data[0]["times"]).is_not_empty()
+        assert_that(data[0]["times"][0].resource_state).is_equal_to(State.UNDEFINED)


### PR DESCRIPTION
Make hauki reader to be failproof when encountering unknown resource states. Previously it blew up when non-existent state was present.  This makes it default to UNDEFINED status.

Refs TILA-2377