### PR TITLE
TILA-2637 | Modify comment permissions to allow staff reserver comment its own reservations

### DIFF
--- a/api/graphql/tests/base.py
+++ b/api/graphql/tests/base.py
@@ -11,6 +11,7 @@ from permissions.models import (
     UnitRoleChoice,
     UnitRolePermission,
 )
+from spaces.models import Unit
 from spaces.tests.factories import ServiceSectorFactory, UnitFactory, UnitGroupFactory
 
 
@@ -113,3 +114,30 @@ class GrapheneTestCaseBase(GraphQLTestCase):
         unit_role.unit_group.add(unit_group)
 
         return unit_group_admin
+
+    def create_staff_reserver_for_unit(self, unit: Unit = None):
+        reserver_staff_user = get_user_model().objects.create(
+            username="res",
+            first_name="res",
+            last_name="erver",
+            email="res.erver@foo.com",
+        )
+        UnitRoleChoice.objects.create(
+            code="staff",
+            verbose_name="staff reserver person",
+        )
+        unit_role = UnitRole.objects.create(
+            user=reserver_staff_user,
+            role=UnitRoleChoice.objects.get(code="staff"),
+        )
+        UnitRolePermission.objects.create(
+            role=UnitRoleChoice.objects.get(code="staff"),
+            permission="can_create_staff_reservations",
+        )
+
+        if not unit:
+            unit = UnitFactory()
+
+        unit_role.unit.add(unit)
+
+        return reserver_staff_user

--- a/api/graphql/tests/test_reservations/test_reservation_working_memo_update.py
+++ b/api/graphql/tests/test_reservations/test_reservation_working_memo_update.py
@@ -7,7 +7,17 @@ from django.contrib.auth import get_user_model
 from django.utils.timezone import get_default_timezone
 
 from api.graphql.tests.test_reservations.base import ReservationTestCaseBase
-from permissions.models import GeneralRole, GeneralRoleChoice, GeneralRolePermission
+from permissions.models import (
+    GeneralRole,
+    GeneralRoleChoice,
+    GeneralRolePermission,
+    ServiceSectorRole,
+    ServiceSectorRoleChoice,
+    ServiceSectorRolePermission,
+    UnitRole,
+    UnitRoleChoice,
+    UnitRolePermission,
+)
 from reservations.models import STATE_CHOICES
 from reservations.tests.factories import ReservationFactory
 
@@ -63,7 +73,7 @@ class ReservationWorkingMemoWriteTestCase(ReservationTestCaseBase):
             input_data["workingMemo"]
         )
 
-    def test_working_memo_saves_with_comment_permission(self):
+    def test_working_memo_saves_with_general_comment_permission(self):
         commenter = get_user_model().objects.create(
             username="commenter",
             first_name="Comm",
@@ -82,6 +92,79 @@ class ReservationWorkingMemoWriteTestCase(ReservationTestCaseBase):
             user=commenter,
             role=comment_role_choice,
         )
+
+        self.client.force_login(commenter)
+        input_data = self.get_valid_update_data()
+
+        response = self.query(self.get_update_memo_query(), input_data=input_data)
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        confirm_data = content.get("data").get("updateReservationWorkingMemo")
+        assert_that(confirm_data.get("errors")).is_none()
+        assert_that(confirm_data.get("workingMemo")).is_equal_to(
+            input_data["workingMemo"]
+        )
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.working_memo).is_equal_to(
+            input_data["workingMemo"]
+        )
+
+    def test_working_memo_saves_with_service_sector_comment_permission(self):
+        commenter = get_user_model().objects.create(
+            username="commenter",
+            first_name="Comm",
+            last_name="Enter",
+            email="commenter@foo.com",
+        )
+
+        comment_role_choice = ServiceSectorRoleChoice.objects.create(
+            code="can_comment_reservations"
+        )
+
+        ServiceSectorRolePermission.objects.create(
+            role=comment_role_choice, permission="can_comment_reservations"
+        )
+        ServiceSectorRole.objects.create(
+            user=commenter, role=comment_role_choice, service_sector=self.service_sector
+        )
+
+        self.client.force_login(commenter)
+        input_data = self.get_valid_update_data()
+
+        response = self.query(self.get_update_memo_query(), input_data=input_data)
+        content = json.loads(response.content)
+
+        assert_that(content.get("errors")).is_none()
+
+        confirm_data = content.get("data").get("updateReservationWorkingMemo")
+        assert_that(confirm_data.get("errors")).is_none()
+        assert_that(confirm_data.get("workingMemo")).is_equal_to(
+            input_data["workingMemo"]
+        )
+        self.reservation.refresh_from_db()
+        assert_that(self.reservation.working_memo).is_equal_to(
+            input_data["workingMemo"]
+        )
+
+    def test_working_memo_saves_with_unit_comment_permission(self):
+        commenter = get_user_model().objects.create(
+            username="commenter",
+            first_name="Comm",
+            last_name="Enter",
+            email="commenter@foo.com",
+        )
+
+        comment_role_choice = UnitRoleChoice.objects.create(
+            code="can_comment_reservations"
+        )
+
+        UnitRolePermission.objects.create(
+            role=comment_role_choice, permission="can_comment_reservations"
+        )
+        u_role = UnitRole.objects.create(user=commenter, role=comment_role_choice)
+        u_role.unit.add(self.unit)
 
         self.client.force_login(commenter)
         input_data = self.get_valid_update_data()

--- a/permissions/helpers.py
+++ b/permissions/helpers.py
@@ -342,8 +342,15 @@ def can_handle_reservation(user: User, reservation: Reservation) -> bool:
 
 
 def can_comment_reservation(user: User, reservation: Reservation) -> bool:
+    permission = "can_comment_reservations"
+    units = Unit.objects.filter(reservationunit__in=reservation.reservation_unit.all())
+    service_sectors = ServiceSector.objects.filter(units__in=units)
+
     return (
-        has_general_permission(user, "can_comment_reservations")
+        is_superuser(user)
+        or has_general_permission(user, permission)
+        or has_service_sector_permission(user, service_sectors, permission)
+        or has_unit_permission(user, units, permission)
         or can_handle_reservation(user, reservation)
         or (user.has_staff_permissions and reservation.user == user)
     )

--- a/permissions/helpers.py
+++ b/permissions/helpers.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from typing import Iterable, List, Optional, Union
 
-from django.contrib.auth.models import User
 from django.db.models import Q, QuerySet
 from django.utils import timezone
 
@@ -10,6 +9,7 @@ from merchants.models import PaymentOrder
 from reservation_units.models import ReservationUnit
 from reservations.models import RecurringReservation, Reservation
 from spaces.models import ServiceSector, Unit, UnitGroup
+from users.models import User
 
 
 def is_superuser(user: User) -> bool:
@@ -342,9 +342,11 @@ def can_handle_reservation(user: User, reservation: Reservation) -> bool:
 
 
 def can_comment_reservation(user: User, reservation: Reservation) -> bool:
-    return has_general_permission(
-        user, "can_comment_reservations"
-    ) or can_handle_reservation(user, reservation)
+    return (
+        has_general_permission(user, "can_comment_reservations")
+        or can_handle_reservation(user, reservation)
+        or (user.has_staff_permissions and reservation.user == user)
+    )
 
 
 def can_handle_reservation_with_units(


### PR DESCRIPTION
## Change log
- Modify can_comment_reservation permission helper to allow staff reserver to comment/save working memo for them own reservations
- Check service sector and unit permissions in `can_comment_reservation` permission

Refs TILA-2637 TILA-2592