### PR TITLE
TILA-2508 | Don't include DRAFT, CANCELLED or EXPIRED in applicationsCount

### DIFF
--- a/api/graphql/application_rounds/application_round_types.py
+++ b/api/graphql/application_rounds/application_round_types.py
@@ -151,7 +151,11 @@ class ApplicationRoundType(AuthNode, PrimaryKeyObjectType):
 
     def resolve_applications_count(self, info: graphene.ResolveInfo):
         applications_count = self.applications.exclude(
-            cached_latest_status=ApplicationStatus.DRAFT
+            cached_latest_status__in=[
+                ApplicationStatus.DRAFT,
+                ApplicationStatus.CANCELLED,
+                ApplicationStatus.EXPIRED,
+            ]
         ).count()
 
         return applications_count

--- a/api/graphql/tests/test_application_rounds/snapshots/snap_test_application_round_query.py
+++ b/api/graphql/tests/test_application_rounds/snapshots/snap_test_application_round_query.py
@@ -7,7 +7,37 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['ApplicationRoundQueryTestCase::test_applications_count_does_not_include_cancelled_applications 1'] = {
+    'data': {
+        'applicationRounds': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationsCount': 1
+                    }
+                }
+            ],
+            'totalCount': 1
+        }
+    }
+}
+
 snapshots['ApplicationRoundQueryTestCase::test_applications_count_does_not_include_draft_applications 1'] = {
+    'data': {
+        'applicationRounds': {
+            'edges': [
+                {
+                    'node': {
+                        'applicationsCount': 1
+                    }
+                }
+            ],
+            'totalCount': 1
+        }
+    }
+}
+
+snapshots['ApplicationRoundQueryTestCase::test_applications_count_does_not_include_expired_applications 1'] = {
     'data': {
         'applicationRounds': {
             'edges': [

--- a/api/graphql/tests/test_application_rounds/test_application_round_query.py
+++ b/api/graphql/tests/test_application_rounds/test_application_round_query.py
@@ -144,6 +144,56 @@ class ApplicationRoundQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase)
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 
+    def test_applications_count_does_not_include_expired_applications(self):
+        application = ApplicationFactory(application_round=self.application_round)
+        ApplicationStatus(application=application, status=ApplicationStatus.EXPIRED)
+
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(
+            """
+            query {
+                applicationRounds {
+                    totalCount
+                    edges {
+                        node {
+                            applicationsCount
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
+    def test_applications_count_does_not_include_cancelled_applications(self):
+        application = ApplicationFactory(application_round=self.application_round)
+        ApplicationStatus(application=application, status=ApplicationStatus.CANCELLED)
+
+        self.client.force_login(self.regular_joe)
+
+        response = self.query(
+            """
+            query {
+                applicationRounds {
+                    totalCount
+                    edges {
+                        node {
+                            applicationsCount
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)
+
     def test_filter_by_pk(self):
         ApplicationRoundFactory()
 


### PR DESCRIPTION
## Change log
- Excludes DRAFT, CANCELLED and  EXPIRED applications from ApplicationRoundType's applicationsCount

## Other notes
In ApplicationRoundType (gql) there is field which tells how many applications there are in the round. Previously it told the amount of applications excluding DRAFTs but for now it should be excluding also CANCELLED and EXPIRED ones.



Refs TILA-2508