### PR TITLE
Fix `HaukiAPIClient.build_url` for origin prefixed resource IDs

### DIFF
--- a/opening_hours/utils/hauki_api_client.py
+++ b/opening_hours/utils/hauki_api_client.py
@@ -23,7 +23,7 @@ class HaukiAPIClient:
 
         url = urljoin(settings.HAUKI_API_URL, f"/v1/{endpoint}/")
         if resource_id:
-            url = urljoin(url, f"{resource_id}/")
+            url += f"{resource_id}/"
 
         return url
 


### PR DESCRIPTION
## 🛠️ Changelog
- Fix `build_url`, as it broke when the resource id had a `:` in it

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- TILA-####