### PR TITLE
TILA-2447 | Don't overwrite working_memo with handling details

### DIFF
--- a/api/graphql/reservations/reservation_serializers/approve_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/approve_serializers.py
@@ -38,8 +38,7 @@ class ReservationApproveSerializer(PrimaryKeySerializer):
         validated_data = super().validated_data
         validated_data["state"] = STATE_CHOICES.CONFIRMED
         validated_data["handled_at"] = datetime.datetime.now(tz=DEFAULT_TIMEZONE)
-        # For now we wan't to copy the handling details to working memo. In future perhaps not.
-        validated_data["working_memo"] = validated_data["handling_details"]
+
         return validated_data
 
     def validate(self, data):

--- a/api/graphql/reservations/reservation_serializers/deny_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/deny_serializers.py
@@ -51,8 +51,7 @@ class ReservationDenySerializer(PrimaryKeySerializer):
         validated_data = super().validated_data
         validated_data["state"] = STATE_CHOICES.DENIED
         validated_data["handled_at"] = datetime.datetime.now(tz=DEFAULT_TIMEZONE)
-        # For now, we want to copy the handling details to working memo. In future perhaps not.
-        validated_data["working_memo"] = validated_data["handling_details"]
+
         return validated_data
 
     def validate(self, data):

--- a/api/graphql/tests/test_reservations/test_reservation_approve.py
+++ b/api/graphql/tests/test_reservations/test_reservation_approve.py
@@ -209,7 +209,9 @@ class ReservationApproveTestCase(ReservationTestCaseBase):
         CELERY_TASK_ALWAYS_EAGER=True,
         SEND_RESERVATION_NOTIFICATION_EMAILS=False,
     )
-    def test_handling_details_saves_to_working_memo_also(self):
+    def test_handling_details_does_not_save_to_working_memo(self):
+        """Previously we had a feature which copied to handling details to working memo."""
+
         self.client.force_login(self.general_admin)
         input_data = self.get_valid_approve_data()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.REQUIRES_HANDLING)
@@ -219,7 +221,7 @@ class ReservationApproveTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.reservation.refresh_from_db()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
-        assert_that(self.reservation.handling_details).is_equal_to(
+        assert_that(self.reservation.handling_details).is_not_equal_to(
             self.reservation.working_memo
         )
 

--- a/api/graphql/tests/test_reservations/test_reservation_deny.py
+++ b/api/graphql/tests/test_reservations/test_reservation_deny.py
@@ -164,7 +164,7 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         CELERY_TASK_ALWAYS_EAGER=True,
         SEND_RESERVATION_NOTIFICATION_EMAILS=False,
     )
-    def test_handling_details_saves_to_working_memo_also(self):
+    def test_handling_details_does_not_save_to_working_memo(self):
         self.client.force_login(self.general_admin)
         input_data = self.get_valid_deny_data()
         response = self.query(self.get_handle_query(), input_data=input_data)
@@ -173,7 +173,7 @@ class ReservationDenyTestCase(ReservationTestCaseBase):
         assert_that(content.get("errors")).is_none()
         self.reservation.refresh_from_db()
         assert_that(self.reservation.state).is_equal_to(STATE_CHOICES.DENIED)
-        assert_that(self.reservation.handling_details).is_equal_to(
+        assert_that(self.reservation.handling_details).is_not_equal_to(
             self.reservation.working_memo
         )
 


### PR DESCRIPTION
## Change log
- Remove overwrite of working memo with handling_details in approve serializer and in deny serializer

## Other notes
The working memo was originally used as the handling details but there has been separation with handling details and working memo some time ago and the copying of the handling details value to working_memo is needed to remove now.


Refs TILA-2447