### PR TITLE
TILA-1321 | Create reservations as CONFIRMED from allocation results

### DIFF
--- a/api/tests/test_application_status_api.py
+++ b/api/tests/test_application_status_api.py
@@ -321,7 +321,7 @@ class ReservationCreationOnStatusCreationTestCase(ApplicationStatusBaseTestCase)
         ).order_by("begin")
         assert_that(reservations[0].state).is_equal_to(STATE_CHOICES.DENIED)
         for reservation in reservations[1:4]:
-            assert_that(reservation.state).is_equal_to(STATE_CHOICES.CREATED)
+            assert_that(reservation.state).is_equal_to(STATE_CHOICES.CONFIRMED)
 
     def test_reservation_gets_denied_status_if_unit_not_open(self, mock):
         mock.return_value.get_reservation_times_based_on_opening_hours.return_value = (

--- a/applications/tests/test_reservation_creation.py
+++ b/applications/tests/test_reservation_creation.py
@@ -22,7 +22,7 @@ from applications.utils.reservation_creation import (
 )
 from opening_hours.hours import TimeElement
 from reservation_units.tests.factories import ReservationUnitFactory
-from reservations.models import Reservation
+from reservations.models import STATE_CHOICES, Reservation
 from spaces.tests.factories import SpaceFactory
 from tilavarauspalvelu.utils.date_util import next_or_current_matching_weekday
 
@@ -251,6 +251,9 @@ class ReservationSchedulerTestCase(TestCase, DjangoTestCase):
     def test_creating_reservations(self, mock):
         create_reservations_from_allocation_results(self.application_event)
         assert_that(Reservation.objects.count()).is_equal_to(4)
+        assert_that(
+            list(Reservation.objects.values_list("state", flat=True))
+        ).is_equal_to([STATE_CHOICES.CONFIRMED for _ in range(4)])
 
     def test_creating_reservations_without_result(self, mock):
         self.result.delete()

--- a/applications/utils/reservation_creation.py
+++ b/applications/utils/reservation_creation.py
@@ -74,7 +74,7 @@ def create_reservation_from_schedule_result(result, application_event):
             reservation = Reservation.objects.create(
                 state=STATE_CHOICES.DENIED
                 if is_overlapping or is_unit_closed
-                else STATE_CHOICES.CREATED,
+                else STATE_CHOICES.CONFIRMED,
                 priority=result.application_event_schedule.priority,
                 user=application_event.application.user,
                 begin=start if not is_unit_closed else res_start,


### PR DESCRIPTION
## Change log
- Create reservations as CONFIRMED from allocation results

## Other notes
Previous was created as CREATED but those states gets deleted by the pruning task

Refs TILA-1321