### PR TITLE
TILA-2679 | Deny user data delete through gdpr api when there's reservations in one month backwards

### DIFF
--- a/api/gdpr.py
+++ b/api/gdpr.py
@@ -1,3 +1,4 @@
+from dateutil.relativedelta import relativedelta
 from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.shortcuts import get_object_or_404
@@ -34,10 +35,10 @@ class TilavarauspalveluGDPRAPIView(GDPRAPIView):
         anonymize_user_data(profile_user.user)
 
     def _check_user_can_be_anonymized(self, user):
-        now = timezone.now()
+        month_ago = timezone.now() - relativedelta(months=1)
 
         has_open_reservations = (
-            user.reservation_set.filter(end__gte=now)
+            user.reservation_set.filter(end__gte=month_ago)
             .exclude(state__in=[ReservationState.CANCELLED, ReservationState.DENIED])
             .exists()
         )

--- a/api/models.py
+++ b/api/models.py
@@ -28,6 +28,8 @@ class ProfileUser(SerializableMixin):
                 [
                     res.name,
                     res.description,
+                    res.begin,
+                    res.end,
                     res.reservee_first_name,
                     res.reservee_last_name,
                     res.reservee_email,
@@ -56,7 +58,8 @@ class ProfileUser(SerializableMixin):
         applications = []
 
         for app in self.user.application_set.all():
-            applications.append(app.additional_information)
+            app_data = []
+            app_data.append(app.additional_information)
 
             events = []
             for e in app.application_events.all():
@@ -64,10 +67,10 @@ class ProfileUser(SerializableMixin):
                 events.append(e.name_fi)
                 events.append(e.name_en)
                 events.append(e.name_sv)
-            applications.append({"events": events})
+            app_data.append({"events": events})
 
             if app.contact_person:
-                applications.append(
+                app_data.append(
                     {
                         "contact_person": [
                             app.contact_person.first_name,
@@ -79,7 +82,7 @@ class ProfileUser(SerializableMixin):
                 )
 
             if app.organisation:
-                applications.append(
+                app_data.append(
                     {
                         "organisation": [
                             app.organisation.name,
@@ -94,7 +97,7 @@ class ProfileUser(SerializableMixin):
                 )
 
             if app.organisation and app.organisation.address:
-                applications.append(
+                app_data.append(
                     {
                         "organisation_address": [
                             app.organisation.address.post_code,
@@ -111,7 +114,7 @@ class ProfileUser(SerializableMixin):
                 )
 
             if app.billing_address:
-                applications.append(
+                app_data.append(
                     {
                         "billing_address": [
                             app.billing_address.post_code,
@@ -126,6 +129,7 @@ class ProfileUser(SerializableMixin):
                         ]
                     }
                 )
+            applications.append(app_data)
 
         return applications
 

--- a/api/tests/test_gdpr/test_gdpr_api.py
+++ b/api/tests/test_gdpr/test_gdpr_api.py
@@ -18,8 +18,11 @@ from api.tests.test_gdpr.gdpr_key import rsa_key
 from applications.models import ApplicationStatus
 from applications.tests.factories import (
     AddressFactory,
+    ApplicationEventFactory,
     ApplicationFactory,
     ApplicationStatusFactory,
+    OrganisationFactory,
+    PersonFactory,
 )
 from merchants.models import OrderStatus
 from merchants.tests.factories import PaymentOrderFactory
@@ -47,9 +50,53 @@ class TilavarauspalveluGDPRAPIViewTestCase(APITestCase):
             last_name="regular",
             email="joe.regular@foo.com",
         )
-        ReservationFactory(user=cls.user)
-        billing_address = AddressFactory()
-        ApplicationFactory(user=cls.user, billing_address=billing_address)
+        begin = datetime.datetime.now(get_default_timezone()) - relativedelta(months=2)
+        end = begin + relativedelta(hours=2)
+        cls.reservation = ReservationFactory(
+            user=cls.user,
+            name="anonymizable reservation",
+            description="anonymizable reservation description",
+            begin=begin,
+            end=end,
+            reservee_first_name="Test",
+            reservee_last_name="Person",
+            reservee_email="test.person@localhost",
+            reservee_phone="123445",
+            reservee_address_zip="00020",
+            reservee_address_city="TheCity",
+            reservee_address_street="test street 1",
+            billing_first_name="Test",
+            billing_last_name="person",
+            billing_email="test.person@localhost",
+            billing_phone="123445",
+            billing_address_zip="00020",
+            billing_address_city="TheCity",
+            billing_address_street="billing street 2",
+            reservee_id="65432",
+            reservee_organisation_name="Organisation name",
+            free_of_charge_reason="I'm obliged",
+            cancel_details="I don't need the space",
+        )
+        cls.application = ApplicationFactory(
+            user=cls.user,
+            additional_information="something to take into consideration",
+            billing_address=AddressFactory(),
+            contact_person=PersonFactory(
+                first_name="Test",
+                last_name="Person",
+                email="contact.person@localhost",
+                phone_number="12434",
+            ),
+            organisation=OrganisationFactory(address=AddressFactory()),
+        )
+        cls.application_event = ApplicationEventFactory(
+            application=cls.application,
+            name="app event name",
+            name_fi="app event name fi",
+            name_en="app event name en",
+            name_sv="app event name sv",
+        )
+
         cls.url = reverse("gdpr_v1", kwargs={"uuid": cls.user.uuid})
 
     def setUp(self) -> None:
@@ -107,6 +154,116 @@ class TilavarauspalveluGDPRAPIViewTestCase(APITestCase):
         response = self.client.get(self.url)
         assert_that(response.status_code).is_equal_to(200)
         assert_that(response.data["children"][0]["value"]).is_not_empty()
+
+    @requests_mock.Mocker()
+    def test_get_user_data_returns_reservations(self, req_mock):
+        auth_header = self.get_auth_header(
+            self.user, [settings.GDPR_API_QUERY_SCOPE], req_mock
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION=auth_header)
+        response = self.client.get(self.url)
+        assert_that(response.status_code).is_equal_to(200)
+        for r in [
+            d for d in response.data["children"] if d.get("key") == "RESERVATIONS"
+        ]:
+            res_data = r["value"][0]
+            expected = [
+                self.reservation.name,
+                self.reservation.description,
+                self.reservation.begin,
+                self.reservation.end,
+                self.reservation.reservee_first_name,
+                self.reservation.reservee_last_name,
+                self.reservation.reservee_email,
+                self.reservation.reservee_phone,
+                self.reservation.reservee_address_zip,
+                self.reservation.reservee_address_city,
+                self.reservation.reservee_address_street,
+                self.reservation.billing_first_name,
+                self.reservation.billing_last_name,
+                self.reservation.billing_email,
+                self.reservation.billing_phone,
+                self.reservation.billing_address_zip,
+                self.reservation.billing_address_city,
+                self.reservation.billing_address_street,
+                self.reservation.reservee_id,
+                self.reservation.reservee_organisation_name,
+                self.reservation.free_of_charge_reason,
+                self.reservation.cancel_details,
+            ]
+            assert_that(res_data).is_equal_to(expected)
+
+    @requests_mock.Mocker()
+    def test_get_user_data_returns_applications(self, req_mock):
+        auth_header = self.get_auth_header(
+            self.user, [settings.GDPR_API_QUERY_SCOPE], req_mock
+        )
+
+        self.client.credentials(HTTP_AUTHORIZATION=auth_header)
+        response = self.client.get(self.url)
+        assert_that(response.status_code).is_equal_to(200)
+        for a in [
+            d for d in response.data["children"] if d.get("key") == "APPLICATIONS"
+        ]:
+            app_data = a["value"][0]
+            expected = [
+                self.application.additional_information,
+                {
+                    "events": [
+                        self.application_event.name,
+                        self.application_event.name_fi,
+                        self.application_event.name_en,
+                        self.application_event.name_sv,
+                    ]
+                },
+                {
+                    "contact_person": [
+                        self.application.contact_person.first_name,
+                        self.application.contact_person.last_name,
+                        self.application.contact_person.email,
+                        self.application.contact_person.phone_number,
+                    ]
+                },
+                {
+                    "organisation": [
+                        self.application.organisation.name,
+                        self.application.organisation.identifier,
+                        self.application.organisation.email,
+                        self.application.organisation.core_business,
+                        self.application.organisation.core_business_fi,
+                        self.application.organisation.core_business_en,
+                        self.application.organisation.core_business_sv,
+                    ]
+                },
+                {
+                    "organisation_address": [
+                        self.application.organisation.address.post_code,
+                        self.application.organisation.address.street_address,
+                        self.application.organisation.address.street_address_fi,
+                        self.application.organisation.address.street_address_en,
+                        self.application.organisation.address.street_address_sv,
+                        self.application.organisation.address.city,
+                        self.application.organisation.address.city_fi,
+                        self.application.organisation.address.city_en,
+                        self.application.organisation.address.city_sv,
+                    ]
+                },
+                {
+                    "billing_address": [
+                        self.application.billing_address.post_code,
+                        self.application.billing_address.street_address,
+                        self.application.billing_address.street_address_fi,
+                        self.application.billing_address.street_address_en,
+                        self.application.billing_address.street_address_sv,
+                        self.application.billing_address.city,
+                        self.application.billing_address.city_fi,
+                        self.application.billing_address.city_en,
+                        self.application.billing_address.city_sv,
+                    ]
+                },
+            ]
+            assert_that(app_data).is_equal_to(expected)
 
     @requests_mock.Mocker()
     def test_get_user_data_should_not_returns_not_found(self, req_mock):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 ignore = W503
-exclude = migrations,venv,build,api/examples.py,snapshots,.tox/
+exclude = migrations,venv,build,api/examples.py,snapshots,.tox,local_settings.py
 max-line-length = 120
 max-complexity = 10
 


### PR DESCRIPTION
## Change log
- Deny deleting user data through gdpr api when user has reservations one month backwards
- Add flake local_settings to flake ignore.
- Add reservation begin and end to gdpr output data
- Add tests for reservation and application data
- Change applications to be returned list inside a list rather than single list with all the application data.


Refs TILA-2679
