### PR TITLE
TILA-2561 | Add task to rebuild space hierarchy and rebuild on save

### DIFF
--- a/spaces/models.py
+++ b/spaces/models.py
@@ -282,6 +282,12 @@ class Space(MPTTModel):
     def __str__(self):
         return "{} ({})".format(self.name, self.building.name if self.building else "")
 
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+
+        tree_id = self.parent.tree_id if self.parent else self.tree_id
+        self.__class__.objects.partial_rebuild(tree_id)
+
 
 class Location(models.Model):
     """

--- a/spaces/tasks.py
+++ b/spaces/tasks.py
@@ -1,0 +1,10 @@
+from django.db import transaction
+
+from spaces.models import Space
+from tilavarauspalvelu.celery import app
+
+
+@app.task(name="rebuild_space_tree_hierarchy")
+def rebuild_space_tree_hierarchy():
+    with transaction.atomic():
+        Space.objects.rebuild()


### PR DESCRIPTION
Sometimes the tree hierarchies gets corrupted and need a rebuilding. This adds task for rebuilding the hierarchies and does partial_rebuild when saving Space instance.