### PR TITLE
TILA-2162 | Reservation deny validation rule additions

### DIFF
--- a/api/graphql/reservations/reservation_serializers/deny_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/deny_serializers.py
@@ -46,7 +46,7 @@ class ReservationDenySerializer(PrimaryKeySerializer):
         validated_data = super().validated_data
         validated_data["state"] = STATE_CHOICES.DENIED
         validated_data["handled_at"] = datetime.datetime.now(tz=DEFAULT_TIMEZONE)
-        # For now we wan't to copy the handling details to working memo. In future perhaps not.
+        # For now, we want to copy the handling details to working memo. In future perhaps not.
         validated_data["working_memo"] = validated_data["handling_details"]
         return validated_data
 

--- a/api/graphql/reservations/reservation_serializers/deny_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/deny_serializers.py
@@ -63,9 +63,21 @@ class ReservationDenySerializer(PrimaryKeySerializer):
                 f"Only reservations with state as {', '.join(allowed_states)} can be denied.",
                 ValidationErrorCodes.DENYING_NOT_ALLOWED,
             )
+
+        self.check_reservation_has_not_ended()
+
         data = super().validate(data)
 
         return data
+
+    def check_reservation_has_not_ended(self):
+        now = datetime.datetime.now(tz=DEFAULT_TIMEZONE)
+
+        if self.instance.end < now:
+            raise ValidationErrorWithCode(
+                "Reservation cannot be denied when the reservation has ended.",
+                ValidationErrorCodes.DENYING_NOT_ALLOWED,
+            )
 
     def save(self, **kwargs):
         instance = super().save(**kwargs)

--- a/api/graphql/tests/test_reservations/test_reservation_deny.py
+++ b/api/graphql/tests/test_reservations/test_reservation_deny.py
@@ -10,7 +10,7 @@ from django.utils.timezone import get_default_timezone
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
 from email_notification.models import EmailType
 from email_notification.tests.factories import EmailTemplateFactory
-from reservations.models import STATE_CHOICES
+from reservations.models import STATE_CHOICES, ReservationType
 from reservations.tests.factories import (
     ReservationDenyReasonFactory,
     ReservationFactory,
@@ -36,6 +36,7 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
             state=STATE_CHOICES.REQUIRES_HANDLING,
             user=self.regular_joe,
             reservee_email="email@reservee",
+            type=ReservationType.NORMAL,
         )
         self.reason = ReservationDenyReasonFactory(
             reason_fi="syy", reason_en="reason", reason_sv="resonera"
@@ -87,6 +88,32 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         assert_that(len(mail.outbox)).is_equal_to(1)
         assert_that(mail.outbox[0].subject).is_equal_to("denied")
 
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_deny_success_when_admin_and_state_is_confirmed(self):
+        self.reservation.state = STATE_CHOICES.CONFIRMED
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
+        response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        deny_data = content.get("data").get("denyReservation")
+        assert_that(deny_data.get("errors")).is_none()
+        assert_that(deny_data.get("state")).is_equal_to(STATE_CHOICES.DENIED.upper())
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
+        assert_that(self.reservation.handling_details).is_equal_to("no can do")
+        assert_that(self.reservation.handled_at).is_not_none()
+        assert_that(len(mail.outbox)).is_equal_to(1)
+        assert_that(mail.outbox[0].subject).is_equal_to("denied")
+
     def test_cant_deny_if_regular_user(self):
         self.client.force_login(self.regular_joe)
         input_data = self.get_valid_deny_data()
@@ -100,7 +127,7 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         self.reservation.refresh_from_db()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
 
-    def test_cant_deny_if_status_not_requires_handling(self):
+    def test_cant_deny_if_status_not_allowed_states(self):
         self.client.force_login(self.general_admin)
         input_data = self.get_valid_deny_data()
         self.reservation.state = STATE_CHOICES.CREATED
@@ -111,7 +138,7 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
 
         assert_that(content.get("errors")).is_not_none()
         assert_that(content.get("errors")[0]["message"]).is_equal_to(
-            "Only reservations with state as REQUIRES_HANDLING can be denied."
+            "Only reservations with state as requires_handling, confirmed can be denied."
         )
         assert_that(content.get("errors")[0]["extensions"]["error_code"]).is_equal_to(
             "DENYING_NOT_ALLOWED"
@@ -173,3 +200,72 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         assert_that(self.reservation.handled_at).is_not_none()
         assert_that(len(mail.outbox)).is_equal_to(1)
         assert_that(mail.outbox[0].subject).is_equal_to("denied")
+
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_denying_staff_type_reservation_does_not_send_email(self):
+        self.reservation.type = ReservationType.STAFF
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        input_data["handlingDetails"] = ""
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+        response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        deny_data = content.get("data").get("denyReservation")
+        assert_that(deny_data.get("errors")).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
+        assert_that(len(mail.outbox)).is_equal_to(0)
+
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_denying_behalf_type_reservation_does_not_send_email(self):
+        self.reservation.type = ReservationType.BEHALF
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        input_data["handlingDetails"] = ""
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+        response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        deny_data = content.get("data").get("denyReservation")
+        assert_that(deny_data.get("errors")).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
+        assert_that(len(mail.outbox)).is_equal_to(0)
+
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=True,
+        EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    )
+    def test_denying_blocked_type_reservation_does_not_send_email(self):
+        self.reservation.type = ReservationType.BLOCKED
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        input_data["handlingDetails"] = ""
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+        response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        deny_data = content.get("data").get("denyReservation")
+        assert_that(deny_data.get("errors")).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
+        assert_that(len(mail.outbox)).is_equal_to(0)

--- a/api/graphql/tests/test_reservations/test_reservation_deny.py
+++ b/api/graphql/tests/test_reservations/test_reservation_deny.py
@@ -269,3 +269,46 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         self.reservation.refresh_from_db()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
         assert_that(len(mail.outbox)).is_equal_to(0)
+
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=False,
+    )
+    def test_can_deny_when_reservation_started_but_not_ended(self):
+        self.reservation.type = ReservationType.BLOCKED
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+
+        with freezegun.freeze_time("2021-10-12T13:30:00Z"):
+            response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        deny_data = content.get("data").get("denyReservation")
+        assert_that(deny_data.get("errors")).is_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
+
+    @override_settings(
+        CELERY_TASK_ALWAYS_EAGER=True,
+        SEND_RESERVATION_NOTIFICATION_EMAILS=False,
+    )
+    def test_cannot_deny_when_reservation_ended(self):
+        self.reservation.type = ReservationType.BLOCKED
+        self.reservation.save()
+
+        self.client.force_login(self.general_admin)
+        input_data = self.get_valid_deny_data()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+
+        with freezegun.freeze_time("2021-10-12T15:30:00Z"):
+            response = self.query(self.get_handle_query(), input_data=input_data)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_not_none()
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
+        assert_that(self.reservation.handling_details).is_empty()


### PR DESCRIPTION
## Change log
- Makes possible to deny also Reservations with state of CONFIRMED
- Makes impossible to deny reservation that end time has passed
- Send emails only when Reservation type is NORMAL
