### PR TITLE
TILA-2516: Adjust profile address parser

### DIFF
--- a/api/graphql/reservations/reservation_serializers/create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/create_serializers.py
@@ -271,18 +271,12 @@ class ReservationCreateSerializer(
                 data[key] = value
 
             address = reader.get_address()
-            if address and not address.get("countryCode"):
+            if address and address.get("address"):
                 data["reservee_address_street"] = address.get("address")
+            if address and address.get("postalCode"):
                 data["reservee_address_zip"] = address.get("postalCode")
+            if address and address.get("city"):
                 data["reservee_address_city"] = address.get("city")
-
-            elif address and address.get("countryCode"):
-                # If countryCode is present then address is abroad address and
-                # then the format can be ambiguous, so we use the street address and city only.
-                data["reservee_address_street"] = address.get("address")
-                data[
-                    "reservee_address_city"
-                ] = f"{address.get('city')} {address.get('countryCode')}"
 
         except ProfileReadError as prof_err:
             log_exception_to_sentry(prof_err)

--- a/api/graphql/tests/test_reservations/test_reservation_create.py
+++ b/api/graphql/tests/test_reservations/test_reservation_create.py
@@ -289,7 +289,7 @@ class ReservationCreateTestCase(ReservationTestCaseBase):
         pk = content.get("data").get("createReservation").get("reservation").get("pk")
         reservation = Reservation.objects.get(id=pk)
         assert_that(reservation).is_not_none()
-        assert_that(reservation.reservee_address_city).is_equal_to("Foreign city AX")
+        assert_that(reservation.reservee_address_city).is_empty()
         assert_that(reservation.reservee_address_street).is_equal_to("Foreign street 1")
         assert_that(reservation.reservee_address_zip).is_empty()
 

--- a/users/tests/test_basic_info_resolver.py
+++ b/users/tests/test_basic_info_resolver.py
@@ -259,7 +259,7 @@ class ProfileUserInfoReaderTestCase(TestCase):
 
         assert_that(address.get("address")).is_equal_to("Foreign street 1")
         assert_that(address.get("postalCode")).is_none()
-        assert_that(address.get("city")).is_equal_to("Foreign city")
+        assert_that(address.get("city")).is_none()
         assert_that(address.get("countryCode")).is_equal_to("AX")
 
     @patch("requests.get")

--- a/users/utils/open_city_profile/basic_info_resolver.py
+++ b/users/utils/open_city_profile/basic_info_resolver.py
@@ -89,6 +89,11 @@ class ProfileUserInfoReader(ProfileReaderTokenMixin):
                          postalCode
                          postOffice
                     }
+                    permanentForeignAddress {
+                        streetAddress
+                        additionalAddress
+                        countryCode
+                    }
                 }
             }
         }
@@ -204,7 +209,6 @@ class ProfileUserInfoReader(ProfileReaderTokenMixin):
         if address:
             return {
                 "address": address.get("streetAddress"),
-                "city": address.get("additionalAddress"),
                 "countryCode": address.get("countryCode"),
             }
 


### PR DESCRIPTION
## Change log
- Adjust address parsing

## Other notes
Sometimes we had addresses where city value container something like "Helsinki FI". This happened with foreign addresses that can have all kinds of weird address formats. Now, only address field is used from the foreign address and other fields are ignored.

## Deployment reminder
- No changes required