### PR TITLE
TILA-2676: Purge image cache on Reservation Unit Image save

### DIFF
--- a/reservation_units/models.py
+++ b/reservation_units/models.py
@@ -908,6 +908,12 @@ class ReservationUnitImage(models.Model):
         update_fields=None,
         update_urls=True,
     ):
+        previous_data = ReservationUnitImage.objects.filter(pk=self.pk).first()
+        if settings.IMAGE_CACHE_ENABLED and previous_data and previous_data.image:
+            aliases = settings.THUMBNAIL_ALIASES[""]
+            for conf_key in list(aliases.keys()):
+                image_path = get_thumbnailer(previous_data.image)[conf_key].url
+                purge_image_cache.delay(image_path)
         super().save(
             force_insert=force_insert,
             force_update=force_update,

--- a/reservation_units/tests/test_reservation_unit_image_save.py
+++ b/reservation_units/tests/test_reservation_unit_image_save.py
@@ -1,7 +1,12 @@
+from io import BytesIO
 from unittest import mock
 
 from assertpy import assert_that
+from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
+from easy_thumbnails.files import get_thumbnailer
+from PIL import Image
 
 from reservation_units.models import ReservationUnitImage
 from reservation_units.tests.factories import ReservationUnitFactory
@@ -20,3 +25,24 @@ class ReservationUnitImageSaveTestCase(TestCase):
         image.save()
 
         assert_that(mock.delay.call_count).is_equal_to(1)
+
+    @mock.patch("reservation_units.models.purge_image_cache.delay")
+    @override_settings(IMAGE_CACHE_ENABLED=True)
+    @override_settings(CELERY_TASK_ALWAYS_EAGER=True)
+    def test_image_cache_is_purged_on_save(self, purge):
+        mock_image_data = BytesIO()
+        mock_image = Image.new("RGB", (100, 100))
+        mock_image.save(fp=mock_image_data, format="PNG")
+        mock_file = SimpleUploadedFile(
+            "image.png", mock_image_data.getvalue(), content_type="image/png"
+        )
+
+        runit_image = ReservationUnitImage(
+            reservation_unit=self.res_unit, image_type="main", image=mock_file
+        )
+        runit_image.save()
+
+        aliases = settings.THUMBNAIL_ALIASES[""]
+        for conf_key in list(aliases.keys()):
+            image_path = get_thumbnailer(runit_image.image)[conf_key].url
+            purge.assert_any_call(image_path)


### PR DESCRIPTION
## Change log
- Added image purge call to ReservationUnitImage save
- Added unit tests

## Other notes
There is no need to purge images when ReservationImageUnit item is deleted because these images are not referenced anywhere anymore. Client should not receive these image urls from the API. Yes, cached images are still visible but cache has 24h TTL so these images will disappears automatically.

## Deployment reminder
- No changes required