### PR TITLE
TILA-2644 | Use correct model in ApplicationEventFilterSet class

### DIFF
--- a/api/graphql/applications/application_filtersets.py
+++ b/api/graphql/applications/application_filtersets.py
@@ -159,8 +159,11 @@ class ApplicationEventFilterSet(filters.FilterSet):
     )
 
     class Meta:
-        model = Application
-        fields = ("application_round", "status", "unit", "user")
+        model = ApplicationEvent
+        fields = (
+            "pk",
+            "status",
+        )
 
     def filter_queryset(self, queryset):
         queryset = queryset.alias(

--- a/api/graphql/tests/test_application_events/test_application_events_query.py
+++ b/api/graphql/tests/test_application_events/test_application_events_query.py
@@ -201,6 +201,11 @@ class ApplicationEventQueryTestCase(ApplicationEventTestCaseBase):
             application=self.application, name="Only I should be listed"
         )
         event.set_status(ApplicationEventStatus.APPROVED)
+        another = ApplicationEventFactory(
+            application=self.application, name="Do not show me ever never ikinä"
+        )
+        another.set_status(ApplicationEventStatus.RESERVED)
+
         filter_clause = f'status: "{ApplicationEventStatus.APPROVED}"'
 
         response = self.query(self.get_query(filter_section=filter_clause))


### PR DESCRIPTION
## Change log
- Changes `ApplicationEvent` as model for the `ApplicationEventFilterSet` class.

## Other notes
This filterset class was using wrong class (Application) and caused oddities.

Refs TILA-2644