### PR TITLE
TILA-2522: Add setuptools to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ ENV PYTHONUSERBASE /pythonbase
 # Copy and install requirements files to image
 COPY requirements.txt ./
 
-RUN pip install --no-cache-dir wheel
+RUN pip install --no-cache-dir setuptools wheel
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .


### PR DESCRIPTION
## Change log
- Add setuptools install to Dockerfile

## Other notes
uWSGI installation fails with the new PIP version. For some reason it works fine in GitHub actions and one difference is that we install `setuptools` in GitHub actions but not in the Dockerfile. I'll give this a try. Another possible fix is to use `--use-pep517` flag with `pip install` but I'll try that next if this does not work.

Because the only way to test this is to merge it and see how it runs in CI, I'll do it without reviews just to get forward with this ⚠️ 🙈 

## Deployment reminder
- No changes required