### PR TITLE
TILA-2620: Fix reservation notification permissions

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_users.py
+++ b/api/graphql/tests/snapshots/snap_test_users.py
@@ -10,12 +10,12 @@ snapshots = Snapshot()
 snapshots['UserQueryTestCase::test_hide_reservation_notification_when_user_is_not_staff 1'] = {
     'data': {
         'currentUser': {
-            'email': 'non-staff.admin@foo.com',
-            'firstName': 'Non-Staff',
+            'email': 'joe.regularl@foo.com',
+            'firstName': 'joe',
             'isSuperuser': False,
-            'lastName': 'Admin',
+            'lastName': 'regular',
             'reservationNotification': None,
-            'username': 'non_staff_admin'
+            'username': 'regjoe'
         }
     }
 }
@@ -141,7 +141,7 @@ snapshots['UsersQueryTestCase::test_general_admin_can_read_other 1'] = {
             'firstName': 'Non-Staff',
             'isSuperuser': False,
             'lastName': 'Admin',
-            'reservationNotification': None,
+            'reservationNotification': 'only_handling_required',
             'username': 'non_staff_admin'
         }
     }
@@ -194,7 +194,7 @@ snapshots['UsersQueryTestCase::test_service_sector_admin_can_read_other 1'] = {
             'firstName': 'Non-Staff',
             'isSuperuser': False,
             'lastName': 'Admin',
-            'reservationNotification': None,
+            'reservationNotification': 'only_handling_required',
             'username': 'non_staff_admin'
         }
     }
@@ -207,7 +207,7 @@ snapshots['UsersQueryTestCase::test_unit_admin_can_read_other 1'] = {
             'firstName': 'Non-Staff',
             'isSuperuser': False,
             'lastName': 'Admin',
-            'reservationNotification': None,
+            'reservationNotification': 'only_handling_required',
             'username': 'non_staff_admin'
         }
     }

--- a/api/graphql/tests/test_users.py
+++ b/api/graphql/tests/test_users.py
@@ -96,8 +96,8 @@ class UserQueryTestCase(UserTestCaseBase):
         self.assertMatchSnapshot(content)
 
     def test_hide_reservation_notification_when_user_is_not_staff(self):
-        assert_that(self.non_staff_user.is_staff).is_false()
-        self.client.force_login(self.non_staff_user)
+        assert_that(self.regular_joe.has_staff_permissions).is_false()
+        self.client.force_login(self.regular_joe)
         response = self.make_user_query()
 
         assert_that(response.status_code).is_equal_to(200)

--- a/api/graphql/users/user_types.py
+++ b/api/graphql/users/user_types.py
@@ -43,7 +43,7 @@ class UserType(AuthNode, PrimaryKeyObjectType):
         connection_class = TilavarausBaseConnection
 
     def resolve_reservation_notification(self, info: graphene.ResolveInfo):
-        if self.is_staff:
+        if self.has_staff_permissions:
             return self.reservation_notification
         return None
 

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -935,6 +935,9 @@ def staff_user():
         reservation_notification=ReservationNotification.ALL,
     )
 
+    general_role_choice = GeneralRoleChoice.objects.create(code="general_role")
+    GeneralRole.objects.create(role=general_role_choice, user=user)
+
     return user
 
 

--- a/api/tests/test_users_api.py
+++ b/api/tests/test_users_api.py
@@ -73,16 +73,6 @@ def test_normal_user_does_not_see_notification_field(user_api_client):
     assert response.data[0]["reservation_notification"] is None
 
 
-def test_non_staff_admin_does_not_see_notification_field(general_admin_api_client):
-    response = general_admin_api_client.get(
-        reverse("user-list"),
-        format="json",
-    )
-
-    assert response.status_code == 200
-    assert response.data[0]["reservation_notification"] is None
-
-
 def test_staff_user_sees_notification_field(staff_user_api_client):
     response = staff_user_api_client.get(
         reverse("user-list"),

--- a/api/users_api.py
+++ b/api/users_api.py
@@ -73,7 +73,7 @@ class UserSerializer(TranslatedModelSerializer):
         }
 
     def get_reservation_notification(self, user) -> Optional[str]:
-        if user.is_staff:
+        if user.has_staff_permissions:
             return user.reservation_notification
         return None
 


### PR DESCRIPTION
## Change log
- Fixed the logic with `get_reservation_notification`
- Updated tests

## Other notes
We need to use `has_staff_permissions` instead of `is_staff`. Thise caused some changes to test data as well. It is actually a bit confusing that we have the `is_staff` flag but we an alternative definition for `staff_permissions`.


## Deployment reminder
- No changes required