### PR TITLE
Opening hours fix

### DIFF
--- a/api/graphql/tests/snapshots/snap_test_orders.py
+++ b/api/graphql/tests/snapshots/snap_test_orders.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['OrderQueryTestCase::test_returns_none_when_not_authenticated 1'] = {
@@ -21,7 +20,6 @@ snapshots['OrderQueryTestCase::test_returns_order_when_user_can_handle_reservati
             'paymentType': 'INVOICE',
             'receiptUrl': None,
             'refundId': None,
-            'reservationPk': '1',
             'status': 'DRAFT'
         }
     }
@@ -35,7 +33,6 @@ snapshots['OrderQueryTestCase::test_returns_order_when_user_owns_reservation 1']
             'paymentType': 'INVOICE',
             'receiptUrl': None,
             'refundId': None,
-            'reservationPk': '1',
             'status': 'DRAFT'
         }
     }
@@ -49,7 +46,6 @@ snapshots['OrderQueryTestCase::test_returns_refund_id_when_it_exists 1'] = {
             'paymentType': 'INVOICE',
             'receiptUrl': None,
             'refundId': 'd55db3a0-0786-4259-ab9e-c4211cae162e',
-            'reservationPk': '1',
             'status': 'DRAFT'
         }
     }

--- a/api/graphql/tests/snapshots/snap_test_reservation_unit_cancellation_rules.py
+++ b/api/graphql/tests/snapshots/snap_test_reservation_unit_cancellation_rules.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from snapshottest import Snapshot
 
-
 snapshots = Snapshot()
 
 snapshots['ReservationUnitCancellationRulesQueryTestCase::test_getting_reservation_unit_cancellation_rules_for_logged_in_user 1'] = {
@@ -16,7 +15,6 @@ snapshots['ReservationUnitCancellationRulesQueryTestCase::test_getting_reservati
                         'nameEn': 'en',
                         'nameFi': 'fi',
                         'nameSv': 'sv',
-                        'pk': 1
                     }
                 }
             ]

--- a/api/graphql/tests/test_orders.py
+++ b/api/graphql/tests/test_orders.py
@@ -74,6 +74,8 @@ class OrderQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
         assert_that(content.get("errors")).is_none()
+        assert "reservationPk" in content["data"]["order"]
+        del content["data"]["order"]["reservationPk"]  # Ignore ID to allow db reuse
         self.assertMatchSnapshot(content)
 
     def test_returns_order_when_user_can_handle_reservations(self):
@@ -83,6 +85,8 @@ class OrderQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
         assert_that(content.get("errors")).is_none()
+        assert "reservationPk" in content["data"]["order"]
+        del content["data"]["order"]["reservationPk"]  # Ignore ID to allow db reuse
         self.assertMatchSnapshot(content)
 
     def test_returns_refund_id_when_it_exists(self):
@@ -94,6 +98,8 @@ class OrderQueryTestCase(GrapheneTestCaseBase, snapshottest.TestCase):
         response = self.query(self.get_order_query())
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
+        assert "reservationPk" in content["data"]["order"]
+        del content["data"]["order"]["reservationPk"]  # Ignore ID to allow db reuse
         assert_that(content.get("errors")).is_none()
         self.assertMatchSnapshot(content)
 

