### PR TITLE
TILA-2540: Remove padding zeroes from date

### DIFF
--- a/merchants/verkkokauppa/helpers.py
+++ b/merchants/verkkokauppa/helpers.py
@@ -39,9 +39,11 @@ def get_formatted_reservation_time(reservation: Reservation) -> str:
 
     preferred_language = reservation.reservee_language or "fi"
     weekday = localized_short_weekday(begin.weekday(), preferred_language)
+    date = "{d.day}.{d.month}.{d.year}".format(d=begin)
+    start_time = begin.strftime("%H:%M")
     end_time = end.strftime("%H:%M")
 
-    return begin.strftime(f"{weekday} %d.%m.%Y %H:%M-{end_time}")
+    return begin.strftime(f"{weekday} {date} {start_time}-{end_time}")
 
 
 def get_validated_phone_number(phone_number: str) -> str:

--- a/merchants/verkkokauppa/tests/test_helpers.py
+++ b/merchants/verkkokauppa/tests/test_helpers.py
@@ -50,25 +50,25 @@ class HelpersTestCase(TestCase):
         self.reservation.save()
 
         date = get_formatted_reservation_time(self.reservation)
-        assert_that(date).is_equal_to("La 05.11.2022 10:00-12:00")
+        assert_that(date).is_equal_to("La 5.11.2022 10:00-12:00")
 
     def test_get_formatted_reservation_time_sv(self):
         self.reservation.reservee_language = "sv"
         self.reservation.save()
 
         date = get_formatted_reservation_time(self.reservation)
-        assert_that(date).is_equal_to("Lö 05.11.2022 10:00-12:00")
+        assert_that(date).is_equal_to("Lö 5.11.2022 10:00-12:00")
 
     def test_get_formatted_reservation_time_en(self):
         self.reservation.reservee_language = "en"
         self.reservation.save()
 
         date = get_formatted_reservation_time(self.reservation)
-        assert_that(date).is_equal_to("Sa 05.11.2022 10:00-12:00")
+        assert_that(date).is_equal_to("Sa 5.11.2022 10:00-12:00")
 
     def test_get_formatted_reservation_time_fi_fallback(self):
         date = get_formatted_reservation_time(self.reservation)
-        assert_that(date).is_equal_to("La 05.11.2022 10:00-12:00")
+        assert_that(date).is_equal_to("La 5.11.2022 10:00-12:00")
 
     def test_get_validated_phone_number(self):
         assert_that(get_validated_phone_number("+358 50 123 4567")).is_equal_to(


### PR DESCRIPTION
## Change log
- Removed padding zeroes from the date

## Other notes
I did not know that Python's date formatting does not support values without padding zeroes. So, ended up building the proper format by hand.

## Deployment reminder
- No changes required