### PR TITLE
Add admin actions to reset application/application round allocation

### DIFF
--- a/actions/application.py
+++ b/actions/application.py
@@ -11,3 +11,17 @@ class ApplicationActions:
     def decline(self) -> None:
         for application_event in self.application.application_events.all():
             application_event.actions.decline_event_schedules()
+
+    def reset_application_allocation(self) -> None:
+        """Reset application allocations to a state before any allocations were made."""
+        from applications.models import ApplicationEventSchedule
+
+        ApplicationEventSchedule.objects.filter(
+            application_event__application=self.application,
+        ).update(
+            allocated_day=None,
+            allocated_begin=None,
+            allocated_end=None,
+            allocated_reservation_unit=None,
+            declined=False,
+        )

--- a/actions/application_round.py
+++ b/actions/application_round.py
@@ -7,3 +7,17 @@ if TYPE_CHECKING:
 class ApplicationRoundActions:
     def __init__(self, application_round: "ApplicationRound") -> None:
         self.application_round = application_round
+
+    def reset_application_round_allocation(self):
+        """Reset application round applications to a state before any allocations were made."""
+        from applications.models import ApplicationEventSchedule
+
+        ApplicationEventSchedule.objects.filter(
+            application_event__application__application_round=self.application_round,
+        ).update(
+            allocated_day=None,
+            allocated_begin=None,
+            allocated_end=None,
+            allocated_reservation_unit=None,
+            declined=False,
+        )

--- a/applications/admin/application.py
+++ b/applications/admin/application.py
@@ -1,4 +1,5 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.http import HttpRequest
 
 from applications.admin.forms.application import ApplicationAdminForm
 from applications.models import Application
@@ -6,6 +7,8 @@ from applications.models import Application
 __all__ = [
     "ApplicationAdmin",
 ]
+
+from applications.querysets.application import ApplicationQuerySet
 
 
 @admin.register(Application)
@@ -19,9 +22,20 @@ class ApplicationAdmin(admin.ModelAdmin):
     ]
     list_filter = [
         "application_round",
+        "application_round__reservation_units__name",
     ]
     search_fields = [
-        "application_round__name",
         "user__first_name",
         "user__last_name",
+        "application_round__reservation_units__name",
     ]
+    actions = ["reset_applications"]
+
+    @admin.action(description="Reset application allocations")
+    def reset_applications(self, request: HttpRequest, queryset: ApplicationQuerySet) -> None:
+        application: Application
+        for application in queryset:
+            application.actions.reset_application_allocation()
+
+        msg = "Applications were reset successfully."
+        self.message_user(request, msg, level=messages.INFO)

--- a/applications/admin/application_event.py
+++ b/applications/admin/application_event.py
@@ -36,7 +36,8 @@ class ApplicationEventAdmin(TranslationAdmin):
     ]
     search_fields = [
         "name",
-        "application__name",
+        "application__user__first_name",
+        "application__user__last_name",
     ]
 
     inlines = [ApplicationEventScheduleInline]

