### PR TITLE
TILA-2519 | Modify reservation handling permission

### DIFF
--- a/api/graphql/reservations/reservation_mutations.py
+++ b/api/graphql/reservations/reservation_mutations.py
@@ -35,6 +35,7 @@ from permissions.api_permissions.graphene_permissions import (
     ReservationDenyPermission,
     ReservationHandlingPermission,
     ReservationPermission,
+    ReservationRefundPermission,
     ReservationStaffCreatePermission,
     StaffAdjustTimePermission,
 )
@@ -101,7 +102,7 @@ class ReservationDenyMutation(AuthSerializerMutation, SerializerMutation):
 
 
 class ReservationRefundMutation(AuthSerializerMutation, SerializerMutation):
-    permission_classes = (ReservationHandlingPermission,)
+    permission_classes = (ReservationRefundPermission,)
 
     class Meta:
         lookup_field = "pk"

--- a/permissions/api_permissions/graphene_permissions.py
+++ b/permissions/api_permissions/graphene_permissions.py
@@ -354,7 +354,11 @@ class ReservationHandlingPermission(BasePermission):
         pk = input.get("pk")
         if pk:
             reservation = get_object_or_404(Reservation, pk=pk)
-            return can_handle_reservation(info.context.user, reservation)
+            user = info.context.user
+            return can_handle_reservation(user, reservation) or (
+                can_create_staff_reservation(user, reservation.reservation_unit.all())
+                and reservation.user == user
+            )
         return False
 
 
@@ -369,6 +373,16 @@ class ReservationDenyPermission(BasePermission):
                 can_create_staff_reservation(user, reservation.reservation_unit.all())
                 and reservation.user == user
             )
+        return False
+
+
+class ReservationRefundPermission(BasePermission):
+    @classmethod
+    def has_mutation_permission(cls, root: Any, info: ResolveInfo, input: dict) -> bool:
+        pk = input.get("pk")
+        if pk:
+            reservation = get_object_or_404(Reservation, pk=pk)
+            return can_handle_reservation(info.context.user, reservation)
         return False
 
 


### PR DESCRIPTION
## Change log
- Changes permission logic to handling permissions 
- Adds new mutation for refund mutation - it works as was previous mutation


## Other notes
This makes possible for reserver role staff user to perform handling permission based mutations to own reservations.

Within this change refund permission is introduced like the handling was originally working => so refund permissions are not changed but only the Approve and RequiresHandling


Refs TILA-2519