### PR TITLE
TILA-2628: Ignore blocked reservations when buffers are checked

### DIFF
--- a/api/graphql/reservations/reservation_serializers/create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/create_serializers.py
@@ -182,10 +182,13 @@ class ReservationCreateSerializer(
 
         sku = None
         for reservation_unit in reservation_units:
+            reservation_type = data.get("type", getattr(self.instance, "type", None))
             self.check_reservation_time(reservation_unit)
             self.check_reservation_overlap(reservation_unit, begin, end)
             self.check_reservation_duration(reservation_unit, begin, end)
-            self.check_buffer_times(reservation_unit, begin, end)
+            self.check_buffer_times(
+                reservation_unit, begin, end, reservation_type=reservation_type
+            )
             self.check_reservation_days_before(begin, reservation_unit)
             self.check_max_reservations_per_user(
                 self.context.get("request").user, reservation_unit

--- a/api/graphql/reservations/reservation_serializers/staff_create_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/staff_create_serializers.py
@@ -164,8 +164,11 @@ class ReservationStaffCreateSerializer(
         self.check_begin(begin, end)
 
         for reservation_unit in reservation_units:
+            reservation_type = data.get("type", getattr(self.instance, "type", None))
             self.check_reservation_overlap(reservation_unit, begin, end)
-            self.check_buffer_times(reservation_unit, begin, end)
+            self.check_buffer_times(
+                reservation_unit, begin, end, reservation_type=reservation_type
+            )
             self.check_reservation_intervals_for_staff_reservation(
                 reservation_unit, begin
             )

--- a/api/graphql/reservations/reservation_serializers/staff_reservation_modify_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/staff_reservation_modify_serializers.py
@@ -177,8 +177,11 @@ class StaffReservationModifySerializer(
         end = data.get("end", self.instance.end)
 
         for reservation_unit in self.instance.reservation_unit.all():
+            reservation_type = data.get("type", getattr(self.instance, "type", None))
             self.check_reservation_overlap(reservation_unit, begin, end)
-            self.check_buffer_times(reservation_unit, begin, end)
+            self.check_buffer_times(
+                reservation_unit, begin, end, reservation_type=reservation_type
+            )
             self.check_reservation_intervals_for_staff_reservation(
                 reservation_unit, begin
             )

--- a/api/graphql/reservations/reservation_types.py
+++ b/api/graphql/reservations/reservation_types.py
@@ -162,7 +162,6 @@ class ReservationType(AuthNode, PrimaryKeyObjectType):
     buffer_time_before = Duration()
     buffer_time_after = Duration()
     staff_event = graphene.Boolean(deprecation_reason="Please refer to type.")
-    type = graphene.String()
     order_uuid = graphene.String()
     order_status = graphene.String()
     handled_at = graphene.DateTime()

--- a/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
+++ b/api/graphql/tests/test_reservations/snapshots/snap_test_reservation_queries.py
@@ -936,7 +936,7 @@ snapshots['ReservationQueryTestCase::test_getting_reservation_with_fields_requir
                     'node': {
                         'name': 'movies',
                         'staffEvent': False,
-                        'type': 'normal'
+                        'type': 'NORMAL'
                     }
                 }
             ],

--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -604,8 +604,13 @@ class ReservationUnit(ExportModelOperationsMixin("reservation_unit"), models.Mod
 
         return qs.exists()
 
-    def get_next_reservation(self, end_time: datetime.datetime, reservation=None):
-        from reservations.models import STATE_CHOICES, Reservation
+    def get_next_reservation(
+        self,
+        end_time: datetime.datetime,
+        reservation=None,
+        exclude_blocked: bool = False,
+    ):
+        from reservations.models import STATE_CHOICES, Reservation, ReservationType
 
         qs = Reservation.objects.filter(
             reservation_unit__in=self.reservation_units_with_same_components,
@@ -615,10 +620,18 @@ class ReservationUnit(ExportModelOperationsMixin("reservation_unit"), models.Mod
         if reservation:
             qs = qs.exclude(id=reservation.id)
 
-        return qs.order_by("-begin").first()
+        if exclude_blocked:
+            qs = qs.exclude(type=ReservationType.BLOCKED)
 
-    def get_previous_reservation(self, start_time: datetime.datetime, reservation=None):
-        from reservations.models import STATE_CHOICES, Reservation
+        return qs.order_by("begin").first()
+
+    def get_previous_reservation(
+        self,
+        start_time: datetime.datetime,
+        reservation=None,
+        exclude_blocked: bool = False,
+    ):
+        from reservations.models import STATE_CHOICES, Reservation, ReservationType
 
         qs = Reservation.objects.filter(
             reservation_unit__in=self.reservation_units_with_same_components,
@@ -627,6 +640,9 @@ class ReservationUnit(ExportModelOperationsMixin("reservation_unit"), models.Mod
 
         if reservation:
             qs = qs.exclude(id=reservation.id)
+
+        if exclude_blocked:
+            qs = qs.exclude(type=ReservationType.BLOCKED)
 
         return qs.order_by("-end").first()
 

--- a/reservation_units/tests/test_reservation_unit.py
+++ b/reservation_units/tests/test_reservation_unit.py
@@ -1,0 +1,100 @@
+from datetime import datetime, timedelta, timezone
+
+from assertpy import assert_that
+from django.test import TestCase
+from freezegun import freeze_time
+
+from reservation_units.models import ReservationUnit
+from reservation_units.tests.factories import ReservationUnitFactory
+from reservations.models import STATE_CHOICES, ReservationType
+from reservations.tests.factories import ReservationFactory
+from spaces.models import Space
+from spaces.tests.factories import SpaceFactory
+
+
+@freeze_time("2023-05-25 12:23:00")
+class GetPreviousReservationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.space: Space = SpaceFactory()
+        self.reservation_unit: ReservationUnit = ReservationUnitFactory(
+            spaces=[self.space]
+        )
+        self.now = datetime.now(tz=timezone.utc)
+        self.reservation_blocked = ReservationFactory(
+            begin=(self.now - timedelta(hours=2)),
+            end=(self.now - timedelta(hours=1)),
+            reservation_unit=[self.reservation_unit],
+            type=ReservationType.BLOCKED,
+            state=STATE_CHOICES.CONFIRMED,
+        )
+        self.reservation = ReservationFactory(
+            begin=(self.now - timedelta(hours=3)),
+            end=(self.now - timedelta(hours=2)),
+            reservation_unit=[self.reservation_unit],
+            state=STATE_CHOICES.CONFIRMED,
+        )
+
+    def test_get_previous_reservation(self):
+        previous_reservation = self.reservation_unit.get_previous_reservation(self.now)
+        assert_that(previous_reservation).is_not_none()
+        assert_that(previous_reservation.name).is_equal_to(
+            self.reservation_blocked.name
+        )
+
+    def test_get_previous_reservation_ignored_given_reservation(self):
+        previous_reservation = self.reservation_unit.get_previous_reservation(
+            self.now, reservation=self.reservation_blocked
+        )
+        assert_that(previous_reservation).is_not_none()
+        assert_that(previous_reservation.name).is_equal_to(self.reservation.name)
+
+    def test_get_previous_reservation_ignores_blocked(self):
+        previous_reservation = self.reservation_unit.get_previous_reservation(
+            self.now, exclude_blocked=True
+        )
+        assert_that(previous_reservation).is_not_none()
+        assert_that(previous_reservation.name).is_equal_to(self.reservation.name)
+
+
+@freeze_time("2023-05-25 12:23:00")
+class GetNextReservationTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.space: Space = SpaceFactory()
+        self.reservation_unit: ReservationUnit = ReservationUnitFactory(
+            spaces=[self.space]
+        )
+        self.now = datetime.now(tz=timezone.utc)
+        self.reservation_blocked = ReservationFactory(
+            begin=(self.now + timedelta(hours=1)),
+            end=(self.now + timedelta(hours=2)),
+            reservation_unit=[self.reservation_unit],
+            type=ReservationType.BLOCKED,
+            state=STATE_CHOICES.CONFIRMED,
+        )
+        self.reservation = ReservationFactory(
+            begin=(self.now + timedelta(hours=2)),
+            end=(self.now + timedelta(hours=3)),
+            reservation_unit=[self.reservation_unit],
+            state=STATE_CHOICES.CONFIRMED,
+        )
+
+    def test_get_next_reservation(self):
+        next_reservation = self.reservation_unit.get_next_reservation(self.now)
+        assert_that(next_reservation).is_not_none()
+        assert_that(next_reservation.name).is_equal_to(self.reservation_blocked.name)
+
+    def test_get_next_reservation_ignored_given_reservation(self):
+        next_reservation = self.reservation_unit.get_next_reservation(
+            self.now, reservation=self.reservation_blocked
+        )
+        assert_that(next_reservation).is_not_none()
+        assert_that(next_reservation.name).is_equal_to(self.reservation.name)
+
+    def test_get_next_reservation_ignores_blocked(self):
+        next_reservation = self.reservation_unit.get_next_reservation(
+            self.now, exclude_blocked=True
+        )
+        assert_that(next_reservation).is_not_none()
+        assert_that(next_reservation.name).is_equal_to(self.reservation.name)


### PR DESCRIPTION
## Change log
- Fixed a bug with `get_next_reservation`
- Ignore `BLOCKED` reservations when buffers are checked
- When BLOCKED reservation is created/updated, buffer check is skipped

## Deployment reminder
- No changes required