### PR TITLE
Add endpoint for fetching a single banner notification

### DIFF
--- a/api/graphql/schema.py
+++ b/api/graphql/schema.py
@@ -424,6 +424,7 @@ class Query(graphene.ObjectType):
 
     order = Field(PaymentOrderType, order_uuid=graphene.String())
 
+    banner_notification = relay.Node.Field(BannerNotificationType)
     banner_notifications = BannerNotificationConnection(BannerNotificationType)
 
     if "graphiql_debug_toolbar" in settings.INSTALLED_APPS:


### PR DESCRIPTION
## 🛠️ Changelog
- Adds endpoint for fetching a single banner notification by ID

## 🗒️ Other notes


## 🚚 Deployment reminder
- [ ] PR requires deployment changes
- [ ] Pipeline configuration change PR [link here]
- [ ] Azure devops library updated if needed
- [ ] Pipeline configuration change PR merged

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- [TILA-1588](https://helsinkisolutionoffice.atlassian.net/browse/TILA-1588)


[TILA-1588]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-1588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