### PR TITLE
TILA-2517: Log invalid webhook calls

### DIFF
--- a/api/tests/test_webhook_api.py
+++ b/api/tests/test_webhook_api.py
@@ -79,8 +79,8 @@ class WebhookPaymentAPITestCase(WebhookAPITestCaseBase):
             "paymentId": self.verkkokauppa_payment.payment_id,
             "orderId": self.verkkokauppa_payment.order_id,
             "namespace": self.verkkokauppa_payment.namespace,
-            "type": "PAYMENT_PAID",
-            "timestamp": self.verkkokauppa_payment.timestamp.isoformat(),
+            "eventType": "PAYMENT_PAID",
+            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     @mock.patch("api.webhook_api.views.send_confirmation_email")
@@ -124,7 +124,7 @@ class WebhookPaymentAPITestCase(WebhookAPITestCaseBase):
         self, mock_capture_exception, mock_get_payment
     ):
         data = self.get_valid_data()
-        data.pop("type")
+        data.pop("eventType")
 
         response = self.client.post(
             reverse("payment-list"),
@@ -133,7 +133,7 @@ class WebhookPaymentAPITestCase(WebhookAPITestCaseBase):
         )
         assert_that(response.status_code).is_equal_to(400)
 
-        expected_error = {"status": 400, "message": "Required field missing: type"}
+        expected_error = {"status": 400, "message": "Required field missing: eventType"}
         assert_that(response.data).is_equal_to(expected_error)
         assert_that(mock_capture_exception.called).is_true
 
@@ -210,7 +210,7 @@ class WebhookPaymentAPITestCase(WebhookAPITestCaseBase):
 
     def test_returns_501_with_error_on_invalid_type(self, mock_get_payment):
         data = self.get_valid_data()
