### PR TITLE
TILA-2271: Separate Dockerfile for running the service locally

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,13 @@
+FROM python:3.8.13-bullseye
+
+RUN pip install --upgrade pip
+COPY ./requirements.txt .
+RUN pip install -r requirements.txt
+
+COPY . /tvp
+WORKDIR /tvp
+
+RUN apt-get update && apt-get -y install libgdal-dev
+RUN pip install --no-cache-dir -r requirements.txt
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -11,21 +11,14 @@ To run tilavarauspalvelu locally you need to have DEBUG=True in your .env file.
 Easiest way is to copy and rename .env.example to .env and make sure DEBUG=True is set. 
  
 ## Installation with docker
+To run the service locally in Docker, you can run the following command:
 
-You'll need a redhat developer account to gain access to redhat subsriptions
-needed to run the docker image. 
+```
+docker-compose up backend
+```
 
-Register at https://developers.redhat.com/register and confirm your email address. 
 
-Set following environment variables in .env file or pass them to docker compose
-- BUILD_MODE=local
-- REDHAT_USERNAME=your redhat account username 
-- REDHAT_PASSWORD=your redhat account password
-
-Then you can run docker image with
-
-`docker-compose up dev`
-
+This will start the service and also runs the database in a separate docker container.
 ## Requirements
 
 Workflow with requirements is as follows.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,20 @@ services:
         volumes:
             - postgres-data-volume:/var/lib/postgresql/data
 
+    backend:
+        container_name: tilavarauspalvelu_core
+        image: tilavarauspalvelu_core_local
+        depends_on:
+            - db
+        build:
+            context: ./
+            dockerfile: ./Dockerfile.local
+        environment:
+            - DATABASE_URL=postgis://tvp:tvp@db/tvp
+            - CELERY_ENABLED=false
+        ports:
+            - "8000:8000"
+
     dev:
         image: tilavarauspalvelu_dev
         depends_on:


### PR DESCRIPTION
## Change log
- Created separate Dockerfile for local running
- Updated README to contain simplified instructions

## Other notes
Running core locally can be a pain in the 🍑 . So, I decided to simplify it for the frontend devs. We don't need all that RedHat crap and service runs just fine in with standard python image. This drops some configuration and RedHat requirements and service can be run with a single command.

## Deployment reminder
- No changes required