### PR TITLE
TILA-2451 | Reservation unit state helper fixes

### DIFF
--- a/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_units_state_filter.py
+++ b/api/graphql/tests/test_reservation_units/snapshots/snap_test_reservation_units_state_filter.py
@@ -132,3 +132,24 @@ snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_scheduled_publ
         }
     }
 }
+
+snapshots['ReservationUnitsFilterStateTestCase::test_filtering_by_scheduled_publishing_when_begin_after_end 1'] = {
+    'data': {
+        'reservationUnits': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'I am scheduled for publishing!',
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                },
+                {
+                    'node': {
+                        'nameFi': "I'm scheduled for publishing and my begins is after end.",
+                        'state': 'SCHEDULED_PUBLISHING'
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/api/graphql/tests/test_reservation_units/test_reservation_units_state_filter.py
+++ b/api/graphql/tests/test_reservation_units/test_reservation_units_state_filter.py
@@ -222,3 +222,33 @@ class ReservationUnitsFilterStateTestCase(ReservationUnitQueryTestCaseBase):
         assert_that(self.content_is_empty(content)).is_false()
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
+
+    def test_filtering_by_scheduled_publishing_when_begin_after_end(self):
+        now = datetime.datetime.now(tz=get_default_timezone())
+
+        ReservationUnitFactory(
+            name="I'm scheduled for publishing and my begins is after end.",
+            is_archived=False,
+            is_draft=False,
+            publish_begins=(now + datetime.timedelta(days=2)),
+            publish_ends=(now + datetime.timedelta(days=1)),
+        )
+        response = self.query(
+            """
+            query {
+                reservationUnits(state:"SCHEDULED_PUBLISHING"){
+                    edges {
+                        node {
+                            nameFi
+                            state
+                        }
+                    }
+                }
+            }
+            """
+        )
+
+        content = json.loads(response.content)
+        assert_that(self.content_is_empty(content)).is_false()
+        assert_that(content.get("errors")).is_none()
+        self.assertMatchSnapshot(content)

--- a/reservation_units/tests/test_reservation_unit_reservation_state_helper.py
+++ b/reservation_units/tests/test_reservation_unit_reservation_state_helper.py
@@ -65,3 +65,15 @@ class ReservationUnitReservationStateHelperTestCase(TestCase):
         assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
             ReservationState.RESERVATION_CLOSED
         )
+
+    def test_state_is_closed_when_reservation_begin_and_end_in_past_and_same_value(
+        self,
+    ):
+        self.reservation_unit.reservation_begins = self.now - datetime.timedelta(days=1)
+        self.reservation_unit.reservation_ends = (
+            self.reservation_unit.reservation_begins
+        )
+
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationState.RESERVATION_CLOSED
+        )

--- a/reservation_units/tests/test_reservation_unit_state_helper.py
+++ b/reservation_units/tests/test_reservation_unit_state_helper.py
@@ -90,3 +90,12 @@ class ReservationUnitStateHelperTestCase(TestCase):
         assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
             ReservationUnitState.SCHEDULED_PERIOD
         )
+
+    def test_state_is_hidden_when_publish_end_and_begins_in_the_past_and_the_same(self):
+        self.reservation_unit.is_archived = False
+        self.reservation_unit.is_draft = False
+        self.reservation_unit.publish_begins = self.now - datetime.timedelta(hours=1)
+        self.reservation_unit.publish_ends = self.reservation_unit.publish_begins
+        assert_that(Helper.get_state(self.reservation_unit)).is_equal_to(
+            ReservationUnitState.HIDDEN
+        )

--- a/reservation_units/utils/reservation_unit_reservation_state_helper.py
+++ b/reservation_units/utils/reservation_unit_reservation_state_helper.py
@@ -143,7 +143,7 @@ class ReservationUnitReservationStateHelper:
                 or (
                     reservation_unit.reservation_begins <= now
                     and reservation_unit.reservation_begins
-                    < reservation_unit.reservation_ends
+                    <= reservation_unit.reservation_ends
                 )
             )
             or (
@@ -165,8 +165,8 @@ class ReservationUnitReservationStateHelper:
                 Q(reservation_ends__lte=now)
                 & (
                     Q(
-                        reservation_begins__lte=now,
-                        reservation_begins__lt=F("reservation_ends"),
+                        Q(reservation_begins__lte=now)
+                        & Q(reservation_begins__lte=F("reservation_ends"))
                     )
                     | Q(reservation_begins__isnull=True)
                 )

--- a/reservation_units/utils/reservation_unit_state_helper.py
+++ b/reservation_units/utils/reservation_unit_state_helper.py
@@ -68,7 +68,11 @@ class ReservationUnitStateHelper:
             publish_begins__isnull=False,
             publish_begins__gt=now,
         )
-        second_q = Q(publish_ends__isnull=True) | Q(publish_ends__lt=now)
+        second_q = (
+            Q(publish_ends__isnull=True)
+            | Q(publish_ends__lte=now)
+            | Q(Q(publish_ends__gt=now, publish_begins__gt=F("publish_ends")))
+        )
 
         return Q(first_q) & Q(second_q)
 

--- a/reservation_units/utils/reservation_unit_state_helper.py
+++ b/reservation_units/utils/reservation_unit_state_helper.py
@@ -146,7 +146,7 @@ class ReservationUnitStateHelper:
                 reservation_unit.publish_begins is None
                 or (
                     reservation_unit.publish_begins <= now
-                    and reservation_unit.publish_begins < reservation_unit.publish_ends
+                    and reservation_unit.publish_begins <= reservation_unit.publish_ends
                 )
             )
             or (
@@ -165,7 +165,10 @@ class ReservationUnitStateHelper:
             Q(
                 Q(publish_ends__lte=now)
                 & (
-                    Q(publish_begins__lte=now, publish_begins__lt=F("publish_ends"))
+                    Q(
+                        Q(publish_begins__lte=now)
+                        & Q(publish_begins__lte=F("publish_ends"))
+                    )
                     | Q(publish_begins__isnull=True)
                 )
             )


### PR DESCRIPTION
## Change log
- changes the ReservationUnitReservationStateHelper to return
reservation state as RESERVATION CLOSED when reservation unit's
reservation begins and *_ends dates are in past and the same
- Returns HIDDEN state when publish dates in the past and the same
- Shows correctly scheduled publishing reservation units when publish dates in the future

## Other notes
See commit messages for details

Refs TILA-2451
