### PR TITLE
TILA-2676: Add support for image cache and purging of individual images

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -283,3 +283,12 @@ VERKKOKAUPPA_ORDER_EXPIRATION_MINUTES=5
 
 # Redis cache URL
 REDIS_URL=redis://127.0.0.1:6379/0
+
+# Is image cache enalbed
+IMAGE_CACHE_ENABLED=False
+
+# Root url for cached images (where Varnish is located)
+IMAGE_CACHE_ROOT_URL=""
+
+# Secret key for purging images
+IMAGE_CACHE_PURGE_KEY=""

--- a/reservation_units/tasks.py
+++ b/reservation_units/tasks.py
@@ -16,6 +16,7 @@ from merchants.verkkokauppa.product.types import (
     CreateProductParams,
 )
 from tilavarauspalvelu.celery import app
+from utils.image_cache import purge
 
 from .pricing_updates import update_reservation_unit_pricings
 from .utils.reservation_unit_payment_helper import ReservationUnitPaymentHelper
@@ -136,3 +137,8 @@ def update_urls(pk: int = None):
 
         except InvalidImageFormatError as err:
             capture_exception(err)
+
+
+@app.task(name="purge_image_cache")
+def purge_image_cache(image_path: str):
+    purge(image_path)

--- a/reservation_units/tests/test_purpose.py
+++ b/reservation_units/tests/test_purpose.py
@@ -1,0 +1,32 @@
+from io import BytesIO
+from unittest import mock
+
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import override_settings
+from django.test.testcases import TestCase
+from easy_thumbnails.files import get_thumbnailer
+from PIL import Image
+
+from reservation_units.tests.factories import PurposeFactory
+
+
+class PurposeTestCase(TestCase):
+    @mock.patch("reservation_units.models.purge_image_cache.delay")
+    @override_settings(IMAGE_CACHE_ENABLED=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_image_purge_on_save(self, purge):
+        mock_image_data = BytesIO()
+        mock_image = Image.new("RGB", (100, 100))
+        mock_image.save(fp=mock_image_data, format="PNG")
+        mock_file = SimpleUploadedFile(
+            "image.png", mock_image_data.getvalue(), content_type="image/png"
+        )
+
+        purpose = PurposeFactory(name="test purpose", image=mock_file)
+        purpose.save()
+
+        aliases = settings.THUMBNAIL_ALIASES[""]
+        for conf_key in list(aliases.keys()):
+            image_path = get_thumbnailer(purpose.image)[conf_key].url
+            purge.assert_any_call(image_path)

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -248,6 +248,10 @@ env = environ.Env(
     REDIS_PASSWORD=(str, None),
     # Elasticsearch
     ELASTICSEARCH_URL=(str, "http://localhost:9200"),
+    # Image cache
+    IMAGE_CACHE_ENABLED=(bool, False),
+    IMAGE_CACHE_ROOT_URL=(str, ""),
+    IMAGE_CACHE_PURGE_KEY=(str, ""),
 )
 
 environ.Env.read_env()
@@ -553,6 +557,9 @@ THUMBNAIL_ALIASES = {
         "purpose_image": {"size": (390, 245), "crop": True},
     },
 }
+IMAGE_CACHE_ENABLED = env("IMAGE_CACHE_ENABLED")
+IMAGE_CACHE_ROOT_URL = env("IMAGE_CACHE_ROOT_URL")
+IMAGE_CACHE_PURGE_KEY = env("IMAGE_CACHE_PURGE_KEY")
 
 # Do not try to chmod when uploading images.
 # Our environments use persistent storage for media and operation will not be permitted.