--- a/templates/admin/reset_allocation_confirmation.html
+++ b/templates/admin/reset_allocation_confirmation.html
@@ -1,0 +1,41 @@
+{% extends "admin/base_site.html" %}
+{% load i18n l10n admin_urls static %}
+
+{# Adapted from 'django/contrib/admin/templates/admin/delete_selected_confirmation.html' #}
+
+{% block extrahead %}
+    {{ block.super }}
+    {{ media }}
+    <script src="{% static 'admin/js/cancel.js' %}" async></script>
+{% endblock %}
+
+{% block bodyclass %}{{ block.super }} app-{{ opts.app_label }} model-{{ opts.model_name }} reset-allocation-confirmation{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin:app_list' app_label=opts.app_label %}">{{ opts.app_config.verbose_name }}</a>
+    &rsaquo; <a href="{% url opts|admin_urlname:'changelist' %}">{{ opts.verbose_name_plural|capfirst }}</a>
+    &rsaquo; {% translate 'Reset allocations' %}
+</div>
+{% endblock %}
+
+{% block content %}
+{% block delete_confirm %}
+
+<form method="post">{% csrf_token %}
+    <div>
+        {% for obj in queryset %}
+        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+        {% endfor %}
+
+        <input type="hidden" name="action" value={{ action_name }}>
+        <input type="hidden" name="post" value="yes">
+
+        <input type="submit" value="{% translate 'Yes, I’m sure' %}">
+        <a href="#" class="button cancel-link">{% translate "No, take me back" %}</a>
+    </div>
+</form>
+
+{% endblock %}
+{% endblock content %}

--- a/tests/factories/application.py
+++ b/tests/factories/application.py
@@ -121,7 +121,7 @@ class ApplicationFactory(GenericDjangoModelFactory[Application]):
     @classmethod
     def create_in_status_handled(cls, **kwargs: Any) -> Application:
         """
-        Create a handled application with a single reserved application event
+        Create a handled application with a single approved application event
         in an application round in the handled stage.
         """
         from .application_event import ApplicationEventFactory
@@ -141,7 +141,7 @@ class ApplicationFactory(GenericDjangoModelFactory[Application]):
 
         if event_key not in kwargs:
             event_kwargs["application"] = application
-            ApplicationEventFactory.create_in_status_reserved(**event_kwargs)
+            ApplicationEventFactory.create_in_status_approved(**event_kwargs)
 
         return application
 

--- a/tests/test_actions/test_reset_application_allocation.py
+++ b/tests/test_actions/test_reset_application_allocation.py
@@ -1,0 +1,48 @@
+import pytest
+
+from applications.choices import ApplicationStatusChoice
+from tests.factories import ApplicationFactory, ApplicationRoundFactory
+
+# Applied to all tests
+pytestmark = [
+    pytest.mark.django_db,
+    pytest.mark.usefixtures("_disable_elasticsearch"),
+]
+
+
+def test_reset_application_allocation():
+    # given:
+    # - There is a single handled application in an application round in allocation
+    application_round = ApplicationRoundFactory.create_in_status_in_allocation()
+    application = ApplicationFactory.create_in_status_handled(application_round=application_round)
+
+    # when:
+    # - User tries to reset allocation on the application
+    application.actions.reset_application_allocation()
+
+    # then:
+    # - The application is in allocation again
+    application.refresh_from_db()
+    assert application.status == ApplicationStatusChoice.IN_ALLOCATION
+
+
+def test_reset_application_round_allocation():
+    # given:
+    # - There is a single handled application in an application round in allocation
+    application_round = ApplicationRoundFactory.create_in_status_in_allocation()
+    application_1 = ApplicationFactory.create_in_status_handled(application_round=application_round)
+    application_2 = ApplicationFactory.create_in_status_handled(application_round=application_round)
+    application_3 = ApplicationFactory.create_in_status_handled(application_round=application_round)
+
+    # when:
+    # - User tries to reset allocation on the application
+    application_round.actions.reset_application_round_allocation()
+
+    # then:
+    # - The application is in allocation again
+    application_1.refresh_from_db()
+    assert application_1.status == ApplicationStatusChoice.IN_ALLOCATION
+    application_2.refresh_from_db()
+    assert application_2.status == ApplicationStatusChoice.IN_ALLOCATION
+    application_3.refresh_from_db()
+    assert application_3.status == ApplicationStatusChoice.IN_ALLOCATION

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -247,7 +247,7 @@ if env("DATABASE_ENGINE"):
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [


### PR DESCRIPTION
## 🛠️ Changelog
- Add an option to reset application rounds' or applications' allocation from the admin panel

## 🎫 Tickets
*This pull request resolves all or part of the following ticket(s):*
- [TILA-2771](https://helsinkisolutionoffice.atlassian.net/browse/TILA-2771)


[TILA-2771]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-2771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