### PR TITLE
TILA-2428: Fix update_expired_orders

### DIFF
--- a/merchants/pruning.py
+++ b/merchants/pruning.py
@@ -28,10 +28,10 @@ def update_expired_orders(older_than_minutes: int) -> None:
     for order in expired_orders:
         try:
             result = get_payment(order.remote_id, settings.VERKKOKAUPPA_NAMESPACE)
-            if result.status == WebShopPaymentStatus.CANCELLED:
+            if result and result.status == WebShopPaymentStatus.CANCELLED:
                 order.status = OrderStatus.CANCELLED
 
-            elif result.status == WebShopPaymentStatus.PAID_ONLINE:
+            elif result and result.status == WebShopPaymentStatus.PAID_ONLINE:
                 order.status = OrderStatus.PAID
             else:
                 order.status = OrderStatus.EXPIRED


### PR DESCRIPTION
## Change log
- Added checks for case where payment does not exist
- Unit test that catches the old problem and confirms the fix

## Other notes
It did not handle the case where payment does not exist in Verkkokauppa. I added the checks and if status cannot be checked, it is treated as expired.

## Deployment reminder
- No changes required