### PR TITLE
TILA-2582: Upgrade NPM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -69,6 +69,7 @@ COPY deploy/* ./deploy/
 
 RUN subscription-manager remove --all
 
+RUN npm install -g npm@9.6.6
 RUN npm install @sentry/cli
 
 # Can be used to inquire about running app


### PR DESCRIPTION
## Change log
- Upgraded NPM

## Other notes
For some reason sentry-cli installation failed. Let's see if upgrading NPM solves the issue.

## Deployment reminder
- No changes required