### PR TITLE
TILA-2464: Fix order creating issue with wrong datetime format

### DIFF
--- a/merchants/verkkokauppa/order/test/test_create_order_params.py
+++ b/merchants/verkkokauppa/order/test/test_create_order_params.py
@@ -59,7 +59,7 @@ class CreateOrderParamsToJsonTestCase(TestCase):
             (
                 datetime.now(tz=get_default_timezone())
                 + timedelta(minutes=settings.VERKKOKAUPPA_ORDER_EXPIRATION_MINUTES)
-            ).isoformat()
+            ).strftime("%Y-%m-%dT%H:%M:%S")
         )
         assert_that(json["items"]).is_length(1)
         assert_that(json["items"][0]["productId"]).is_equal_to(

--- a/merchants/verkkokauppa/order/types.py
+++ b/merchants/verkkokauppa/order/types.py
@@ -192,7 +192,10 @@ class CreateOrderParams:
             "namespace": self.namespace,
             "user": str(self.user),
             "language": self.language,
-            "lastValidPurchaseDateTime": self.last_valid_purchase_datetime.isoformat(),
+            # Order Experience API does not support standard ISO 8601 format with UTC offset
+            "lastValidPurchaseDateTime": self.last_valid_purchase_datetime.strftime(
+                "%Y-%m-%dT%H:%M:%S"
+            ),
             "items": [
                 {
                     "productId": str(item.product_id),

--- a/merchants/verkkokauppa/tests/test_order_types.py
+++ b/merchants/verkkokauppa/tests/test_order_types.py
@@ -130,7 +130,7 @@ class OrderTypesTestCase(TestCase):
                 "namespace": "test-namespace",
                 "user": "test-user",
                 "language": "fi",
-                "lastValidPurchaseDateTime": "2022-11-24T12:00:00+00:00",
+                "lastValidPurchaseDateTime": "2022-11-24T12:00:00",
                 "priceNet": "100.0",
                 "priceVat": "24.0",
                 "priceTotal": "124.0",


### PR DESCRIPTION
## Change log
- Replaced `isoformat()` with `strftime()` and custom format

## Other notes
Order Experience API does not support standard ISO 8601 format with UTC offset. That is why we have to manually define a custom format. This is a bit risky since Verkkokauppa assumes that this date has to be in Europe/Helsinki timezone. Any change in timezones can cause problems.

## Deployment reminder
- No changes required