### PR TITLE
Refs TILA-2676: Add IMAGE_CACHE_HOST_HEADER setting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -287,8 +287,11 @@ REDIS_URL=redis://127.0.0.1:6379/0
 # Is image cache enalbed
 IMAGE_CACHE_ENABLED=False
 
-# Root url for cached images (where Varnish is located)
-IMAGE_CACHE_ROOT_URL=""
+# Varnish hostname for purging images
+IMAGE_CACHE_VARNISH_HOST=""
 
 # Secret key for purging images
 IMAGE_CACHE_PURGE_KEY=""
+
+# Host header for purging images
+IMAGE_CACHE_HOST_HEADER=""

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -250,8 +250,9 @@ env = environ.Env(
     ELASTICSEARCH_URL=(str, "http://localhost:9200"),
     # Image cache
     IMAGE_CACHE_ENABLED=(bool, False),
-    IMAGE_CACHE_ROOT_URL=(str, ""),
+    IMAGE_CACHE_VARNISH_HOST=(str, ""),
     IMAGE_CACHE_PURGE_KEY=(str, ""),
+    IMAGE_CACHE_HOST_HEADER=(str, ""),
 )
 
 environ.Env.read_env()
@@ -558,8 +559,9 @@ THUMBNAIL_ALIASES = {
     },
 }
 IMAGE_CACHE_ENABLED = env("IMAGE_CACHE_ENABLED")
-IMAGE_CACHE_ROOT_URL = env("IMAGE_CACHE_ROOT_URL")
+IMAGE_CACHE_VARNISH_HOST = env("IMAGE_CACHE_VARNISH_HOST")
 IMAGE_CACHE_PURGE_KEY = env("IMAGE_CACHE_PURGE_KEY")
+IMAGE_CACHE_HOST_HEADER = env("IMAGE_CACHE_HOST_HEADER")
 
 # Do not try to chmod when uploading images.
 # Our environments use persistent storage for media and operation will not be permitted.

--- a/utils/image_cache.py
+++ b/utils/image_cache.py
@@ -13,18 +13,19 @@ def purge(path: str) -> None:
     if not settings.IMAGE_CACHE_ENABLED:
         return
 
-    if not settings.IMAGE_CACHE_ROOT_URL or not settings.IMAGE_CACHE_PURGE_KEY:
+    if not settings.IMAGE_CACHE_VARNISH_HOST or not settings.IMAGE_CACHE_PURGE_KEY:
         raise ImageCacheConfigurationError(
-            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+            "IMAGE_CACHE_VARNISH_HOST or IMAGE_CACHE_PURGE_KEY setting is not configured"
         )
 
-    full_url = urljoin(settings.IMAGE_CACHE_ROOT_URL, path)
+    full_url = urljoin(settings.IMAGE_CACHE_VARNISH_HOST, path)
 
     response = request(
         "PURGE",
         full_url,
         headers={
             "X-VC-Purge-Key": settings.IMAGE_CACHE_PURGE_KEY,
+            "Host": settings.IMAGE_CACHE_HOST_HEADER,
         },
     )
 

--- a/utils/tests/test_image_cache.py
+++ b/utils/tests/test_image_cache.py
@@ -10,8 +10,9 @@ from utils import image_cache
 
 @override_settings(
     IMAGE_CACHE_ENABLED=True,
-    IMAGE_CACHE_ROOT_URL="https://test.url",
+    IMAGE_CACHE_VARNISH_HOST="https://test.url",
     IMAGE_CACHE_PURGE_KEY="test-purge-key",
+    IMAGE_CACHE_HOST_HEADER="test.tilavaraus.url",
 )
 class ImageCacheTestCase(TestCase):
     @override_settings(IMAGE_CACHE_ENABLED=False)
@@ -20,13 +21,13 @@ class ImageCacheTestCase(TestCase):
         image_cache.purge("foo/bar.jpg")
         assert_that(urljoin.called).is_false()
 
-    @override_settings(IMAGE_CACHE_ROOT_URL=None)
+    @override_settings(IMAGE_CACHE_VARNISH_HOST=None)
     def test_purge_error_if_cache_root_url_missing(self):
         with raises(image_cache.ImageCacheConfigurationError) as err:
             image_cache.purge("foo/bar.jpg")
 
         assert_that(str(err.value)).is_equal_to(
-            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+            "IMAGE_CACHE_VARNISH_HOST or IMAGE_CACHE_PURGE_KEY setting is not configured"
         )
 
     @override_settings(IMAGE_CACHE_PURGE_KEY=None)
@@ -35,7 +36,7 @@ class ImageCacheTestCase(TestCase):
             image_cache.purge("foo/bar.jpg")
 
         assert_that(str(err.value)).is_equal_to(
-            "IMAGE_CACHE_ROOT_URL or IMAGE_CACHE_PURGE_KEY setting is not configured"
+            "IMAGE_CACHE_VARNISH_HOST or IMAGE_CACHE_PURGE_KEY setting is not configured"
         )
 
     @mock.patch("utils.image_cache.capture_message")
@@ -46,7 +47,7 @@ class ImageCacheTestCase(TestCase):
         request.assert_called_with(
             "PURGE",
             "https://test.url/foo/bar.jpg",
-            headers={"X-VC-Purge-Key": "test-purge-key"},
+            headers={"X-VC-Purge-Key": "test-purge-key", "Host": "test.tilavaraus.url"},
         )
         assert_that(capture_message.called).is_false()
 


### PR DESCRIPTION
## Change log
- Added `IMAGE_CACHE_HOST_HEADER` settings
- Renamed `IMAGE_CACHE_ROOT_URL`-> `IMAGE_CACHE_VARNISH_HOST`
- Updated tests

## Other notes
I did not know that host header is required for purge to work but that seems to be the case 🤷 

## Deployment reminder
- [x] Pipeline configuration change [PR](https://dev.azure.com/City-of-Helsinki/tilavarauspalvelu/_git/tilavarauspalvelu-pipelines/pullrequest/5192)
- [x] Azure devops library updated if needed
- [x] Pipeline configuration change PR merged