### PR TITLE
TILA-2410 | Separate reservationUnitImage gql to own endpoint

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -49,6 +49,7 @@ from api.graphql.reservation_units.reservation_unit_types import (
     ReservationUnitByPkType,
     ReservationUnitCancellationRuleType,
     ReservationUnitHaukiUrlType,
+    ReservationUnitImageType,
     ReservationUnitType,
     ReservationUnitTypeType,
     TaxPercentageType,
@@ -132,7 +133,12 @@ from permissions.helpers import (
     get_service_sectors_where_can_view_reservations,
     get_units_where_can_view_reservations,
 )
-from reservation_units.models import Equipment, EquipmentCategory, ReservationUnit
+from reservation_units.models import (
+    Equipment,
+    EquipmentCategory,
+    ReservationUnit,
+    ReservationUnitImage,
+)
 from reservations.models import Reservation
 from resources.models import Resource
 from spaces.models import Space, Unit
@@ -560,10 +566,6 @@ class Mutation(graphene.ObjectType):
     create_reservation_unit = ReservationUnitCreateMutation.Field()
     update_reservation_unit = ReservationUnitUpdateMutation.Field()
 
-    create_reservation_unit_image = ReservationUnitImageCreateMutation.Field()
-    update_reservation_unit_image = ReservationUnitImageUpdateMutation.Field()
-    delete_reservation_unit_image = ReservationUnitImageDeleteMutation.Field()
-
     create_purpose = PurposeCreateMutation.Field()
     update_purpose = PurposeUpdateMutation.Field()
 
@@ -590,4 +592,21 @@ class Mutation(graphene.ObjectType):
     refresh_order = RefreshOrderMutation.Field()
 
 
+class ReservationUnitImageMutations(graphene.ObjectType):
+    create_reservation_unit_image = ReservationUnitImageCreateMutation.Field()
+    update_reservation_unit_image = ReservationUnitImageUpdateMutation.Field()
+    delete_reservation_unit_image = ReservationUnitImageDeleteMutation.Field()
+
+
+class ReservationUnitImageQuery(graphene.ObjectType):
+    reservation_unit_image = Field(ReservationUnitImageType, pk=graphene.Int())
+
+    @check_resolver_permission(ReservationUnitPermission)
+    def resolve_reservation_unit_image(self, info, **kwargs):
+        return get_object_or_404(ReservationUnitImage, pk=kwargs.get("pk"))
+
+
 schema = graphene.Schema(query=Query, mutation=Mutation)
+file_upload_schema = graphene.Schema(
+    query=ReservationUnitImageQuery, mutation=ReservationUnitImageMutations
+)

--- a/api/graphql/tests/test_reservation_unit_image.py
+++ b/api/graphql/tests/test_reservation_unit_image.py
@@ -16,13 +16,13 @@ from reservation_units.tests.factories import (
     ReservationUnitImageFactory,
 )
 
-DEFAULT_GRAPHQL_URL = "/graphql/"
-
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageCreateTestCase(
     GrapheneTestCaseBase, GraphQLFileUploadTestCase
 ):
+    GRAPHQL_URL = "/graphql/images/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -60,6 +60,7 @@ class ReservationUnitImageCreateTestCase(
                 }
             },
             client=self.client,
+            graphql_url=self.GRAPHQL_URL,
         )
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
@@ -96,6 +97,7 @@ class ReservationUnitImageCreateTestCase(
                 }
             },
             client=self.client,
+            graphql_url=self.GRAPHQL_URL,
         )
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
@@ -119,6 +121,7 @@ class ReservationUnitImageCreateTestCase(
                 }
             },
             client=self.client,
+            graphql_url=self.GRAPHQL_URL,
         )
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
@@ -131,6 +134,8 @@ class ReservationUnitImageCreateTestCase(
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageUpdateTestCase(GrapheneTestCaseBase):
+    GRAPHQL_URL = "/graphql/images/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()
@@ -185,6 +190,8 @@ class ReservationUnitImageUpdateTestCase(GrapheneTestCaseBase):
 
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageDeleteGraphQLTestCase(GrapheneTestCaseBase):
+    GRAPHQL_URL = "/graphql/images/"
+
     @classmethod
     def setUpTestData(cls):
         super().setUpTestData()

--- a/api/urls.py
+++ b/api/urls.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.urls import path
 from django.views.decorators.csrf import csrf_exempt
+from graphene_django.views import GraphQLView
 from graphene_file_upload.django import FileUploadGraphQLView
 from rest_framework import routers
 
@@ -23,6 +24,7 @@ from .applications_api.views import (
 from .city_api import CityViewSet
 from .declined_reservation_units_api import DeclinedReservationUnitViewSet
 from .gdpr import TilavarauspalveluGDPRAPIView
+from .graphql.schema import file_upload_schema, schema
 from .hauki_api import OpeningHoursViewSet
 from .ical_api import (
     ApplicationEventIcalViewset,
@@ -132,9 +134,16 @@ router.register(r"parameters/city", CityViewSet, "city")
 router.register(r"webhook/payment", WebhookPaymentViewSet, "payment")
 router.register(r"webhook/order", WebhookOrderViewSet, "order")
 router.register(r"webhook/refund", WebhookRefundViewSet, "refund")
+
 urlpatterns = [
+    path("graphql/", GraphQLView.as_view(schema=schema, graphiql=settings.DEBUG)),
     path(
-        "graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=settings.DEBUG))
+        "graphql/images/",
+        csrf_exempt(
+            FileUploadGraphQLView.as_view(
+                schema=file_upload_schema, graphiql=settings.DEBUG
+            )
+        ),
     ),
     path(
         "gdpr/v1/user/<str:uuid>/",


### PR DESCRIPTION
This because it needs to support image upload and that's going to have the csrf_exempt.

Refs TILA-2410

