### PR TITLE
TILA-2410 - Small tweaks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,9 @@ CONN_MAX_AGE=0
 # Django setting: prepended to CSRF_COOKIE_NAME and SESSION_COOKIE_NAME
 COOKIE_PREFIX=tilavarauspalvelu
 
+# Session cookie domain if Django's default behavior needs to be overridden
+# SESSION_COOKIE_DOMAIN=local-tilavaraus.hel.fi
+
 # Django INTERNAL_IPS setting allows some debugging aids for the addresses
 # specified here
 # DJango setting: INTERNAL_IPS https://docs.djangoproject.com/en/3.0/ref/settings/#internal-ips

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ celerybeat-schedule
 .tox
 coverage.xml
 celery.exchange
+celery.pidbox.exchange

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -246,6 +246,7 @@ env = environ.Env(
     REDIS_SENTINEL_SERVICE=(str, None),
     REDIS_URL=(str, None),
     REDIS_PASSWORD=(str, None),
+    SESSION_COOKIE_DOMAIN=(str, None),
     # Elasticsearch
     ELASTICSEARCH_URL=(str, "http://localhost:9200"),
     # Image cache
@@ -465,6 +466,7 @@ LOGOUT_REDIRECT_URL = "/admin/"
 SESSION_SERIALIZER = "django.contrib.sessions.serializers.PickleSerializer"
 SESSION_COOKIE_AGE = 12 * 60 * 60  # 12 hours in seconds
 SESSION_COOKIE_SECURE = True
+SESSION_COOKIE_DOMAIN = env("SESSION_COOKIE_DOMAIN")
 
 OIDC_API_TOKEN_AUTH = {
     "AUDIENCE": env("TUNNISTAMO_JWT_AUDIENCE"),


### PR DESCRIPTION
## Change log
- Added `celery.pidbox.exchange` to `.gitignore`
- Added `SESSION_COOKIE_DOMAIN`

# Notes
This PR used to be about file upload, but yesterday we agreed that we just keep the CSRF-token disabled, because there is no easy way to make it work and with the limited time we have, we can't focus on figuring out how to make it work on both frontend and backend.

So, now it is just about small tweaks.

## Deployment reminder
- No changes required