### PR TITLE
TILA-2662: Set authenticated user in create and update

### DIFF
--- a/api/applications_api/serializers.py
+++ b/api/applications_api/serializers.py
@@ -665,6 +665,8 @@ class ApplicationSerializer(serializers.ModelSerializer):
             request.user if request and request.user.is_authenticated else None
         )
 
+        validated_data["user"] = request_user
+
         billing_address_data = validated_data.pop("billing_address")
         if billing_address_data:
             billing_address = Address.objects.create(**billing_address_data)
@@ -697,6 +699,8 @@ class ApplicationSerializer(serializers.ModelSerializer):
         request_user = (
             request.user if request and request.user.is_authenticated else None
         )
+
+        validated_data["user"] = instance.user
 
         billing_address_data = validated_data.pop("billing_address", None)
         if billing_address_data:


### PR DESCRIPTION
## Change log
- Set user in `create` and `update` methods

## Other notes
In the REST API, creating and updating an application did not save the user. This is probably because of the updated `djangorestframework`. The simple fix was to just set it manually in create and update methods.

Would be really nice to get rid of these REST endpoints 😄 


## Deployment reminder
- No changes required