--- a/api/graphql/tests/test_reservation_unit_cancellation_rules.py
+++ b/api/graphql/tests/test_reservation_unit_cancellation_rules.py
@@ -34,6 +34,8 @@ class ReservationUnitCancellationRulesQueryTestCase(GrapheneTestCaseBase, snapsh
         assert_that(response.status_code).is_equal_to(200)
         content = json.loads(response.content)
         assert_that(content.get("errors")).is_none()
+        assert "pk" in content["data"]["reservationUnitCancellationRules"]["edges"][0]["node"]
+        del content["data"]["reservationUnitCancellationRules"]["edges"][0]["node"]["pk"]  # Ignore ID to allow db reuse
         self.assertMatchSnapshot(content)
 
     def test_getting_reservation_unit_cancellation_rules_for_not_logged_in_user(self):

--- a/api/graphql/tests/test_reservation_units/conftest.py
+++ b/api/graphql/tests/test_reservation_units/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def setup_hauki_env_variables(settings):
+    settings.HAUKI_API_URL = "url"
+    settings.HAUKI_EXPORTS_ENABLED = None
+    settings.HAUKI_ORIGIN_ID = "origin"
+    settings.HAUKI_SECRET = "HAUKISECRET"  # noqa: S105
+    settings.HAUKI_ORGANISATION_ID = None
+    settings.HAUKI_ADMIN_UI_URL = "https://test.com"

--- a/applications/tests/test_application_export.py
+++ b/applications/tests/test_application_export.py
@@ -177,66 +177,6 @@ class ApplicationDataExporterTestCase(ApplicationDataExportTestCaseBase):
         file_name = self._get_filename_for_round(self.application_round_id)
         self._test_first_data_line(file_name, expected_row)
 
-    def test_no_time_range(self):
-        self.application_event.max_duration = timedelta(hours=1)
-        self.application_event.save()
-
-        call_command("export_applications", self.application_round_id)
-
-        event: ApplicationEvent = self.application_event
-        application: Application = event.application
-
-        expected_row = [
-            str(application.id),
-            ApplicationStatus.get_verbose_status(self.application_status.status),
-            application.organisation.name,
-            application.organisation.identifier,
-            application.contact_person.first_name,
-            application.contact_person.last_name,
-            application.contact_person.email,
-            application.contact_person.phone_number,
-            str(event.id),
-            event.name,
-            (
-                f"{event.begin.day}.{event.begin.month}.{event.begin.year}"
-                f" - {event.end.day}.{event.end.month}.{event.end.year}"
-            ),
-            application.home_city.name,
-            event.purpose.name,
-            str(event.age_group),
-            str(event.num_persons),
-            application.applicant_type,
-            str(event.events_per_week),
-            "1 h",
-            self.space_2_name,
-            self.space_3_name,
-            self.space_1_name,
-            "",
-            "12:00 - 14:00",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
-        ]
-
-        file_name = self._get_filename_for_round(self.application_round_id)
-        self._test_first_data_line(file_name, expected_row)
-
     def test_only_one_distinct_duration(self):
         self.application_event.max_duration = timedelta(hours=1)
         self.application_event.save()
@@ -1364,7 +1304,7 @@ class ApplicationDataExporterTestCase(ApplicationDataExportTestCaseBase):
         assert_that(not_existing_file_high.is_file()).is_false()
 
     def test_empty_arguments_throw_error(self):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             call_command("export_applications")
 
     def test_spaces_columns_are_added_dynamically(self):

--- a/email_notification/tests/test_notification_builders.py
+++ b/email_notification/tests/test_notification_builders.py
@@ -414,20 +414,6 @@ class ReservationEmailNotificationBuilderTestCase(ReservationEmailBaseTestCase):
         with self.assertRaises(EmailTemplateValidationError):
             ReservationEmailNotificationBuilder(self.reservation, template)
 
-    def test_macros_not_supported(self):
-        content = """
-                    {% for i in range(0, 100) %}
-                    loopey looper
-                    {% endfor %}
-
-                    {% macro secret_macro() %}
-                    ninja sabotage
-                    {% endmacro %}
-                """
-        template = EmailTemplateFactory(type=EmailType.RESERVATION_MODIFIED, content=content, subject="subject")
-        with self.assertRaises(EmailTemplateValidationError):
-            ReservationEmailNotificationBuilder(self.reservation, template)
-
     def test_currency_filter_comma_separator(self):
         content = "{{price | currency}}"
         compiled_content = "52,00"

--- a/merchants/verkkokauppa/tests/conftest.py
+++ b/merchants/verkkokauppa/tests/conftest.py
@@ -6,7 +6,7 @@ from merchants.verkkokauppa.product.types import CreateProductParams
 
 
 @fixture(autouse=True)
-def setup_audit_log(settings):
+def setup_verkkokauppa_env_variables(settings):
     settings.VERKKOKAUPPA_API_KEY = "test-api-key"
     settings.VERKKOKAUPPA_PRODUCT_API_URL = "http://test-product:1234"
     settings.VERKKOKAUPPA_ORDER_API_URL = "http://test-order:1234"

--- a/opening_hours/hours.py
+++ b/opening_hours/hours.py
@@ -169,10 +169,13 @@ def get_periods_for_resource(resource_id: Union[str, int, list], hauki_origin_id
         }
         for time_span_group in period["time_span_groups"]:
             for time_data_in in time_span_group["time_spans"]:
+                start_time = time_data_in.pop("start_time")
+                end_time = time_data_in.pop("end_time")
+
                 period_data_out["time_spans"].append(
                     TimeSpan(
-                        start_time=datetime.time.fromisoformat(time_data_in.pop("start_time")),
-                        end_time=datetime.time.fromisoformat(time_data_in.pop("end_time")),
+                        start_time=datetime.time.fromisoformat(start_time) if start_time else None,
+                        end_time=datetime.time.fromisoformat(end_time) if end_time else None,
                         **time_data_in,
                     )
                 )

--- a/opening_hours/tests/conftest.py
+++ b/opening_hours/tests/conftest.py
@@ -1,10 +1,11 @@
 import pytest
-from django.conf import settings
 
 
 @pytest.fixture(autouse=True)
-def enable_hauki_admin_ui():
+def enable_hauki_admin_ui(settings):
+    settings.HAUKI_API_URL = "url"
+    settings.HAUKI_EXPORTS_ENABLED = None
     settings.HAUKI_ORIGIN_ID = "test-tvp"
-    settings.HAUKI_SECRET = "super_secret"
+    settings.HAUKI_SECRET = "super_secret"  # noqa: S105
     settings.HAUKI_ORGANISATION_ID = "parent-organisation"
     settings.HAUKI_ADMIN_UI_URL = "http://test.com/admin"

--- a/opening_hours/tests/test_get_opening_hours.py
+++ b/opening_hours/tests/test_get_opening_hours.py
@@ -9,7 +9,7 @@ from opening_hours.hours import get_opening_hours
 
 
 @mock.patch("opening_hours.hours.make_hauki_get_request")
-@override_settings(HAUKI_API_URL="asdf")
+@override_settings(HAUKI_API_URL="url")
 class GetOpeningHoursTestCase(TestCase):
     @classmethod
     def get_opening_hours(self):

--- a/reservation_units/tests/test_reservation_unit_reservations.py
+++ b/reservation_units/tests/test_reservation_unit_reservations.py
@@ -78,15 +78,6 @@ class CheckReservationOverlapForSpacesTestCase(TestCase, UnitTestCase):
         )
         self.assertTrue(self.res_unit_whole_room.check_reservation_overlap(self.begin, self.end))
 
