### PR TITLE
TILA-2485: Add reservation number and language support

### DIFF
--- a/merchants/verkkokauppa/exceptions.py
+++ b/merchants/verkkokauppa/exceptions.py
@@ -7,3 +7,7 @@ class VerkkokauppaConfigurationError(VerkkokauppaError):
         super().__init__(
             "One or more Verkkokauppa setting is missing. Check environment variables with VERKKOKAUPPA_* prefix"
         )
+
+
+class UnsupportedMetaKey(VerkkokauppaError):
+    pass


### PR DESCRIPTION
## Change log
- Add reservation number to webshop order meta fields
- Add language support to meta field labels

## Other notes
The implementation might still change because I'm not sure if language should come from the reservation user or from `reservee_language` field

## Deployment reminder
- No changes required