### PR TITLE
TILA-2101 | Make possible to empty RecurringReservation description

### DIFF
--- a/api/graphql/reservations/recurring_reservation_serializers/create_serializers.py
+++ b/api/graphql/reservations/recurring_reservation_serializers/create_serializers.py
@@ -37,7 +37,7 @@ class RecurringReservationCreateSerializer(PrimaryKeySerializer):
     )
 
     name = serializers.CharField(required=False, default="")
-    description = serializers.CharField(required=False, default="")
+    description = serializers.CharField(required=False, default="", allow_blank=True)
     begin_time = serializers.TimeField(
         required=True, help_text="Time when reservations begins."
     )

--- a/api/graphql/tests/test_recurring_reservations/test_recurring_reservation_create.py
+++ b/api/graphql/tests/test_recurring_reservations/test_recurring_reservation_create.py
@@ -281,6 +281,30 @@ class RecurringReservationTestCase(GrapheneTestCaseBase):
         assert_that(recurring.ability_group_id).is_equal_to(self.ability_group.id)
         assert_that(recurring.description).is_equal_to(input_data["description"])
 
+    def test_description_can_be_emptied(self):
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_optional_full_input_data()
+        input_data["description"] = ""
+        response = self.query(self.get_create_query(), input_data=input_data)
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data")
+            .get("createRecurringReservation")
+            .get("recurringReservation")
+            .get("pk")
+        ).is_not_none()
+        pk = (
+            content.get("data")
+            .get("createRecurringReservation")
+            .get("recurringReservation")
+            .get("pk")
+        )
+        recurring = RecurringReservation.objects.get(id=pk)
+
+        assert_that(recurring.description).is_empty()
+
     def test_recurrence_in_days_not_in_allowed_values(self):
         self.client.force_login(self.general_admin)
         input_data = self.get_valid_minimum_input_data()

--- a/api/graphql/tests/test_recurring_reservations/test_recurring_reservation_update.py
+++ b/api/graphql/tests/test_recurring_reservations/test_recurring_reservation_update.py
@@ -175,3 +175,31 @@ class RecurringReservationUpdateTestCase(GrapheneTestCaseBase):
 
         recurring = RecurringReservation.objects.first()
         assert_that(recurring.reservation_unit).is_equal_to(self.reservation_unit)
+
+    def test_description_can_be_emptied(self):
+        self.recurring.description = "Some description"
+        self.recurring.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_input_data()
+        input_data["description"] = ""
+
+        response = self.query(self.get_update_query(), input_data=input_data)
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+        assert_that(
+            content.get("data")
+            .get("updateRecurringReservation")
+            .get("recurringReservation")
+            .get("pk")
+        ).is_not_none()
+        pk = (
+            content.get("data")
+            .get("updateRecurringReservation")
+            .get("recurringReservation")
+            .get("pk")
+        )
+        recurring = RecurringReservation.objects.get(id=pk)
+
+        assert_that(recurring.description).is_empty()


### PR DESCRIPTION
## Change log
- Make possible to empty the `RecurringReservation` description through the gql api mutations



Refs TILA-2101