### PR TITLE
TILA-2616: Remove deprecated timezone handling

### DIFF
--- a/api/graphql/opening_hours/opening_hours_types.py
+++ b/api/graphql/opening_hours/opening_hours_types.py
@@ -17,7 +17,7 @@ def get_time_as_utc(time: datetime.time, date: datetime.date, tz_info: timezone)
     So for now we render all as UTC using this little helper.
     """
     start_dt = datetime.datetime.combine(date, time)
-    start_dt = tz_info.localize(start_dt)
+    start_dt = start_dt.astimezone(tz_info)
     start_dt = start_dt.astimezone(timezone.utc)
     return start_dt.timetz()
 

--- a/opening_hours/decorators.py
+++ b/opening_hours/decorators.py
@@ -15,8 +15,8 @@ def datetime_args_to_default_timezone(func: callable):
                 timezone = arg.tzinfo
                 if not timezone:
                     timezone = TIMEZONE
-                dt = timezone.localize(
-                    datetime.datetime(1977, 1, 1, arg.hour, arg.minute, arg.second)
+                dt = datetime.datetime(
+                    1977, 1, 1, arg.hour, arg.minute, arg.second, tzinfo=timezone
                 )
                 arg = dt.astimezone(TIMEZONE).time()
             converted_args.append(arg)

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -111,7 +111,7 @@ def get_opening_hours(
     days_data_out = []
     for day_data_in in days_data_in["results"]:
         timezone = ZoneInfo(
-            day_data_in.get("resource", {}).get("timezone", DEFAULT_TIMEZONE.zone)
+            day_data_in.get("resource", {}).get("timezone", DEFAULT_TIMEZONE.key)
         )
         for opening_hours in day_data_in["opening_hours"]:
             day_data_out = {

--- a/opening_hours/utils/opening_hours_client.py
+++ b/opening_hours/utils/opening_hours_client.py
@@ -60,26 +60,14 @@ class OpeningHours:
             if full_day or not time_element.end_time
             else time_element.end_time
         )
-        start_time = timezone.localize(
-            datetime.datetime(
-                date.year,
-                date.month,
-                date.day,
-                start.hour,
-                start.minute,
-            )
+        start_time = datetime.datetime(
+            date.year, date.month, date.day, start.hour, start.minute, tzinfo=timezone
         )
 
         if end_time_on_next_day:
             date += datetime.timedelta(days=1)
-        end_time = timezone.localize(
-            datetime.datetime(
-                date.year,
-                date.month,
-                date.day,
-                end.hour,
-                end.minute,
-            )
+        end_time = datetime.datetime(
+            date.year, date.month, date.day, end.hour, end.minute, tzinfo=timezone
         )
 
         # If the length of opening is zero, return None for helping the UI.

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -72,14 +72,13 @@ class ReservationUnitReservationScheduler:
                     open_application_round.reservation_period_end
                     + datetime.timedelta(days=1)
                 )
-                self.start_time = DEFAULT_TIMEZONE.localize(
-                    datetime.datetime(
-                        self.start_time.year,
-                        self.start_time.month,
-                        self.start_time.day,
-                        0,
-                        0,
-                    )
+                self.start_time = datetime.datetime(
+                    self.start_time.year,
+                    self.start_time.month,
+                    self.start_time.day,
+                    0,
+                    0,
+                    tzinfo=DEFAULT_TIMEZONE,
                 )
 
             else:
@@ -134,7 +133,7 @@ class ReservationUnitReservationScheduler:
                 days=self.reservation_unit.reservations_min_days_before
             )
 
-        return DEFAULT_TIMEZONE.localize(datetime.datetime.now() + delta)
+        return (datetime.datetime.now() + delta).astimezone(DEFAULT_TIMEZONE)
 
     def _get_reservation_period_end(self, start: datetime.datetime) -> datetime.date:
         if (
@@ -150,8 +149,8 @@ class ReservationUnitReservationScheduler:
         if self.reservation_unit.reservations_max_days_before:
             delta = self.reservation_unit.reservations_max_days_before
 
-        end = DEFAULT_TIMEZONE.localize(
-            datetime.datetime.now() + datetime.timedelta(days=delta)
+        end = (datetime.datetime.now() + datetime.timedelta(days=delta)).astimezone(
+            DEFAULT_TIMEZONE
         )
 
         return end.date()

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -640,13 +640,6 @@ elif env("REDIS_SENTINEL_SERVICE") and env("REDIS_MASTER"):
         }
     }
 
-# Python 3.9 added pytz features to the standard library so using
-# pytz is not recommended anymore. However, we have some issues
-# I couldn't figure out and this flag solves them. The flag will be
-# removed in Django 5.0 so this is not a proper fix and we should
-# figure out how to fix the issues properly.
-USE_DEPRECATED_PYTZ = True
-
 # local_settings.py can be used to override environment-specific settings
 # like database and email that differ between development and production.
 local_settings_path = os.path.join(BASE_DIR, "local_settings.py")


### PR DESCRIPTION
## Change log
- Removed deprecated timezone handlings
- Removed USE_DEPRECATED_PYTZ settings. Not needed anymore.

## Other notes
We still had places where pytz library was used to handle timezones. This causes problems and confusing behaviour with the new Python version so I fixed all of them.

I also removed USE_DEPRECATED_PYTZ setting because it is not needed anymore.


## Deployment reminder
- No changes required