### PR TITLE
TILA-2421: Split prune tasks

### DIFF
--- a/reservations/pruning.py
+++ b/reservations/pruning.py
@@ -21,7 +21,7 @@ def prune_inactive_reservations(older_than_minutes: int) -> None:
     logger.info(f"Pruned {num_deleted} inactive reservations.")
 
 
-def prune_reservation_with_inactive_payments(older_than_minutes: int) -> None:
+def prune_reservations_with_inactive_payment(older_than_minutes: int) -> None:
     """
     Finds reservations with order that was created given minutes ago and
     are expired or cancelled, and deletes them

--- a/reservations/tasks.py
+++ b/reservations/tasks.py
@@ -27,6 +27,10 @@ REMOVE_RECURRINGS_OLDER_THAN_DAYS = 1
 @app.task(name="prune_reservations")
 def _prune_reservations() -> None:
     prune_inactive_reservations(PRUNE_OLDER_THAN_MINUTES)
+
+
+@app.task(name="prune_reservations_with_inactive_payment")
+def prune_reservations_with_inactive_payment_task() -> None:
     prune_reservations_with_inactive_payment(PRUNE_WITH_ORDERS_OLDER_THAN_MINUTES)
 
 

--- a/reservations/tasks.py
+++ b/reservations/tasks.py
@@ -8,7 +8,7 @@ from .pruning import (
     prune_inactive_reservations,
     prune_recurring_reservations,
     prune_reservation_statistics,
-    prune_reservation_with_inactive_payments,
+    prune_reservations_with_inactive_payment,
 )
 
 # The pruning task will be run periodically at every PRUNE_INTERVAL_SECONDS
@@ -27,7 +27,7 @@ REMOVE_RECURRINGS_OLDER_THAN_DAYS = 1
 @app.task(name="prune_reservations")
 def _prune_reservations() -> None:
     prune_inactive_reservations(PRUNE_OLDER_THAN_MINUTES)
-    prune_reservation_with_inactive_payments(PRUNE_WITH_ORDERS_OLDER_THAN_MINUTES)
+    prune_reservations_with_inactive_payment(PRUNE_WITH_ORDERS_OLDER_THAN_MINUTES)
 
 
 @app.task(name="update_expired_orders")

--- a/reservations/tests/test_pruning.py
+++ b/reservations/tests/test_pruning.py
@@ -20,7 +20,7 @@ from ..pruning import (
     prune_inactive_reservations,
     prune_recurring_reservations,
     prune_reservation_statistics,
-    prune_reservation_with_inactive_payments,
+    prune_reservations_with_inactive_payment,
 )
 from .factories import RecurringReservationFactory, ReservationFactory
 
@@ -110,7 +110,7 @@ class PruneReservationsWithInactivePaymentsTestCase(TestCase):
             )
 
         with freeze_time(now):
-            prune_reservation_with_inactive_payments(older_than_minutes=5)
+            prune_reservations_with_inactive_payment(older_than_minutes=5)
             assert_that(Reservation.objects.exists()).is_false()
 
     def test_prune_does_not_delete_reservations_with_fresh_payments(self):
@@ -149,7 +149,7 @@ class PruneReservationsWithInactivePaymentsTestCase(TestCase):
             )
 
         with freeze_time(now):
-            prune_reservation_with_inactive_payments(older_than_minutes=5)
+            prune_reservations_with_inactive_payment(older_than_minutes=5)
             assert_that(Reservation.objects.count()).is_equal_to(2)
 
     def test_prune_does_not_delete_reservations_in_other_states(self):
@@ -176,7 +176,7 @@ class PruneReservationsWithInactivePaymentsTestCase(TestCase):
                 )
 
             with freeze_time(now):
-                prune_reservation_with_inactive_payments(older_than_minutes=5)
+                prune_reservations_with_inactive_payment(older_than_minutes=5)
                 assert_that(Reservation.objects.count()).is_equal_to(1)
                 Reservation.objects.all().delete()
 
@@ -191,7 +191,7 @@ class PruneReservationsWithInactivePaymentsTestCase(TestCase):
             PaymentOrderFactory(reservation=reservation, status=OrderStatus.CANCELLED)
 
         with freeze_time(now):
-            prune_reservation_with_inactive_payments(older_than_minutes=5)
+            prune_reservations_with_inactive_payment(older_than_minutes=5)
             assert_that(Reservation.objects.exists()).is_true()
 
     def test_prune_does_not_delete_reservations_without_order(self):
@@ -199,7 +199,7 @@ class PruneReservationsWithInactivePaymentsTestCase(TestCase):
             name="do not delete_me", state=STATE_CHOICES.WAITING_FOR_PAYMENT
         )
 
-        prune_reservation_with_inactive_payments(older_than_minutes=5)
+        prune_reservations_with_inactive_payment(older_than_minutes=5)
         assert_that(Reservation.objects.exists()).is_true()
 
 


### PR DESCRIPTION
## Change log
- Renamed `prune_reservation_with_inactive_payments` to `prune_reservations_with_inactive_payment`
- Moved `prune_reservations_with_inactive_payment` into a separate task

## Deployment reminder
- New task must be scheduled