### PR TITLE
TILA-2510 | Generate image urls on reservation unit image save

### DIFF
--- a/api/graphql/tests/test_reservation_unit_image.py
+++ b/api/graphql/tests/test_reservation_unit_image.py
@@ -3,6 +3,7 @@ import json
 from assertpy import assert_that
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
 from graphene_file_upload.django.testing import (
     GraphQLFileUploadTestCase,
     file_graphql_query,
@@ -18,6 +19,7 @@ from reservation_units.tests.factories import (
 DEFAULT_GRAPHQL_URL = "/graphql/"
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageCreateTestCase(
     GrapheneTestCaseBase, GraphQLFileUploadTestCase
 ):
@@ -127,6 +129,7 @@ class ReservationUnitImageCreateTestCase(
         assert_that(img).is_none()
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageUpdateTestCase(GrapheneTestCaseBase):
     @classmethod
     def setUpTestData(cls):
@@ -180,6 +183,7 @@ class ReservationUnitImageUpdateTestCase(GrapheneTestCaseBase):
         assert_that(content.get("errors")).is_not_none()
 
 
+@override_settings(CELERY_TASK_ALWAYS_EAGER=True)
 class ReservationUnitImageDeleteGraphQLTestCase(GrapheneTestCaseBase):
     @classmethod
     def setUpTestData(cls):

--- a/reservation_units/migrations/0084_reservation_unit_image_url_fields.py
+++ b/reservation_units/migrations/0084_reservation_unit_image_url_fields.py
@@ -11,7 +11,7 @@ def update_urls(apps, schema_editor):
             image.large_url = image.image["large"].url
             image.medium_url = image.image["medium"].url
             image.small_url = image.image["small"].url
-            image.save()
+            image.save(update_urls=False)
         except InvalidImageFormatError:
             pass
 

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -12,7 +12,10 @@ from easy_thumbnails.fields import ThumbnailerImageField
 
 from merchants.models import PaymentAccounting, PaymentMerchant, PaymentProduct
 from reservation_units.enums import ReservationState, ReservationUnitState
-from reservation_units.tasks import refresh_reservation_unit_product_mapping
+from reservation_units.tasks import (
+    refresh_reservation_unit_product_mapping,
+    update_urls,
+)
 from resources.models import Resource
 from services.models import Service
 from spaces.models import Space, Unit
@@ -789,6 +792,27 @@ class ReservationUnitImage(models.Model):
         return "{} ({})".format(
             self.reservation_unit.name, self.get_image_type_display()
         )
+
+    def save(
+        self,
+        force_insert=False,
+        force_update=False,
+        using=None,
+        update_fields=None,
+        update_urls=True,
+    ):
+        super().save(
+            force_insert=force_insert,
+            force_update=force_update,
+            using=using,
+            update_fields=update_fields,
+        )
+
+        if update_urls:
+            self.update_image_urls()
+
+    def update_image_urls(self):
+        update_urls.delay(self.pk)
 
 
 class Purpose(models.Model):

--- a/reservation_units/tasks.py
+++ b/reservation_units/tasks.py
@@ -118,15 +118,20 @@ def refresh_reservation_unit_accounting(reservation_unit_pk) -> None:
 
 
 @app.task(name="update_reservation_unit_image_urls")
-def update_urls():
+def update_urls(pk: int = None):
     from .models import ReservationUnitImage
 
-    for image in ReservationUnitImage.objects.all():
+    images = ReservationUnitImage.objects.filter(image__isnull=False)
+
+    if pk:
+        images = images.filter(pk=pk)
+
+    for image in images:
         try:
             image.large_url = image.image["large"].url
             image.medium_url = image.image["medium"].url
             image.small_url = image.image["small"].url
-            image.save()
+            image.save(update_urls=False)
 
         except InvalidImageFormatError as err:
             capture_exception(err)

--- a/reservation_units/tests/test_reservation_unit_image_save.py
+++ b/reservation_units/tests/test_reservation_unit_image_save.py
@@ -1,0 +1,22 @@
+from unittest import mock
+
+from assertpy import assert_that
+from django.test import TestCase, override_settings
+
+from reservation_units.models import ReservationUnitImage
+from reservation_units.tests.factories import ReservationUnitFactory
+
+
+class ReservationUnitImageSaveTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.res_unit = ReservationUnitFactory()
+
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    @mock.patch("reservation_units.models.update_urls")
+    def test_update_urls_called_when_save(self, mock):
+        image = ReservationUnitImage(reservation_unit=self.res_unit, image_type="main")
+
+        image.save()
+
+        assert_that(mock.delay.call_count).is_equal_to(1)


### PR DESCRIPTION

## Change log
- Generates `ReservationUnitImage`'s urls when its saved
- Changes the `update_url` task to take optional parameter for giving single res unit image

Refs TILA-2510