--- a/utils/image_cache.py
+++ b/utils/image_cache.py
@@ -1,0 +1,35 @@
+from urllib.parse import urljoin
+
+from django.conf import settings
+from requests import request
+from sentry_sdk import capture_message
+
+
+class ImageCacheConfigurationError(Exception):
+    pass
+
+
+def purge(path: str) -> None:
+    if not settings.IMAGE_CACHE_ENABLED:
+        return
+
+    if not settings.IMAGE_CACHE_ROOT_URL or not settings.IMAGE_CACHE_PURGE_KEY:
+        raise ImageCacheConfigurationError(
+            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+        )
+
+    full_url = urljoin(settings.IMAGE_CACHE_ROOT_URL, path)
+
+    response = request(
+        "PURGE",
+        full_url,
+        headers={
+            "X-VC-Purge-Key": settings.IMAGE_CACHE_PURGE_KEY,
+        },
+    )
+
+    if response.status_code != 200:
+        capture_message(
+            f"Purging an image cache failed with status code {response.status_code}. Check image cache configuration.",
+            level="error",
+        )

--- a/utils/tests/test_image_cache.py
+++ b/utils/tests/test_image_cache.py
@@ -1,0 +1,59 @@
+from unittest import mock
+
+from assertpy import assert_that
+from django.test import override_settings
+from django.test.testcases import TestCase
+from pytest import raises
+
+from utils import image_cache
+
+
+@override_settings(
+    IMAGE_CACHE_ENABLED=True,
+    IMAGE_CACHE_ROOT_URL="https://test.url",
+    IMAGE_CACHE_PURGE_KEY="test-purge-key",
+)
+class ImageCacheTestCase(TestCase):
+    @override_settings(IMAGE_CACHE_ENABLED=False)
+    @mock.patch("utils.image_cache.urljoin")
+    def test_purge_no_action_if_disabled(self, urljoin):
+        image_cache.purge("foo/bar.jpg")
+        assert_that(urljoin.called).is_false()
+
+    @override_settings(IMAGE_CACHE_ROOT_URL=None)
+    def test_purge_error_if_cache_root_url_missing(self):
+        with raises(image_cache.ImageCacheConfigurationError) as err:
+            image_cache.purge("foo/bar.jpg")
+
+        assert_that(str(err.value)).is_equal_to(
+            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+        )
+
+    @override_settings(IMAGE_CACHE_PURGE_KEY=None)
+    def test_purge_error_if_cache_purge_key_missing(self):
+        with raises(image_cache.ImageCacheConfigurationError) as err:
+            image_cache.purge("foo/bar.jpg")
+
+        assert_that(str(err.value)).is_equal_to(
+            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+        )
+
+    @mock.patch("utils.image_cache.capture_message")
+    @mock.patch("utils.image_cache.request")
+    def test_purge_makes_correct_request(self, request, capture_message):
+        request.return_value = mock.MagicMock(status_code=200)
+        image_cache.purge("foo/bar.jpg")
+        request.assert_called_with(
+            "PURGE",
+            "https://test.url/foo/bar.jpg",
+            headers={"X-VC-Purge-Key": "test-purge-key"},
+        )
+        assert_that(capture_message.called).is_false()
+
+    @mock.patch("utils.image_cache.capture_message")
+    @mock.patch("utils.image_cache.request")
+    def test_purge_logs_failed_requests(self, request, capture_message):
+        request.return_value = mock.MagicMock(status_code=400)
+
+        image_cache.purge("foo/bar.jpg")
+        assert_that(capture_message.called).is_true()


### PR DESCRIPTION
## Change log
- Added a helper function for purging individual images
- Updated Purpose save so that it'll purge images every time Purpose is saved
- Unit tests for new functionality

## Other notes
Images are purged every time Purpose is saved. I didn't bother checking if new image is actually uploaded since this is just about the cache. All it causes is an addition backend hit before image is cached again. I decided to do this in as a background task because it is using HTTP calls that can delay the `save` call. Because cache purge is a secondary action, in case of error it does not prevent Purpose saving. However, errors are logged.

Vitalijus already set up an image cache for us in the dev environment. We just need to enabled it before this one is merged.

## Deployment reminder
- [ ] Azure devops library updated if needed