### PR TITLE
TILA-2522: Add --use-pep517 flag to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,8 @@ ENV PYTHONUSERBASE /pythonbase
 # Copy and install requirements files to image
 COPY requirements.txt ./
 
-RUN pip install --no-cache-dir setuptools wheel
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --no-cache-dir wheel
+RUN pip install --use-pep517 --no-cache-dir -r requirements.txt
 
 COPY . .
 


### PR DESCRIPTION
## Change log
- Removed previous build test
- Added `--use-pep517` flag to Dockerfile

## Other notes
uWSGI installation fails with the new PIP version. Because the only way to test this is to merge it and run it in CI, I'll merge this without reviews ⚠️ 🙈 

## Deployment reminder
- No changes required