### PR TITLE
TILA-2531 | Read only regular user's profile_id

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -47,6 +47,14 @@ class User(AbstractUser):
         else:
             return self.preferred_language
 
+    @property
+    def has_staff_permissions(self):
+        return (
+            self.general_roles.exists()
+            or self.service_sector_roles.exists()
+            or self.unit_roles.exists()
+        )
+
 
 class PersonalInfoViewLog(models.Model):
     field = models.CharField(max_length=255, null=False, blank=False, editable=False)


### PR DESCRIPTION
## Change log
- Add util property check whether user is supposed to be staff user (since django's is_staff won't work in this case)
- Read profile id only for regular users - not staff users
- Catch exceptions reading profile_id and send'em to sentry 


Refs TILA-2531

