### PR TITLE
TILA-2608: Add is_handled field to ReservationType

### DIFF
--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -170,6 +170,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     reservee_is_unregistered_association = graphene.Boolean()
     applying_for_free_of_charge = graphene.Boolean()
     price_net = graphene.Decimal()
+    is_handled = graphene.Boolean()
 
     class Meta:
         model = Reservation
@@ -222,6 +223,7 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
             "order_status",
             "handled_at",
             "refund_uuid",
+            "is_handled",
         ]
         filter_fields = {
             "state": ["exact"],
@@ -433,6 +435,10 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     @reservation_non_public_field
     def resolve_tax_percentage_value(self, info: ResolveInfo) -> Optional[Decimal]:
         return self.tax_percentage_value
+
+    @reservation_non_public_field
+    def resolve_is_handled(self, info: ResolveInfo) -> Optional[bool]:
+        return self.handled_at is not None
 
 
 class ReservationCancelReasonType(AuthNode, PrimaryKeyObjectType):

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -567,6 +567,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission 1'] = {
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'movies',
                         'numPersons': None,
                         'orderStatus': None,
@@ -629,6 +630,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'admin movies',
                         'numPersons': None,
                         'orderStatus': None,
@@ -681,6 +683,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_admin 1'] 
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'movies',
                         'numPersons': None,
                         'orderStatus': None,
@@ -743,6 +746,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'admin movies',
                         'numPersons': None,
                         'orderStatus': None,
@@ -795,6 +799,7 @@ snapshots['ReservationQueryTestCase::test_filter_only_with_permission_unit_group
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'movies',
                         'numPersons': None,
                         'orderStatus': None,
@@ -994,6 +999,7 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'end': '2021-10-12T13:00:00+00:00',
                         'freeOfChargeReason': None,
                         'homeCity': None,
+                        'isHandled': None,
                         'name': None,
                         'numPersons': None,
                         'orderStatus': None,
@@ -1042,6 +1048,7 @@ snapshots['ReservationQueryTestCase::test_hide_fields_with_personal_information 
                         'homeCity': {
                             'name': 'Test'
                         },
+                        'isHandled': False,
                         'name': 'movies',
                         'numPersons': None,
                         'orderStatus': None,


### PR DESCRIPTION
## Change log
- Added `is_handled` field to `ReservationType`
- Updated tests

## Deployment reminder
- No changes required