### PR TITLE
TILA-2618: Remove roles when user is anonymized

### DIFF
--- a/tilavarauspalvelu/tests/test_anonymization.py
+++ b/tilavarauspalvelu/tests/test_anonymization.py
@@ -14,6 +14,7 @@ from tilavarauspalvelu.utils.anonymisation import (
     anonymize_user_applications,
     anonymize_user_reservations,
 )
+from users.models import ReservationNotification
 
 
 class AnonymizationTestCase(TestCase):
@@ -24,6 +25,10 @@ class AnonymizationTestCase(TestCase):
             first_name="anony",
             last_name="mous",
             email="anony.mous@foo.com",
+            reservation_notification=ReservationNotification.ALL,
+            is_active=True,
+            is_superuser=True,
+            is_staff=True,
         )
         cls.reservation = ReservationFactory.create(
             user=cls.mr_anonymous,
@@ -58,6 +63,12 @@ class AnonymizationTestCase(TestCase):
             f"{self.mr_anonymous.first_name}.{self.mr_anonymous.last_name}@anonymized.net"
         )
         assert_that(self.mr_anonymous.uuid).is_not_equal_to(user_data["uuid"])
+        assert_that(self.mr_anonymous.reservation_notification).is_equal_to(
+            ReservationNotification.NONE
+        )
+        assert_that(self.mr_anonymous.is_active).is_false()
+        assert_that(self.mr_anonymous.is_superuser).is_false()
+        assert_that(self.mr_anonymous.is_staff).is_false()
 
     def test_application_anonymization(self):
         anonymize_user_applications(self.mr_anonymous)

--- a/tilavarauspalvelu/utils/anonymisation.py
+++ b/tilavarauspalvelu/utils/anonymisation.py
@@ -6,6 +6,7 @@ from auditlog.models import LogEntry
 
 from applications.models import Address, Application, ApplicationEvent, Person
 from reservations.models import Reservation, ReservationType
+from users.models import ReservationNotification
 
 FIRST_NAMES = [
     "Patrick",
@@ -77,6 +78,10 @@ def anonymize_user(user):
     user.uuid = uuid.uuid4()
     user.username = f"anonymized-{user.uuid}"
     user.date_of_birth = None
+    user.reservation_notification = ReservationNotification.NONE
+    user.is_active = False
+    user.is_superuser = False
+    user.is_staff = False
     user.save()
 
 

--- a/tilavarauspalvelu/utils/anonymisation.py
+++ b/tilavarauspalvelu/utils/anonymisation.py
@@ -5,6 +5,7 @@ from typing import Optional
 from auditlog.models import LogEntry
 
 from applications.models import Address, Application, ApplicationEvent, Person
+from permissions.models import GeneralRole, ServiceSectorRole, UnitRole
 from reservations.models import Reservation, ReservationType
 from users.models import ReservationNotification
 
@@ -83,6 +84,10 @@ def anonymize_user(user):
     user.is_superuser = False
     user.is_staff = False
     user.save()
+
+    GeneralRole.objects.filter(user=user).delete()
+    ServiceSectorRole.objects.filter(user=user).delete()
+    UnitRole.objects.filter(user=user).delete()
 
 
 def anonymize_user_reservations(user):


### PR DESCRIPTION
## Change log
- Disable special roles and notifications when user is anonymized
- Disable general, service sector and unit roles when user is anonymized

## Deployment reminder
- No changes required