### PR TITLE
TILA-2661 | Take into account collapsing closed opening hours

### DIFF
--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -1,3 +1,5 @@
+from types import DynamicClassAttribute
+
 from django.utils.translation import pgettext_lazy
 from enumfields import Enum
 
@@ -47,6 +49,14 @@ class State(Enum):
     @classmethod
     def closed_states(cls):
         return [None, cls.CLOSED, cls.UNDEFINED, cls.NOT_IN_USE, cls.MAINTENANCE]
+
+    @DynamicClassAttribute
+    def is_open(self) -> bool:
+        return self in State.open_states()
+
+    @DynamicClassAttribute
+    def is_closed(self) -> bool:
+        return self in State.closed_states()
 
     @classmethod
     def reservable_states(cls):

--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -36,12 +36,17 @@ class State(Enum):
     def open_states(cls):
         return [
             cls.OPEN,
+            cls.OPEN_AND_RESERVABLE,
             cls.SELF_SERVICE,
             cls.WITH_KEY,
             cls.WITH_RESERVATION,
             cls.WITH_KEY_AND_RESERVATION,
             cls.ENTER_ONLY,
         ]
+
+    @classmethod
+    def closed_states(cls):
+        return [None, cls.CLOSED, cls.UNDEFINED, cls.NOT_IN_USE, cls.MAINTENANCE]
 
     @classmethod
     def reservable_states(cls):

--- a/opening_hours/enums.py
+++ b/opening_hours/enums.py
@@ -35,36 +35,57 @@ class State(Enum):
         MAINTENANCE = pgettext_lazy("State", "Maintenance")
 
     @classmethod
-    def open_states(cls):
+    def accessible_states(cls):
+        """
+        States indicating the space can be accessed in some way,
+        whether the access is restricted (e.g. via key or reservation)
+        or not.
+        """
         return [
+            cls.ENTER_ONLY,
             cls.OPEN,
             cls.OPEN_AND_RESERVABLE,
             cls.SELF_SERVICE,
             cls.WITH_KEY,
-            cls.WITH_RESERVATION,
             cls.WITH_KEY_AND_RESERVATION,
-            cls.ENTER_ONLY,
+            cls.WITH_RESERVATION,
+        ]
+
+    @classmethod
+    def reservable_states(cls):
+        """
+        States indicating the space can be reserved in some way.
+        """
+        return [
+            cls.OPEN_AND_RESERVABLE,
+            cls.WITH_KEY_AND_RESERVATION,
+            cls.WITH_RESERVATION,
         ]
 
     @classmethod
     def closed_states(cls):
-        return [None, cls.CLOSED, cls.UNDEFINED, cls.NOT_IN_USE, cls.MAINTENANCE]
+        """
+        States indicating the space is closed and inaccessible.
+        """
+        return [
+            None,
+            cls.CLOSED,
+            cls.MAINTENANCE,
+            cls.NOT_IN_USE,
+            cls.UNDEFINED,
+        ]
 
     @DynamicClassAttribute
-    def is_open(self) -> bool:
-        return self in State.open_states()
+    def is_accessible(self) -> bool:
+        return self in State.accessible_states()
+
+    @DynamicClassAttribute
+    def is_reservable(self) -> bool:
+        return self in State.reservable_states()
 
     @DynamicClassAttribute
     def is_closed(self) -> bool:
         return self in State.closed_states()
-
-    @classmethod
-    def reservable_states(cls):
-        return [
-            cls.WITH_RESERVATION,
-            cls.OPEN_AND_RESERVABLE,
-            cls.WITH_KEY_AND_RESERVATION,
-        ]
 
     @classmethod
     def get(cls, state):

