### PR TITLE
Don't prefill data from profile in reservation update

### DIFF
--- a/api/graphql/reservations/reservation_serializers/create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/create_serializers.py
@@ -168,7 +168,7 @@ class ReservationCreateSerializer(
         self.fields["num_persons"].required = False
         self.fields["purpose_pk"].required = False
 
-    def validate(self, data):
+    def validate(self, data, prefill_from_profile=True):
         begin = data.get("begin", getattr(self.instance, "begin", None))
         end = data.get("end", getattr(self.instance, "end", None))
         begin = begin.astimezone(DEFAULT_TIMEZONE)
@@ -238,7 +238,7 @@ class ReservationCreateSerializer(
         reservation_unit_ids = list(map(lambda x: x.pk, reservation_units))
         self.check_reservation_type(user, reservation_unit_ids, reservation_type)
 
-        if settings.PREFILL_RESERVATION_WITH_PROFILE_DATA:
+        if settings.PREFILL_RESERVATION_WITH_PROFILE_DATA and prefill_from_profile:
             data = self._prefill_from_from_profile(user, data)
 
         return data

--- a/api/graphql/reservations/reservation_serializers/update_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/update_serializers.py
@@ -39,7 +39,7 @@ class ReservationUpdateSerializer(
         self.fields["reservation_unit_pks"].required = False
         self.fields["purpose_pk"].required = False
 
-    def validate(self, data):
+    def validate(self, data, prefill_from_profile=False):
         if self.instance.state not in (STATE_CHOICES.CREATED,):
             raise ValidationErrorWithCode(
                 "Reservation cannot be changed anymore.",
@@ -53,7 +53,7 @@ class ReservationUpdateSerializer(
                 ValidationErrorCodes.STATE_CHANGE_NOT_ALLOWED,
             )
 
-        data = super().validate(data)
+        data = super().validate(data, prefill_from_profile)
         data["state"] = new_state
 
         reservation_units = data.get(


### PR DESCRIPTION
## Change log
- Disable profile data fetch in reservation update serializer

## Other notes
ReservationUpdateSerializer is subclass of reservationCreate so the prefill logic is present also there. This isn't what we wan't. This disables the data fetching from profile in reservation update serializer.