-        data["type"] = "invalid"
+        data["eventType"] = "invalid"
 
         response = self.client.post(
             reverse("payment-list"),
@@ -230,8 +230,8 @@ class WebhookOrderAPITestCase(WebhookAPITestCaseBase):
         return {
             "orderId": self.verkkokauppa_payment.order_id,
             "namespace": self.verkkokauppa_payment.namespace,
-            "type": "ORDER_CANCELLED",
-            "timestamp": self.verkkokauppa_payment.timestamp.isoformat(),
+            "eventType": "ORDER_CANCELLED",
+            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     def test_returns_200_without_body_on_success(self, mock_get_order):
@@ -268,7 +268,7 @@ class WebhookOrderAPITestCase(WebhookAPITestCaseBase):
         self, mock_capture_exception, mock_get_payment
     ):
         data = self.get_valid_data()
-        data.pop("type")
+        data.pop("eventType")
 
         response = self.client.post(
             reverse("order-list"),
@@ -277,7 +277,7 @@ class WebhookOrderAPITestCase(WebhookAPITestCaseBase):
         )
         assert_that(response.status_code).is_equal_to(400)
 
-        expected_error = {"status": 400, "message": "Required field missing: type"}
+        expected_error = {"status": 400, "message": "Required field missing: eventType"}
         assert_that(response.data).is_equal_to(expected_error)
         assert_that(mock_capture_exception.called).is_true()
 
@@ -354,7 +354,7 @@ class WebhookOrderAPITestCase(WebhookAPITestCaseBase):
 
     def test_returns_501_with_error_on_invalid_type(self, mock_get_payment):
         data = self.get_valid_data()
-        data["type"] = "invalid"
+        data["eventType"] = "invalid"
 
         response = self.client.post(
             reverse("order-list"),
@@ -382,8 +382,8 @@ class WebhookRefundAPITestCase(WebhookAPITestCaseBase):
             "refundId": self.payment_order.refund_id,
             "refundPaymentId": uuid4(),
             "namespace": self.verkkokauppa_order.namespace,
-            "type": "REFUND_PAID",
-            "timestamp": self.verkkokauppa_payment.timestamp.isoformat(),
+            "eventType": "REFUND_PAID",
+            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     def test_refund_returns_200_without_body_on_success(self):
@@ -468,7 +468,7 @@ class WebhookRefundAPITestCase(WebhookAPITestCaseBase):
 
     def test_refund_returns_501_on_invalid_namespace(self):
         data = self.get_valid_data()
-        data["type"] = "invalid"
+        data["eventType"] = "invalid"
 
         response = self.client.post(
             reverse("refund-list"),

--- a/api/webhook_api/views.py
+++ b/api/webhook_api/views.py
@@ -44,7 +44,13 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
     permission_classes = [WebhookPermission]
 
     def validate_request(self, request):
-        required_field = ["paymentId", "orderId", "namespace", "type", "timestamp"]
+        required_field = [
+            "paymentId",
+            "orderId",
+            "namespace",
+            "eventType",
+            "eventTimestamp",
+        ]
         for field in required_field:
             if field not in request.data:
                 raise WebhookError(
@@ -52,7 +58,7 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
                 )
 
         namespace = request.data.get("namespace", None)
-        webhook_type = request.data.get("type", None)
+        webhook_type = request.data.get("eventType", None)
 
         if namespace != settings.VERKKOKAUPPA_NAMESPACE:
             raise WebhookError(message="Invalid namespace", status_code=400)
@@ -67,7 +73,7 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
                 "paymentId": serializers.UUIDField(),
                 "orderId": serializers.UUIDField(),
                 "namespace": serializers.CharField(),
-                "type": serializers.ChoiceField(
+                "eventType": serializers.ChoiceField(
                     choices=[
                         (
                             "PAYMENT_PAID",
@@ -75,7 +81,7 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
                         )
                     ]
                 ),
-                "timestamp": serializers.DateTimeField(),
+                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,
@@ -148,7 +154,7 @@ class WebhookOrderViewSet(viewsets.ViewSet):
     permission_classes = [WebhookPermission]
 
     def validate_request(self, request):
-        required_field = ["orderId", "namespace", "type", "timestamp"]
+        required_field = ["orderId", "namespace", "eventType", "eventTimestamp"]
         for field in required_field:
             if field not in request.data:
                 raise WebhookError(
@@ -156,7 +162,7 @@ class WebhookOrderViewSet(viewsets.ViewSet):
                 )
 
         namespace = request.data.get("namespace", None)
-        webhook_type = request.data.get("type", None)
+        webhook_type = request.data.get("eventType", None)
 
         if namespace != settings.VERKKOKAUPPA_NAMESPACE:
             raise WebhookError(message="Invalid namespace", status_code=400)
@@ -170,10 +176,10 @@ class WebhookOrderViewSet(viewsets.ViewSet):
             fields={
                 "orderId": serializers.UUIDField(),
                 "namespace": serializers.CharField(),
-                "type": serializers.ChoiceField(
+                "eventType": serializers.ChoiceField(
                     choices=[("ORDER_CANCELLED", "ORDER_CANCELLED")]
                 ),
-                "timestamp": serializers.DateTimeField(),
+                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,
@@ -237,8 +243,8 @@ class WebhookRefundViewSet(viewsets.ViewSet):
             "refundId",
             "refundPaymentId",
             "namespace",
-            "type",
-            "timestamp",
+            "eventType",
+            "eventTimestamp",
         ]
         for field in required_field:
             if field not in request.data:
@@ -247,7 +253,7 @@ class WebhookRefundViewSet(viewsets.ViewSet):
                 )
 
         namespace = request.data.get("namespace", None)
-        webhook_type = request.data.get("type", None)
+        webhook_type = request.data.get("eventType", None)
 
         if namespace != settings.VERKKOKAUPPA_NAMESPACE:
             raise WebhookError(message="Invalid namespace", status_code=400)
@@ -263,10 +269,10 @@ class WebhookRefundViewSet(viewsets.ViewSet):
                 "refundId": serializers.UUIDField(),
                 "refundPaymentId": serializers.UUIDField(),
                 "namespace": serializers.CharField(),
-                "type": serializers.ChoiceField(
+                "eventType": serializers.ChoiceField(
                     choices=[("REFUND_PAID", "REFUND_PAID")]
                 ),
-                "timestamp": serializers.DateTimeField(),
+                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,


### PR DESCRIPTION
## Change log
- Fixed webhook payload. Webshop documentation was wrong and that lead to wrong implementation
- Log invalid webhook calls to sentry
- Updated tests

## Other notes
In normal use webhooks should not fail. Failures are indication of changes in webshop side or someone bombarding API with malicious payload. By sending these to Sentry we get proper alerts when things go haywire.

## Deployment reminder
- No changes required