--- a/opening_hours/tests/test_opening_hours_client.py
+++ b/opening_hours/tests/test_opening_hours_client.py
@@ -153,7 +153,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T12:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -169,7 +169,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T23:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_false()
@@ -186,7 +186,7 @@ class OpeningHoursClientTestCase(TestCase):
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T23:00+04:00"
         )
 
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -221,7 +221,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T12:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -256,7 +256,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T12:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_false()
@@ -282,7 +282,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T12:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -316,7 +316,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T12:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -350,7 +350,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T16:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_true()
@@ -383,7 +383,7 @@ class OpeningHoursClientTestCase(TestCase):
         end = datetime.datetime.fromisoformat(
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T13:00"
         )
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_false()
@@ -400,7 +400,7 @@ class OpeningHoursClientTestCase(TestCase):
             f"{DATES[0].year}-0{DATES[0].month}-0{DATES[0].day}T07:00+02:00"
         )
 
-        is_open = client.is_resource_open_for_reservations(
+        is_open = client.is_resource_reservable(
             str(self.reservation_unit.uuid), begin, end
         )
         assert_that(is_open).is_false()

--- a/opening_hours/tests/test_opening_hours_client.py
+++ b/opening_hours/tests/test_opening_hours_client.py
@@ -408,10 +408,14 @@ class OpeningHoursClientTestCase(TestCase):
     def test_next_opening_times_returns_date_and_times(self, mock):
         mock.return_value = self.get_mocked_opening_hours()
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
         date, times = client.next_opening_times(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
 
         assert_that(date).is_equal_to(DATES[0])
@@ -429,10 +433,14 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = self.get_mocked_opening_hours()
         from_date = datetime.date(2022, 1, 1)
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
         date, times = client.next_opening_times(
-            str(self.reservation_unit.uuid), from_date
+            str(self.reservation_unit.uuid),
+            from_date,
         )
 
         assert_that(date).is_none()
@@ -470,10 +478,14 @@ class OpeningHoursClientTestCase(TestCase):
 
         mock.return_value = data
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_zero()
 
@@ -490,17 +502,37 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin_1 = datetime.datetime.combine(DATES[0], datetime.time(8), tzinfo=DEFAULT_TIMEZONE)
-        end_1 = datetime.datetime.combine(DATES[0], datetime.time(13), tzinfo=DEFAULT_TIMEZONE)
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(8),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(13),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_2 = datetime.datetime.combine(DATES[0], datetime.time(13), tzinfo=DEFAULT_TIMEZONE)
-        end_2 = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(13),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
 
         assert_that(len(times)).is_equal_to(2)
@@ -511,7 +543,9 @@ class OpeningHoursClientTestCase(TestCase):
 
         assert_that(times[1].start_time).is_equal_to(begin_2)
         assert_that(times[1].end_time).is_equal_to(end_2)
-        assert_that(times[1].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[1].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
     def test_closed_time_affects_open_time_end(self, mock):
         data = self.get_mocked_opening_hours()
@@ -526,23 +560,45 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin_1 = datetime.datetime.combine(DATES[0], datetime.time(10), tzinfo=DEFAULT_TIMEZONE)
-        end_1 = datetime.datetime.combine(DATES[0], datetime.time(20), tzinfo=DEFAULT_TIMEZONE)
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(20),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_2 = datetime.datetime.combine(DATES[0], datetime.time(20), tzinfo=DEFAULT_TIMEZONE)
-        end_2 = datetime.datetime.combine(DATES[0], datetime.time(23), tzinfo=DEFAULT_TIMEZONE)
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(20),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(23),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(2)
 
         assert_that(times[0].start_time).is_equal_to(begin_1)
         assert_that(times[0].end_time).is_equal_to(end_1)
-        assert_that(times[0].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
         assert_that(times[1].start_time).is_equal_to(begin_2)
         assert_that(times[1].end_time).is_equal_to(end_2)
@@ -564,14 +620,26 @@ class OpeningHoursClientTestCase(TestCase):
             str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
         )
 
-        begin_1 = datetime.datetime.combine(DATES[0], datetime.time(10), tzinfo=DEFAULT_TIMEZONE)
-        end_1 = datetime.datetime.combine(DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE)
+        begin_1 = datetime.datetime.combine(
+            DATES[0], datetime.time(10), tzinfo=DEFAULT_TIMEZONE
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE
+        )
 
-        begin_2 = datetime.datetime.combine(DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE)
-        end_2 = datetime.datetime.combine(DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE)
+        begin_2 = datetime.datetime.combine(
+            DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE
+        )
 
-        begin_3 = datetime.datetime.combine(DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE)
-        end_3 = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin_3 = datetime.datetime.combine(
+            DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE
+        )
+        end_3 = datetime.datetime.combine(
+            DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE
+        )
 
         times = client.get_opening_hours_for_resource(
             str(self.reservation_unit.uuid), DATES[0]
@@ -581,7 +649,9 @@ class OpeningHoursClientTestCase(TestCase):
 
         assert_that(times[0].start_time).is_equal_to(begin_1)
         assert_that(times[0].end_time).is_equal_to(end_1)
-        assert_that(times[0].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value
+        )
 
         assert_that(times[1].start_time).is_equal_to(begin_2)
         assert_that(times[1].end_time).is_equal_to(end_2)
@@ -589,7 +659,9 @@ class OpeningHoursClientTestCase(TestCase):
 
         assert_that(times[2].start_time).is_equal_to(begin_3)
         assert_that(times[2].end_time).is_equal_to(end_3)
-        assert_that(times[2].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[2].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
     def test_two_closed_times_inside_open_time_creates_three_open_times(self, mock):
         data = self.get_mocked_opening_hours()
@@ -613,29 +685,72 @@ class OpeningHoursClientTestCase(TestCase):
             str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
         )
 
-        begin_1 = datetime.datetime.combine(DATES[0], datetime.time(10), tzinfo=DEFAULT_TIMEZONE)
-        end_1 = datetime.datetime.combine(DATES[0], datetime.time(11), tzinfo=DEFAULT_TIMEZONE)
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(11),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_2 = datetime.datetime.combine(DATES[0], datetime.time(11), tzinfo=DEFAULT_TIMEZONE)
-        end_2 = datetime.datetime.combine(DATES[0], datetime.time(12), tzinfo=DEFAULT_TIMEZONE)
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(11),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(12),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_3 = datetime.datetime.combine(DATES[0], datetime.time(12), tzinfo=DEFAULT_TIMEZONE)
-        end_3 = datetime.datetime.combine(DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE)
+        begin_3 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(12),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_3 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(15),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_4 = datetime.datetime.combine(DATES[0], datetime.time(15), tzinfo=DEFAULT_TIMEZONE)
-        end_4 = datetime.datetime.combine(DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE)
+        begin_4 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(15),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_4 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(18),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
-        begin_5 = datetime.datetime.combine(DATES[0], datetime.time(18), tzinfo=DEFAULT_TIMEZONE)
-        end_5 = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin_5 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(18),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_5 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(5)
 
         assert_that(times[0].start_time).is_equal_to(begin_1)
         assert_that(times[0].end_time).is_equal_to(end_1)
-        assert_that(times[0].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
         assert_that(times[1].start_time).is_equal_to(begin_2)
         assert_that(times[1].end_time).is_equal_to(end_2)
@@ -643,7 +758,9 @@ class OpeningHoursClientTestCase(TestCase):
 
         assert_that(times[2].start_time).is_equal_to(begin_3)
         assert_that(times[2].end_time).is_equal_to(end_3)
-        assert_that(times[2].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[2].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
         assert_that(times[3].start_time).is_equal_to(begin_4)
         assert_that(times[3].end_time).is_equal_to(end_4)
@@ -651,7 +768,9 @@ class OpeningHoursClientTestCase(TestCase):
 
         assert_that(times[4].start_time).is_equal_to(begin_5)
         assert_that(times[4].end_time).is_equal_to(end_5)
-        assert_that(times[4].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[4].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
 
     def test_open_time_inside_closed_time_is_removed(self, mock):
         data = self.get_mocked_opening_hours()
@@ -676,11 +795,20 @@ class OpeningHoursClientTestCase(TestCase):
             str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
         )
 
-        begin = datetime.datetime.combine(DATES[0], datetime.time(10), tzinfo=DEFAULT_TIMEZONE)
-        end = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(1)
         assert_that(times[0].resource_state).is_equal_to(State.MAINTENANCE.value)
@@ -700,17 +828,31 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin = datetime.datetime.combine(DATES[0], datetime.time(6), tzinfo=DEFAULT_TIMEZONE)
-        end = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(6),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(1)
-        assert_that(times[0].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
         assert_that(times[0].start_time).is_equal_to(begin)
         assert_that(times[0].end_time).is_equal_to(end)
 
@@ -727,19 +869,90 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin = datetime.datetime.combine(DATES[0], datetime.time(8), tzinfo=DEFAULT_TIMEZONE)
-        end = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(8),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(1)
-        assert_that(times[0].resource_state).is_equal_to(State.OPEN_AND_RESERVABLE.value)
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
         assert_that(times[0].start_time).is_equal_to(begin)
         assert_that(times[0].end_time).is_equal_to(end)
+
+    def test_two_open_times_with_different_states(self, mock):
+        data = self.get_mocked_opening_hours()
+        data[0]["times"].append(
+            TimeElement(
+                start_time=datetime.time(hour=8),
+                end_time=datetime.time(hour=12),
+                end_time_on_next_day=False,
+                resource_state=State.OPEN.value,
+            )
+        )
+        mock.return_value = data
+
+        client = OpeningHoursClient(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
+        )
+
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(8),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(12),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        times = client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+        )
+        assert_that(len(times)).is_equal_to(2)
+
+        assert_that(times[0].resource_state).is_equal_to(State.OPEN.value)
+        assert_that(times[0].start_time).is_equal_to(begin_1)
+        assert_that(times[0].end_time).is_equal_to(end_1)
+
+        assert_that(times[1].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
+        assert_that(times[1].start_time).is_equal_to(begin_2)
+        assert_that(times[1].end_time).is_equal_to(end_2)
 
     def test_two_closed_times_are_concatenated(self, mock):
         data = self.get_mocked_opening_hours()
@@ -761,14 +974,26 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin = datetime.datetime.combine(DATES[0], datetime.time(6), tzinfo=DEFAULT_TIMEZONE)
-        end = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(6),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(1)
         assert_that(times[0].resource_state).is_equal_to(State.MAINTENANCE.value)
@@ -795,16 +1020,175 @@ class OpeningHoursClientTestCase(TestCase):
         mock.return_value = data
 
         client = OpeningHoursClient(
-            str(self.reservation_unit.uuid), DATES[0], DATES[1], single=True
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
         )
 
-        begin = datetime.datetime.combine(DATES[0], datetime.time(8), tzinfo=DEFAULT_TIMEZONE)
-        end = datetime.datetime.combine(DATES[0], datetime.time(22), tzinfo=DEFAULT_TIMEZONE)
+        begin = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(8),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
 
         times = client.get_opening_hours_for_resource(
-            str(self.reservation_unit.uuid), DATES[0]
+            str(self.reservation_unit.uuid),
+            DATES[0],
         )
         assert_that(len(times)).is_equal_to(1)
         assert_that(times[0].resource_state).is_equal_to(State.MAINTENANCE.value)
         assert_that(times[0].start_time).is_equal_to(begin)
         assert_that(times[0].end_time).is_equal_to(end)
+
+    def test_two_closed_times_with_different_states(self, mock):
+        data = self.get_mocked_opening_hours()
+        first_time_element = data[0]["times"][0]
+        data[0]["times"][0] = TimeElement(
+            start_time=first_time_element.start_time,
+            end_time=first_time_element.end_time,
+            end_time_on_next_day=first_time_element.end_time_on_next_day,
+            resource_state=State.MAINTENANCE.value,
+        )
+        data[0]["times"].append(
+            TimeElement(
+                start_time=datetime.time(hour=8),
+                end_time=datetime.time(hour=12),
+                end_time_on_next_day=False,
+                resource_state=State.CLOSED.value,
+            )
+        )
+        mock.return_value = data
+
+        client = OpeningHoursClient(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
+        )
+
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(8),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(12),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        times = client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+        )
+        assert_that(len(times)).is_equal_to(2)
+
+        assert_that(times[0].resource_state).is_equal_to(State.CLOSED.value)
+        assert_that(times[0].start_time).is_equal_to(begin_1)
+        assert_that(times[0].end_time).is_equal_to(end_1)
+
+        assert_that(times[1].resource_state).is_equal_to(State.MAINTENANCE.value)
+        assert_that(times[1].start_time).is_equal_to(begin_2)
+        assert_that(times[1].end_time).is_equal_to(end_2)
+
+    def test_neither_open_nor_closed_state_passed_though(self, mock):
+        data = self.get_mocked_opening_hours()
+        first_time_element = data[0]["times"][0]
+        data[0]["times"] = [
+            TimeElement(
+                start_time=first_time_element.start_time,
+                end_time=datetime.time(hour=13),
+                end_time_on_next_day=first_time_element.end_time_on_next_day,
+                resource_state=State.OPEN_AND_RESERVABLE.value,
+            ),
+            TimeElement(
+                start_time=datetime.time(hour=12),
+                end_time=datetime.time(hour=14),
+                end_time_on_next_day=False,
+                resource_state=State.WEATHER_PERMITTING.value,
+            ),
+            TimeElement(
+                start_time=datetime.time(hour=13),
+                end_time=first_time_element.end_time,
+                end_time_on_next_day=first_time_element.end_time_on_next_day,
+                resource_state=State.MAINTENANCE.value,
+            ),
+        ]
+        mock.return_value = data
+
+        client = OpeningHoursClient(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+            DATES[1],
+            single=True,
+        )
+
+        begin_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(10),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_1 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(13),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        begin_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(12),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_2 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(14),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        begin_3 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(13),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+        end_3 = datetime.datetime.combine(
+            DATES[0],
+            datetime.time(22),
+            tzinfo=DEFAULT_TIMEZONE,
+        )
+
+        times = client.get_opening_hours_for_resource(
+            str(self.reservation_unit.uuid),
+            DATES[0],
+        )
+        assert_that(len(times)).is_equal_to(3)
+
+        assert_that(times[0].resource_state).is_equal_to(
+            State.OPEN_AND_RESERVABLE.value,
+        )
+        assert_that(times[0].start_time).is_equal_to(begin_1)
+        assert_that(times[0].end_time).is_equal_to(end_1)
+
+        assert_that(times[1].resource_state).is_equal_to(State.WEATHER_PERMITTING.value)
+        assert_that(times[1].start_time).is_equal_to(begin_2)
+        assert_that(times[1].end_time).is_equal_to(end_2)
+
+        assert_that(times[2].resource_state).is_equal_to(State.MAINTENANCE.value)
+        assert_that(times[2].start_time).is_equal_to(begin_3)
+        assert_that(times[2].end_time).is_equal_to(end_3)

--- a/opening_hours/utils/opening_hours_client.py
+++ b/opening_hours/utils/opening_hours_client.py
@@ -432,7 +432,7 @@ class OpeningHoursClient:
     ) -> bool:
         times = self.get_opening_hours_for_resource(resource, start_time.date())
         for time in times:
-            if ResourceState(time.resource_state).is_closed:
+            if not ResourceState(time.resource_state).is_reservable:
                 continue
 
             open_full_day = not time.start_time and not time.end_time

--- a/reservation_units/utils/reservation_unit_reservation_scheduler.py
+++ b/reservation_units/utils/reservation_unit_reservation_scheduler.py
@@ -112,7 +112,7 @@ class ReservationUnitReservationScheduler:
     def is_reservation_unit_open(
         self, start: datetime.datetime, end: datetime.datetime
     ):
-        return self.opening_hours_client.is_resource_open_for_reservations(
+        return self.opening_hours_client.is_resource_reservable(
             str(self.reservation_unit.uuid), start, end
         )
 


### PR DESCRIPTION
Takes into an account collapsing opening hours e.g when the reservation unit is open 10-18 and there is maintenance break 13-14 the opening hour needs to be splitted into two (10-13 and 14-18)

Refs TILA-2661