### PR TITLE
Add session engine conf to OpenShit section

### DIFF
--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -624,6 +624,8 @@ if env("REDIS_URL"):
 # Configure Redis cache for production OpenShift environment
 elif env("REDIS_SENTINEL_SERVICE") and env("REDIS_MASTER"):
     sentinel_host, sentinel_port = env("REDIS_SENTINEL_SERVICE").split(":")
+    SESSION_ENGINE = "django.contrib.sessions.backends.cache"
+    SESSION_CACHE_ALIAS = "default"
     DJANGO_REDIS_CONNECTION_FACTORY = "django_redis.pool.SentinelConnectionFactory"
     CACHES = {
         "default": {


### PR DESCRIPTION
## Change log
- Add missing cache settings to OpenShift config section

## Other notes
Forgot to add these settings to OpenShift section when I moved these settings around and removed the nesting. I'll merge this without review because just to move forward a bit faster. We can review the final state as soon as Redis cache works ☺️ 

## Deployment reminder
- No changes required