### PR TITLE
TILA-2518: Fix and improve refreshOrder mutation

### DIFF
--- a/api/graphql/merchants/merchant_mutations.py
+++ b/api/graphql/merchants/merchant_mutations.py
@@ -27,6 +27,7 @@ class RefreshOrderMutation(relay.ClientIDMutation, AuthMutation):
 
     order_uuid = graphene.UUID()
     status = graphene.String()
+    reservation_pk = graphene.Int()
 
     @classmethod
     def mutate_and_get_payload(cls, root, info, **input):
@@ -85,5 +86,7 @@ class RefreshOrderMutation(relay.ClientIDMutation, AuthMutation):
                 send_confirmation_email(payment_order.reservation)
 
         return RefreshOrderMutation(
-            order_uuid=payment_order.remote_id, status=payment_order.status
+            order_uuid=payment_order.remote_id,
+            status=payment_order.status,
+            reservation_pk=payment_order.reservation.pk,
         )

--- a/api/graphql/tests/test_merchants/test_merchant_mutations.py
+++ b/api/graphql/tests/test_merchants/test_merchant_mutations.py
@@ -1,0 +1,216 @@
+import json
+from datetime import datetime
+from typing import Any, Dict
+from unittest import mock
+from uuid import uuid4
+
+from assertpy import assert_that
+from django.test import override_settings
+from django.utils.timezone import get_default_timezone
+from freezegun import freeze_time
+
+from api.graphql.tests.base import GrapheneTestCaseBase
+from api.graphql.validation_errors import ValidationErrorCodes
+from merchants.models import OrderStatus
+from merchants.tests.factories import PaymentOrderFactory
+from merchants.verkkokauppa.payment.test.factories import PaymentFactory
+from reservations.tests.factories import ReservationFactory
+
+
+@override_settings(VERKKOKAUPPA_NAMESPACE="tilanvaraus")
+@freeze_time("2023-05-04 12:00:00", tz_offset=0)
+class RefreshOrderMutationTestCase(GrapheneTestCaseBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls.reservation = ReservationFactory()
+        cls.payment_order = PaymentOrderFactory(
+            remote_id=uuid4(), reservation=cls.reservation
+        )
+
+    def setUp(self):
+        self.client.force_login(self.general_admin)
+
+    def get_valid_data(self, order_uuid: bool) -> Dict[str, Any]:
+        return {
+            "orderUuid": order_uuid,
+        }
+
+    def get_refresh_order_query(self) -> str:
+        return """
+        mutation refreshOrder($input: RefreshOrderMutationInput!) {
+            refreshOrder(input: $input){
+                orderUuid
+                status
+                reservationPk
+            }
+        }
+        """
+
+    @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
+    def test_refresh_mutation_set_order_to_paid(self, mock_get_payment):
+        remote_id = str(self.payment_order.remote_id)
+        mock_get_payment.return_value = PaymentFactory(
+            payment_id=remote_id, status="payment_paid_online"
+        )
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        result = content.get("data").get("refreshOrder")
+        assert_that(result.get("orderUuid")).is_equal_to(remote_id)
+        assert_that(result.get("status")).is_equal_to(OrderStatus.PAID.value)
+        assert_that(result.get("reservationPk")).is_equal_to(self.reservation.pk)
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.PAID)
+        assert_that(self.payment_order.processed_at).is_equal_to(
+            datetime.now().astimezone(get_default_timezone())
+        )
+
+    @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
+    def test_refresh_mutation_set_order_to_cancelled(self, mock_get_payment):
+        remote_id = str(self.payment_order.remote_id)
+        mock_get_payment.return_value = PaymentFactory(
+            payment_id=remote_id, status="payment_cancelled"
+        )
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        result = content.get("data").get("refreshOrder")
+        assert_that(result.get("orderUuid")).is_equal_to(remote_id)
+        assert_that(result.get("status")).is_equal_to(OrderStatus.CANCELLED.value)
+        assert_that(result.get("reservationPk")).is_equal_to(self.reservation.pk)
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.CANCELLED)
+        assert_that(self.payment_order.processed_at).is_equal_to(
+            datetime.now().astimezone(get_default_timezone())
+        )
+
+    @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
+    def test_refresh_mutation_skip_update_if_order_is_not_in_updateable_state(
+        self, mock_get_payment
+    ):
+        self.payment_order.status = OrderStatus.REFUNDED
+        self.payment_order.save()
+
+        remote_id = str(self.payment_order.remote_id)
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        assert_that(content.get("errors")).is_none()
+
+        result = content.get("data").get("refreshOrder")
+        assert_that(result.get("orderUuid")).is_equal_to(remote_id)
+        assert_that(result.get("status")).is_equal_to(OrderStatus.REFUNDED.value)
+        assert_that(result.get("reservationPk")).is_equal_to(self.reservation.pk)
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.REFUNDED)
+        assert_that(self.payment_order.processed_at).is_none()
+
+        assert_that(mock_get_payment.called).is_false()
+
+    @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
+    def test_refresh_mutation_raise_error_when_order_not_found(self, mock_get_payment):
+        not_found_remote_id = str(uuid4())
+        mock_get_payment.return_value = None
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(not_found_remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        errors = content.get("errors")
+
+        assert_that(len(errors)).is_equal_to(1)
+        assert_that(errors[0].get("message")).is_equal_to("Order not found")
+        assert_that(errors[0].get("extensions").get("error_code")).is_equal_to(
+            ValidationErrorCodes.NOT_FOUND.value
+        )
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.DRAFT)
+        assert_that(self.payment_order.processed_at).is_none()
+
+    @mock.patch("api.graphql.merchants.merchant_mutations.capture_message")
+    @mock.patch("api.graphql.merchants.merchant_mutations.get_payment")
+    def test_refresh_mutation_raise_error_when_payment_not_found(
+        self, mock_get_payment, mock_capture_message
+    ):
+        remote_id = str(self.payment_order.remote_id)
+        mock_get_payment.return_value = None
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+
+        errors = content.get("errors")
+        assert_that(len(errors)).is_equal_to(1)
+        assert_that(errors[0].get("message")).is_equal_to(
+            "Unable to check order payment"
+        )
+        assert_that(errors[0].get("extensions").get("error_code")).is_equal_to(
+            ValidationErrorCodes.NOT_FOUND.value
+        )
+
+        assert_that(mock_capture_message.called).is_true
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.DRAFT)
+        assert_that(self.payment_order.processed_at).is_none()
+
+    def test_refresh_mutation_raise_error_when_no_permission(self):
+        self.client.force_login(self.regular_joe)
+        remote_id = str(self.payment_order.remote_id)
+
+        response = self.query(
+            query=self.get_refresh_order_query(),
+            input_data=self.get_valid_data(remote_id),
+        )
+
+        assert_that(response.status_code).is_equal_to(200)
+
+        content = json.loads(response.content)
+        errors = content.get("errors")
+        assert_that(len(errors)).is_equal_to(1)
+        assert_that(errors[0].get("message")).is_equal_to(
+            "No permission to refresh the order"
+        )
+        assert_that(errors[0].get("extensions").get("error_code")).is_equal_to(
+            ValidationErrorCodes.NO_PERMISSION.value
+        )
+
+        self.payment_order.refresh_from_db()
+        assert_that(self.payment_order.status).is_equal_to(OrderStatus.DRAFT)
+        assert_that(self.payment_order.processed_at).is_none()

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -714,7 +714,4 @@ class OrderRefreshPermission(BasePermission):
     def has_mutation_permission(cls, root, info, input):
         remote_id = input.get("order_uuid")
         payment_order = PaymentOrder.objects.filter(remote_id=remote_id).first()
-        if not payment_order:
-            return False
-
         return can_refresh_order(info.context.user, payment_order)

--- a/permissions/helpers.py
+++ b/permissions/helpers.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union
 
 from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
@@ -490,7 +490,7 @@ def can_view_users(user: User):
     )
 
 
-def can_refresh_order(user: User, payment_order: PaymentOrder) -> bool:
+def can_refresh_order(user: User, payment_order: Optional[PaymentOrder]) -> bool:
     if not user.is_authenticated:
         return False
 
@@ -498,7 +498,7 @@ def can_refresh_order(user: User, payment_order: PaymentOrder) -> bool:
     return (
         is_superuser(user)
         or has_general_permission(user, permission)
-        or user.uuid == payment_order.reservation_user_uuid
+        or (payment_order and user.uuid == payment_order.reservation_user_uuid)
     )
 
 


### PR DESCRIPTION
## Change log
- Fixed wonky permission check when order is not found
- Save `payment_id` and `processed_at` fields on refresh
- Added `reservationPk` to the response to avoid extra calls in the client
- Prevent updates if order is not in updateable state
- Add tests!

## Other notes
Additional notes if needed

## Deployment reminder
- No changes required