### PR TITLE
Use reservation user info for payment instead of reservee info

### DIFF
--- a/merchants/verkkokauppa/order/test/test_create_order_params.py
+++ b/merchants/verkkokauppa/order/test/test_create_order_params.py
@@ -8,7 +8,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from django.utils.timezone import get_default_timezone
 
-from merchants.verkkokauppa.helpers import _get_order_params, get_validated_phone_number
+from merchants.verkkokauppa.helpers import _get_order_params
 from reservations.choices import CustomerTypeChoice
 from tests.factories import PaymentProductFactory, ReservationFactory, ReservationUnitFactory
 
@@ -22,7 +22,7 @@ class CreateOrderParamsToJsonTestCase(TestCase):
             username="test",
             email="test@localhost",
             first_name="First",
-            last_name="Name",
+            last_name="Last",
         )
 
         reservation = ReservationFactory(
@@ -48,10 +48,10 @@ class CreateOrderParamsToJsonTestCase(TestCase):
         assert_that(json["priceNet"]).is_equal_to("10.12")
         assert_that(json["priceVat"]).is_equal_to("2.43")
         assert_that(json["priceTotal"]).is_equal_to("12.55")
-        assert_that(json["customer"]["firstName"]).is_equal_to("Firstname")
-        assert_that(json["customer"]["lastName"]).is_equal_to("Lastname")
-        assert_that(json["customer"]["email"]).is_equal_to("test@example.com")
-        assert_that(json["customer"]["phone"]).is_equal_to(get_validated_phone_number(reservation.reservee_phone))
+        assert_that(json["customer"]["firstName"]).is_equal_to("First")
+        assert_that(json["customer"]["lastName"]).is_equal_to("Last")
+        assert_that(json["customer"]["email"]).is_equal_to("test@localhost")
+        assert_that(json["customer"]["phone"]).is_equal_to("")
         assert_that(json["lastValidPurchaseDateTime"]).is_equal_to(
             (
                 datetime.now(tz=get_default_timezone())

--- a/merchants/verkkokauppa/tests/test_helpers.py
+++ b/merchants/verkkokauppa/tests/test_helpers.py
@@ -9,12 +9,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from merchants.verkkokauppa.exceptions import UnsupportedMetaKey
-from merchants.verkkokauppa.helpers import (
-    create_verkkokauppa_order,
-    get_formatted_reservation_time,
-    get_meta_label,
-    get_validated_phone_number,
-)
+from merchants.verkkokauppa.helpers import create_verkkokauppa_order, get_formatted_reservation_time, get_meta_label
 from reservations.choices import CustomerTypeChoice
 from tests.factories import PaymentProductFactory, ReservationFactory, ReservationUnitFactory
 
@@ -64,78 +59,6 @@ class HelpersTestCase(TestCase):
     def test_get_formatted_reservation_time_fi_fallback(self):
         date = get_formatted_reservation_time(self.reservation)
         assert_that(date).is_equal_to("La 5.11.2022 10:00-12:00")
-
-    def test_get_validated_phone_number(self):
-        assert_that(get_validated_phone_number("+358 50 123 4567")).is_equal_to("+358 50 123 4567")
-        assert_that(get_validated_phone_number("+358 50 023 4567")).is_equal_to("+358 50 023 4567")
-        assert_that(get_validated_phone_number("+358501234567")).is_equal_to("+358501234567")
-        assert_that(get_validated_phone_number("+358-50-123-4567")).is_equal_to("+358 50 123 4567")
-        assert_that(get_validated_phone_number(" +358  50-  123- 4567  ")).is_equal_to("+358 50 123 4567")
-        assert_that(get_validated_phone_number("+1-55-50  10 0 ")).is_equal_to("+1 55 50 10 0")
-        assert_that(get_validated_phone_number("+1 55 50 10 0")).is_equal_to("+1 55 50 10 0")
-        assert_that(get_validated_phone_number("050 123 4567")).is_equal_to("")
-        assert_that(get_validated_phone_number("(+358) 50 123 4567")).is_equal_to("")
-        assert_that(get_validated_phone_number("")).is_equal_to("")
-
-    @patch("merchants.verkkokauppa.helpers.create_order")
-    def test_create_verkkokauppa_order_phone_number_is_set(self, mock_create_order):
-        user = get_user_model().objects.create(
-            username="testuser",
-            first_name="Test",
-            last_name="User",
-            email="test.user@example.com",
-        )
-        payment_product = PaymentProductFactory()
-        runit = ReservationUnitFactory(payment_product=payment_product)
-        reservation = ReservationFactory(
-            reservation_unit=[runit],
-            user=user,
-            reservee_type=CustomerTypeChoice.INDIVIDUAL,
-            reservee_phone="+358 50 123 4567",
-        )
-
-        create_verkkokauppa_order(reservation)
-        assert_that(mock_create_order.call_args.args[0].customer.phone).is_equal_to(reservation.reservee_phone)
-
-    @patch("merchants.verkkokauppa.helpers.create_order")
-    def test_create_verkkokauppa_order_phone_number_is_not_set_when_not_individual(self, mock_create_order):
-        user = get_user_model().objects.create(
-            username="testuser",
-            first_name="Test",
-            last_name="User",
-            email="test.user@example.com",
-        )
-        payment_product = PaymentProductFactory()
-        runit = ReservationUnitFactory(payment_product=payment_product)
-        reservation = ReservationFactory(
-            reservation_unit=[runit],
-            user=user,
-            reservee_type=CustomerTypeChoice.BUSINESS,
-            reservee_phone="+358 50 123 4567",
-        )
-
-        create_verkkokauppa_order(reservation)
-        assert_that(mock_create_order.call_args.args[0].customer.phone).is_equal_to("")
-
-    @patch("merchants.verkkokauppa.helpers.create_order")
-    def test_create_verkkokauppa_order_phone_number_is_not_set_when_invalid(self, mock_create_order):
-        user = get_user_model().objects.create(
-            username="testuser",
-            first_name="Test",
-            last_name="User",
-            email="test.user@example.com",
-        )
-        payment_product = PaymentProductFactory()
-        runit = ReservationUnitFactory(payment_product=payment_product)
-        reservation = ReservationFactory(
-            reservation_unit=[runit],
-            user=user,
-            reservee_type=CustomerTypeChoice.INDIVIDUAL,
-            reservee_phone="1234-333",
-        )
-
-        create_verkkokauppa_order(reservation)
-        assert_that(mock_create_order.call_args.args[0].customer.phone).is_equal_to("")
 
     @patch("merchants.verkkokauppa.helpers.create_order")
     def test_create_verkkokauppa_order_respect_reservee_language(self, mock_create_order):


### PR DESCRIPTION
## 🛠️ Changelog
- Change verkkokauppa payment user info to reservation user from reservation reservee.

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- TILA-2913
