### PR TITLE
TILA-2442 | ReservationUnits query performance configurations

### DIFF
--- a/utils/query_performance.py
+++ b/utils/query_performance.py
@@ -117,6 +117,11 @@ class QueryPerformanceOptimizerMixin:
                             children=child.selection_set.selections,
                             **optimization_value
                         )
+
+                        # If no child prefetches, just prefetch the base model
+                        if not prefetch:
+                            prefetch = optimization_value.get("field_name")
+
                         prefetches.append(prefetch)
 
                     # CASE: No child fields, simply add field name to prefetch list to fetch base model


### PR DESCRIPTION
## Change log
- Fix bug in `QueryPerformanceOptimizerMixin` class 
   - no prefetches were executed if used advanced optimization and the field did not exist in actual query.
- Fix Correct field_name for querying `reservationUnits` (was `reservationUnit`)
- Adds more query optimizations to reservationUnits query


Refs TILA-2442

## Other notes
There might be some things yet to do with QueryPerformanceOptimizer. Will see.