### PR TITLE
TILA-2670: Allow buffer modifications

### DIFF
--- a/api/graphql/reservations/reservation_serializers/mixins.py
+++ b/api/graphql/reservations/reservation_serializers/mixins.py
@@ -308,10 +308,12 @@ class ReservationSchedulingMixin:
 
     def check_buffer_times(
         self,
-        reservation_unit,
+        reservation_unit: ReservationUnit,
         begin,
         end,
         reservation_type: Optional[ReservationType] = None,
+        buffer_before: Optional[datetime.timedelta] = None,
+        buffer_after: Optional[datetime.timedelta] = None,
     ):
 
         current_type = getattr(self.instance, "type", reservation_type)
@@ -325,29 +327,31 @@ class ReservationSchedulingMixin:
             begin, self.instance, exclude_blocked=True
         )
 
-        buffer_before = max(
-            [
-                buffer
-                for buffer in (
-                    getattr(reservation_before, "buffer_time_after", None),
-                    reservation_unit.buffer_time_before,
-                )
-                if buffer
-            ],
-            default=None,
-        )
+        if not buffer_before:
+            buffer_before = max(
+                [
+                    buffer
+                    for buffer in (
+                        getattr(reservation_before, "buffer_time_after", None),
+                        reservation_unit.buffer_time_before,
+                    )
+                    if buffer
+                ],
+                default=None,
+            )
 
-        buffer_after = max(
-            [
-                buffer
-                for buffer in (
-                    getattr(reservation_after, "buffer_time_before", None),
-                    reservation_unit.buffer_time_after,
-                )
-                if buffer
-            ],
-            default=None,
-        )
+        if not buffer_after:
+            buffer_after = max(
+                [
+                    buffer
+                    for buffer in (
+                        getattr(reservation_after, "buffer_time_before", None),
+                        reservation_unit.buffer_time_after,
+                    )
+                    if buffer
+                ],
+                default=None,
+            )
 
         if (
             reservation_before

--- a/api/graphql/reservations/reservation_serializers/staff_adjust_time_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/staff_adjust_time_serializers.py
@@ -24,6 +24,8 @@ class StaffReservationAdjustTimeSerializer(
             "begin",
             "end",
             "state",
+            "buffer_time_before",
+            "buffer_time_after",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/api/graphql/reservations/reservation_serializers/staff_adjust_time_serializers.py
+++ b/api/graphql/reservations/reservation_serializers/staff_adjust_time_serializers.py
@@ -53,9 +53,18 @@ class StaffReservationAdjustTimeSerializer(
         begin = data["begin"]
         end = data["end"]
 
+        new_buffer_before = data.get("buffer_time_before", None)
+        new_buffer_after = data.get("buffer_time_after", None)
+
         for reservation_unit in self.instance.reservation_unit.all():
             self.check_reservation_overlap(reservation_unit, begin, end)
-            self.check_buffer_times(reservation_unit, begin, end)
+            self.check_buffer_times(
+                reservation_unit,
+                begin,
+                end,
+                buffer_before=new_buffer_before,
+                buffer_after=new_buffer_after,
+            )
             self.check_reservation_intervals_for_staff_reservation(
                 reservation_unit, begin
             )


### PR DESCRIPTION
## Change log
- Updated `staffAdjustReservationTime` mutation to allow buffer modifications
- Added a new test

## Other notes
I'm still wondering if we need to add some additional validations for the new "buffer zones" 🤔 

## Deployment reminder
- No changes required