### PR TITLE
TILA-2525: Remove timestamp fields from validation

### DIFF
--- a/api/tests/test_webhook_api.py
+++ b/api/tests/test_webhook_api.py
@@ -80,7 +80,6 @@ class WebhookPaymentAPITestCase(WebhookAPITestCaseBase):
             "orderId": self.verkkokauppa_payment.order_id,
             "namespace": self.verkkokauppa_payment.namespace,
             "eventType": "PAYMENT_PAID",
-            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     @mock.patch("api.webhook_api.views.send_confirmation_email")
@@ -231,7 +230,6 @@ class WebhookOrderAPITestCase(WebhookAPITestCaseBase):
             "orderId": self.verkkokauppa_payment.order_id,
             "namespace": self.verkkokauppa_payment.namespace,
             "eventType": "ORDER_CANCELLED",
-            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     def test_returns_200_without_body_on_success(self, mock_get_order):
@@ -383,7 +381,6 @@ class WebhookRefundAPITestCase(WebhookAPITestCaseBase):
             "refundPaymentId": uuid4(),
             "namespace": self.verkkokauppa_order.namespace,
             "eventType": "REFUND_PAID",
-            "eventTimestamp": self.verkkokauppa_payment.timestamp.isoformat(),
         }
 
     def test_refund_returns_200_without_body_on_success(self):

--- a/api/webhook_api/views.py
+++ b/api/webhook_api/views.py
@@ -49,7 +49,6 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
             "orderId",
             "namespace",
             "eventType",
-            "eventTimestamp",
         ]
         for field in required_field:
             if field not in request.data:
@@ -81,7 +80,6 @@ class WebhookPaymentViewSet(viewsets.GenericViewSet):
                         )
                     ]
                 ),
-                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,
@@ -154,7 +152,7 @@ class WebhookOrderViewSet(viewsets.ViewSet):
     permission_classes = [WebhookPermission]
 
     def validate_request(self, request):
-        required_field = ["orderId", "namespace", "eventType", "eventTimestamp"]
+        required_field = ["orderId", "namespace", "eventType"]
         for field in required_field:
             if field not in request.data:
                 raise WebhookError(
@@ -179,7 +177,6 @@ class WebhookOrderViewSet(viewsets.ViewSet):
                 "eventType": serializers.ChoiceField(
                     choices=[("ORDER_CANCELLED", "ORDER_CANCELLED")]
                 ),
-                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,
@@ -244,7 +241,6 @@ class WebhookRefundViewSet(viewsets.ViewSet):
             "refundPaymentId",
             "namespace",
             "eventType",
-            "eventTimestamp",
         ]
         for field in required_field:
             if field not in request.data:
@@ -272,7 +268,6 @@ class WebhookRefundViewSet(viewsets.ViewSet):
                 "eventType": serializers.ChoiceField(
                     choices=[("REFUND_PAID", "REFUND_PAID")]
                 ),
-                "eventTimestamp": serializers.DateTimeField(),
             },
         ),
         responses=default_responses,


### PR DESCRIPTION
## Change log
- Remove timestamp fields from webhook validation

## Other notes
We are not using these fields so just to avoid shadowboxing with all the mixed implementations on webshop side, I just removed'em.

## Deployment reminder
- No changes required