### PR TITLE
TILA-2569: Add reserveName field to ReservationType

### DIFF
--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -570,6 +570,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission 1'] = {
                         'reserveeFirstName': 'Reser',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Vee',
+                        'reserveeName': 'Reser Vee',
                         'reserveeOrganisationName': 'Test organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -613,6 +614,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'reserveeFirstName': 'Shouldbe',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Hidden',
+                        'reserveeName': 'Shouldbe Hidden',
                         'reserveeOrganisationName': 'Hidden organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -646,6 +648,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'reserveeFirstName': 'Reser',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Vee',
+                        'reserveeName': 'Reser Vee',
                         'reserveeOrganisationName': 'Test organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -689,6 +692,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group
                         'reserveeFirstName': 'Shouldbe',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Hidden',
+                        'reserveeName': 'Shouldbe Hidden',
                         'reserveeOrganisationName': 'Hidden organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -722,6 +726,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group
                         'reserveeFirstName': 'Reser',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Vee',
+                        'reserveeName': 'Reser Vee',
                         'reserveeOrganisationName': 'Test organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -907,6 +912,7 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'reserveeFirstName': None,
                         'reserveeId': None,
                         'reserveeLastName': None,
+                        'reserveeName': None,
                         'reserveeOrganisationName': None,
                         'reserveePhone': None,
                         'user': None
@@ -938,6 +944,7 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'reserveeFirstName': 'Reser',
                         'reserveeId': '5727586-5',
                         'reserveeLastName': 'Vee',
+                        'reserveeName': 'Reser Vee',
                         'reserveeOrganisationName': 'Test organisation',
                         'reserveePhone': '+358123456789',
                         'user': {
@@ -1495,6 +1502,7 @@ snapshots['ReservationQueryTestCase::test_reservation_query 1'] = {
                         'reserveeId': '5727586-5',
                         'reserveeIsUnregisteredAssociation': False,
                         'reserveeLastName': 'Vee',
+                        'reserveeName': 'Reser Vee',
                         'reserveeOrganisationName': 'Test organisation',
                         'reserveePhone': '+358123456789',
                         'reserveeType': 'INDIVIDUAL',

--- a/api/graphql/tests/test_reservations/test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/test_reservation_queries.py
@@ -92,6 +92,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
                             reserveeAddressCity
                             reserveeAddressZip
                             reserveeOrganisationName
+                            reserveeName
                             freeOfChargeReason
                             billingFirstName
                             billingLastName
@@ -181,6 +182,7 @@ class ReservationQueryTestCase(ReservationTestCaseBase):
                             numPersons
                             reserveeFirstName
                             reserveeLastName
+                            reserveeName
                             reserveeType
                             reserveeOrganisationName
                             reserveeAddressStreet
@@ -1654,3 +1656,70 @@ class ReservationByPkTestCase(ReservationTestCaseBase):
             self.general_admin.get_full_name()
         )
         assert_that(view_log.viewer_user_email).is_equal_to(self.general_admin.email)
+
+    def test_reservee_name_for_individual_reservee(self):
+        reservation = ReservationFactory(
+            reservee_type=CUSTOMER_TYPES.CUSTOMER_TYPE_INDIVIDUAL,
+            reservee_first_name="First",
+            reservee_last_name="Last",
+        )
+
+        self.client.force_login(self.general_admin)
+        query = f"""
+            {{
+                reservationByPk(pk: {reservation.pk}) {{
+                    reserveeName
+                }}
+            }}
+        """
+        response = self.query(query)
+        content = json.loads(response.content)
+        assert_that(content["data"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]["reserveeName"]).is_equal_to(
+            "First Last"
+        )
+
+    def test_reservee_name_for_business_reservee(self):
+        reservation = ReservationFactory(
+            reservee_type=CUSTOMER_TYPES.CUSTOMER_TYPE_BUSINESS,
+            reservee_organisation_name="Business Oy",
+        )
+
+        self.client.force_login(self.general_admin)
+        query = f"""
+            {{
+                reservationByPk(pk: {reservation.pk}) {{
+                    reserveeName
+                }}
+            }}
+        """
+        response = self.query(query)
+        content = json.loads(response.content)
+        assert_that(content["data"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]["reserveeName"]).is_equal_to(
+            "Business Oy"
+        )
+
+    def test_reservee_name_for_nonprofit_reservee(self):
+        reservation = ReservationFactory(
+            reservee_type=CUSTOMER_TYPES.CUSTOMER_TYPE_NONPROFIT,
+            reservee_organisation_name="Nonprofit Ry",
+        )
+
+        self.client.force_login(self.general_admin)
+        query = f"""
+            {{
+                reservationByPk(pk: {reservation.pk}) {{
+                    reserveeName
+                }}
+            }}
+        """
+        response = self.query(query)
+        content = json.loads(response.content)
+        assert_that(content["data"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]).is_not_none()
+        assert_that(content["data"]["reservationByPk"]["reserveeName"]).is_equal_to(
+            "Nonprofit Ry"
+        )


### PR DESCRIPTION
## Change log
- Added reserveeName field to ReservationType
- Fixed some typing definitions to keep linters and Sonar happy

## Other notes
This fields returns the correct name based on the customer type. This way we don't have to have the same logic on the client side and they can just show the name.

## Deployment reminder
- No changes required