### PR TITLE
TILA-2471 | Staff can deny self created reservations

### DIFF
--- a/api/graphql/reservations/reservation_mutations.py
+++ b/api/graphql/reservations/reservation_mutations.py
@@ -29,6 +29,7 @@ from merchants.verkkokauppa.order.exceptions import CancelOrderError
 from merchants.verkkokauppa.order.requests import cancel_order
 from permissions.api_permissions.graphene_permissions import (
     ReservationCommentPermission,
+    ReservationDenyPermission,
     ReservationHandlingPermission,
     ReservationPermission,
     ReservationStaffCreatePermission,
@@ -88,7 +89,7 @@ class ReservationCancellationMutation(AuthSerializerMutation, SerializerMutation
 
 
 class ReservationDenyMutation(AuthSerializerMutation, SerializerMutation):
-    permission_classes = (ReservationHandlingPermission,)
+    permission_classes = (ReservationDenyPermission,)
 
     class Meta:
         lookup_field = "pk"

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -358,6 +358,20 @@ class ReservationHandlingPermission(BasePermission):
         return False
 
 
+class ReservationDenyPermission(BasePermission):
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        pk = input.get("pk")
+        if pk:
+            reservation = get_object_or_404(Reservation, pk=pk)
+            user = info.context.user
+            return can_handle_reservation(user, reservation) or (
+                can_create_staff_reservation(user, reservation.reservation_unit.all())
+                and reservation.user == user
+            )
+        return False
+
+
 class ReservationCommentPermission(BasePermission):
     @classmethod
     def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:


### PR DESCRIPTION

## Change log
- Adds new permission class  `ReservationDenyPermission` and use in deny mutation.
  - permission checks for staff user can either handle reservations or can create staff AND is self created one.

## Other notes
There should be possible for staff members to deny self created (staff created reservations).
Makes new permission for denying based on the
ReservationHandlingPermission called ReservationDenyPermission and use in deny mutation.



Refs TILA-2471



