### PR TITLE
Add rotating file logging option to celery workers

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,8 +29,10 @@ RUN echo "Install common dependencies" \
     && mkdir -p "$STATIC_ROOT" \
     && chmod g=u "$STATIC_ROOT" \
     && echo "Create celery broker directories and set permissions" \
+    && mkdir -p /broker \
     && mkdir -p /broker/queue \
     && mkdir -p /broker/processed \
+    && chmod g+rw /broker \
     && chmod g+rw /broker/queue \
     && chmod g+rw /broker/processed \
     && echo "Create directory for django-prometheus metrics" \

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,4 +2,10 @@
 set -euo pipefail
 
 echo "Starting Celery worker and uWSGI server..."
-exec celery -A tilavarauspalvelu worker --detach & uwsgi --yaml /tvp/docker/uwsgi.yml
+exec celery \
+    -A tilavarauspalvelu \
+    worker \
+    --loglevel="${CELERY_LOG_LEVEL:-INFO}" \
+    --logfile=/broker/worker.log \
+    --detach \
+    & uwsgi --yaml /tvp/docker/uwsgi.yml

--- a/docker/worker.sh
+++ b/docker/worker.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "Starting worker server..."
-exec celery -A tilavarauspalvelu worker --detach & celery -A tilavarauspalvelu beat -l info -S django
+echo "Starting Celery worker and Celery beat task scheduler..."
+exec celery \
+    -A tilavarauspalvelu \
+    worker \
+    --loglevel="${CELERY_LOG_LEVEL:-INFO}" \
+    --logfile=/broker/worker.log \
+    --detach \
+    & celery \
+    -A tilavarauspalvelu \
+    beat \
+    --loglevel="${CELERY_LOG_LEVEL:-INFO}" \
+    --scheduler=django

--- a/tilavarauspalvelu/celery.py
+++ b/tilavarauspalvelu/celery.py
@@ -1,6 +1,10 @@
 import os
+import sys
+from logging import StreamHandler
+from logging.handlers import TimedRotatingFileHandler
 
 from celery import Celery
+from celery.app.log import Logging
 
 # Set the default Django settings module for the 'celery' program.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tilavarauspalvelu.settings")
@@ -8,7 +12,19 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tilavarauspalvelu.settings")
 broker_url = os.getenv("CELERY_BROKER_URL", "filesystem://")
 broker_options = os.getenv("CELERY_BROKER_TRANSPORT_OPTIONS", {})
 
-app = Celery("tilavarauspalvelu")
+
+class RotatingCeleryLogging(Logging):
+    def _detect_handler(self, logfile: str | None = None) -> StreamHandler | TimedRotatingFileHandler:
+        logfile = sys.__stderr__ if logfile is None else logfile
+        if hasattr(logfile, "write"):
+            return StreamHandler(logfile)
+
+        # Modify default file logging handler to the rotating file handler
+        # to avoid log file growing too large. Keep 12 hourly backups.
+        return TimedRotatingFileHandler(logfile, interval=1, when="h", backupCount=12, encoding="utf-8")
+
+
+app = Celery("tilavarauspalvelu", log=RotatingCeleryLogging)
 
 app.conf.update({"broker_url": broker_url, "broker_transport_options": broker_options})
 

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -32,6 +32,8 @@ env = environ.Env(
     CELERY_BROKER_URL=(str, "filesystem://"),
     CELERY_CACHE_BACKEND=(str, "django-cache"),
     CELERY_ENABLED=(bool, True),
+    CELERY_LOG_LEVEL=(str, "INFO"),
+    CELERY_LOG_FILE=(str, "./broker/worker.log"),
     CELERY_FILESYSTEM_BACKEND=(bool, True),
     CELERY_PROCESSED_FOLDER=(str, "./broker/processed/"),
     CELERY_QUEUE_FOLDER_IN=(str, "./broker/queue/"),
@@ -475,6 +477,8 @@ REST_FRAMEWORK = {
 # ----- Celery settings --------------------------------------------------------------------------------
 
 CELERY_ENABLED = env("CELERY_ENABLED")
+CELERY_LOG_LEVEL = env("CELERY_LOG_LEVEL")
+CELERY_LOG_FILE = env("CELERY_LOG_FILE")
 CELERY_RESULT_BACKEND = env("CELERY_RESULT_BACKEND")
 CELERY_CACHE_BACKEND = env("CELERY_CACHE_BACKEND")
 CELERY_TIMEZONE = env("CELERY_TIMEZONE")


### PR DESCRIPTION
Helps to debug celery errors

## 🛠️ Changelog
- Adds rotating log file to celery worker for better debugging. Logs are rotated on hourly basis and last 12 files are kept as backup.

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- TILA-####