-    def test_part_of_the_room_reserved_whole_room_partly_same_time_overlaps(self):
-        ReservationFactory(
-            reservation_unit=[self.res_unit_first_half_room],
-            begin=self.begin + timedelta(minutes=30),
-            end=self.end,
-            state=STATE_CHOICES.CREATED,
-        )
-        self.assertTrue(self.res_unit_whole_room.check_reservation_overlap(self.begin, self.end))
-
     def test_part_of_the_part_room_overlaps_with_same_time_whole_room(self):
         ReservationFactory(
             reservation_unit=[self.res_unit_corner_of_second_half],

--- a/reservations/models.py
+++ b/reservations/models.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timedelta
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.validators import validate_comma_separated_integer_list
 from django.db import models
@@ -20,7 +21,6 @@ from applications.models import (
 )
 from merchants.models import OrderStatus
 from reservation_units.models import ReservationUnit
-from tilavarauspalvelu import settings
 from tilavarauspalvelu.utils.auditlog_util import AuditLogger
 from tilavarauspalvelu.utils.commons import WEEKDAYS
 

--- a/reservations/tests/test_reservation_statistics.py
+++ b/reservations/tests/test_reservation_statistics.py
@@ -132,13 +132,6 @@ class ReservationStatisticsCreateTestCase(TestCase):
         stat = ReservationStatistic.objects.first()
         assert_that(stat.cancel_reason_text).is_equal_to("cancel")
 
-    def test_deny_reason_text(self):
-        self.reservation.cancel_reason = ReservationCancelReasonFactory(reason="cancel")
-        self.reservation.save()
-
-        stat = ReservationStatistic.objects.first()
-        assert_that(stat.cancel_reason_text).is_equal_to("cancel")
-
     def test_is_applied_has_ability_group_name(self):
         self.reservation.recurring_reservation = RecurringReservationFactory(
             ability_group=AbilityGroupFactory(name="abbis"),

--- a/users/tests/test_basic_info_resolver.py
+++ b/users/tests/test_basic_info_resolver.py
@@ -178,10 +178,6 @@ class ProfileUserInfoReaderTestCase(TestCase):
         ):
             cls.reader = ProfileUserInfoReader(cls.user, cls.request)
 
-    @classmethod
-    def __get_profile_gql_with_errors(cls):
-        return {"errors": [{"message": "Bad bad error"}]}
-
     def test_get_first_name(self):
         assert_that(self.reader.get_first_name()).is_equal_to("John")
 


### PR DESCRIPTION
## 🛠️ Changelog
- Fix returning opening hours start and end time when they are none
- Improvements to tests
  - Remove duplicate tests
  - Fix running HAUKI tests when .env variables were set (Before it was required to not have them set at all)
  - Remove IDs from snapshot tests to allow reusing the same test db for faster test runs

## 🗒️ Other notes
- Some tests that fail in parallel require setting `--dist=loadscope` argument when running tests

## 🚚 Deployment reminder
- [ ] PR requires deployment changes
- [ ] Pipeline configuration change PR [link here]
- [ ] Azure devops library updated if needed
- [ ] Pipeline configuration change PR merged

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- TILA-2772, TILA-2836
