### PR TITLE
TILA-2657: Add onlyWithPermission filter to spaces and resources queries

### DIFF
--- a/api/graphql/resources/resource_filtersets.py
+++ b/api/graphql/resources/resource_filtersets.py
@@ -1,0 +1,26 @@
+import django_filters
+
+from permissions.helpers import can_manage_resources, get_units_with_permission
+from spaces.models import Space
+
+
+class ResourceFilterSet(django_filters.FilterSet):
+    only_with_permission = django_filters.BooleanFilter(
+        method="get_only_with_permission"
+    )
+
+    def get_only_with_permission(self, qs, property, value):
+        """Returns resources where the user has resource management permissions"""
+        if not value:
+            return qs
+
+        user = self.request.user
+
+        if user.is_anonymous:
+            return qs.none()
+        elif user.is_superuser or can_manage_resources(user):
+            return qs
+
+        units = get_units_with_permission(user, "can_manage_resources")
+        spaces = Space.objects.filter(unit__in=units).distinct()
+        return qs.filter(space__in=spaces).distinct()

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -79,6 +79,7 @@ from api.graphql.reservations.reservation_types import (
     ReservationPurposeType,
     ReservationType,
 )
+from api.graphql.resources.resource_filtersets import ResourceFilterSet
 from api.graphql.resources.resource_mutations import (
     ResourceCreateMutation,
     ResourceDeleteMutation,
@@ -416,7 +417,7 @@ class Query(graphene.ObjectType):
         ReservationUnitTypeType, filterset_class=ReservationUnitTypeFilterSet
     )
 
-    resources = ResourcesFilter(ResourceType)
+    resources = ResourcesFilter(ResourceType, filterset_class=ResourceFilterSet)
     resource = relay.Node.Field(ResourceType)
     resource_by_pk = Field(ResourceType, pk=graphene.Int())
 

--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -85,6 +85,7 @@ from api.graphql.resources.resource_mutations import (
     ResourceUpdateMutation,
 )
 from api.graphql.resources.resource_types import ResourceType
+from api.graphql.spaces.space_filtersets import SpaceFilterSet
 from api.graphql.spaces.space_mutations import (
     SpaceCreateMutation,
     SpaceDeleteMutation,
@@ -427,7 +428,7 @@ class Query(graphene.ObjectType):
     equipment_category = relay.Node.Field((EquipmentCategoryType))
     equipment_category_by_pk = Field(EquipmentCategoryType, pk=graphene.Int())
 
-    spaces = SpacesFilter(SpaceType)
+    spaces = SpacesFilter(SpaceType, filterset_class=SpaceFilterSet)
     space = relay.Node.Field(SpaceType)
     space_by_pk = Field(SpaceType, pk=graphene.Int())
     service_sectors = ServiceSectorFilter(ServiceSectorType)

--- a/api/graphql/spaces/space_filtersets.py
+++ b/api/graphql/spaces/space_filtersets.py
@@ -1,0 +1,25 @@
+import django_filters
+from django.db.models import Q
+
+from permissions.helpers import can_manage_spaces, get_units_with_permission
+
+
+class SpaceFilterSet(django_filters.FilterSet):
+    only_with_permission = django_filters.BooleanFilter(
+        method="get_only_with_permission"
+    )
+
+    def get_only_with_permission(self, qs, property, value):
+        """Returns spaces where the user has space management permissions"""
+        if not value:
+            return qs
+
+        user = self.request.user
+
+        if user.is_anonymous:
+            return qs.none()
+        elif user.is_superuser or can_manage_spaces(user):
+            return qs
+
+        units = get_units_with_permission(user, "can_manage_spaces")
+        return qs.filter(Q(unit__in=units)).distinct()

--- a/api/graphql/tests/snapshots/snap_test_resources.py
+++ b/api/graphql/tests/snapshots/snap_test_resources.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
+
 snapshots = Snapshot()
 
 snapshots['ResourceGraphQLTestCase::test_getting_resources_with_null_buffer_times 1'] = {
@@ -18,10 +19,75 @@ snapshots['ResourceGraphQLTestCase::test_getting_resources_with_null_buffer_time
                         'locationType': 'FIXED',
                         'nameFi': 'Test resource',
                         'space': {
-                            'nameFi': 'Test space',
+                            'nameFi': 'Test space'
                         }
                     }
                 }
+            ]
+        }
+    }
+}
+
+snapshots['ResourceGraphQLTestCase::test_only_with_permission_with_service_sector_role 1'] = {
+    'data': {
+        'resources': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'i am from the sector!'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ResourceGraphQLTestCase::test_only_with_permission_with_unit_group_role 1'] = {
+    'data': {
+        'resources': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': "i'm from the unit group!"
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ResourceGraphQLTestCase::test_only_with_permission_with_unit_role 1'] = {
+    'data': {
+        'resources': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': "i'm from the unit!"
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ResourceGraphQLTestCase::test_only_with_permissions_with_general_role 1'] = {
+    'data': {
+        'resources': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'Test resource'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['ResourceGraphQLTestCase::test_only_with_permissions_with_no_permissions 1'] = {
+    'data': {
+        'resources': {
+            'edges': [
             ]
         }
     }

--- a/api/graphql/tests/snapshots/snap_test_spaces.py
+++ b/api/graphql/tests/snapshots/snap_test_spaces.py
@@ -7,6 +7,71 @@ from snapshottest import Snapshot
 
 snapshots = Snapshot()
 
+snapshots['SpacesQueryTestCase::test_only_with_permission_with_general_role 1'] = {
+    'data': {
+        'spaces': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'outerspace'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['SpacesQueryTestCase::test_only_with_permission_with_service_sector_role 1'] = {
+    'data': {
+        'spaces': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'i am from the sector!'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['SpacesQueryTestCase::test_only_with_permission_with_unit_group_role 1'] = {
+    'data': {
+        'spaces': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'i am from the unit group!'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['SpacesQueryTestCase::test_only_with_permission_with_unit_role 1'] = {
+    'data': {
+        'spaces': {
+            'edges': [
+                {
+                    'node': {
+                        'nameFi': 'i am from the unit!'
+                    }
+                }
+            ]
+        }
+    }
+}
+
+snapshots['SpacesQueryTestCase::test_only_with_permission_without_permissions 1'] = {
+    'data': {
+        'spaces': {
+            'edges': [
+            ]
+        }
+    }
+}
+
 snapshots['SpacesQueryTestCase::test_spaces_query 1'] = {
     'data': {
         'spaces': {


### PR DESCRIPTION
## Change log
- Added `onlyWithPermission` filter to `spaces` query
- Added `onlyWithPermission` filter to `resources` query
- Created unit tests covering different permission cases

## Other notes
This changes allows listing only spaces/resources that user can **modify**.

## Deployment reminder
- No changes required