### PR TITLE
Fix first reservable time bug with blocking reservation

### DIFF
--- a/common/date_utils.py
+++ b/common/date_utils.py
@@ -1,0 +1,222 @@
+import datetime
+import zoneinfo
+
+from django.conf import settings
+
+__all__ = [
+    "local_timezone",
+    "local_datetime",
+    "local_date",
+    "local_time",
+    "local_time_min",
+    "local_time_max",
+    "utc_datetime",
+    "utc_date",
+    "utc_time",
+    "utc_datetime_min",
+    "utc_datetime_max",
+    "utc_time_min",
+    "utc_time_max",
+    "combine",
+    "datetimes_equal",
+    "times_equal",
+    "timedelta_to_json",
+    "timedelta_from_json",
+]
+
+
+### LOCAL TIME ###########################################################################################
+
+
+def local_timezone() -> datetime.timezone:
+    """
+    Fetch local timezone used to convert naive datetimes to aware datetimes.
+
+    Cannot use `django.utils.timezone.get_default_timezone()`,
+    because it returns a `zoneinfo.ZoneInfo` object, which when used together with
+    `datetime.timezone` (e.g. datetime.UTC/datetime.timezone.utc) will not work as
+    expected when comparing with `datetime.time` objects:
+
+    ```python 3.11
+    import zoneinfo
+    import datetime
+
+    tz = zoneinfo.ZoneInfo("Europe/Helsinki")
+
+    dt_1 = datetime.datetime(2021, 1, 1, tzinfo=tz)
+    dt_2 = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+
+    assert dt_1 < dt_2  # Works as expected
+
+    t_1 = datetime.time(tzinfo=tz)
+    t_2 = datetime.time(tzinfo=datetime.UTC)
+
+    assert t_1 < t_2  # raises "TypeError: can't compare offset-naive and offset-aware times"
+    ```
+    """
+    return datetime.timezone(
+        zoneinfo.ZoneInfo(settings.TIME_ZONE).utcoffset(datetime.datetime.utcnow()),
+        name=settings.TIME_ZONE,
+    )
+
+
+def local_datetime() -> datetime.datetime:
+    """Get current datetime in the local timezone."""
+    return datetime.datetime.now(tz=local_timezone())
+
+
+def local_date() -> datetime.date:
+    """Get current date in the local timezone."""
+    return local_datetime().date()
+
+
+def local_time() -> datetime.time:
+    """Get current time in the local timezone."""
+    return local_datetime().timetz()
+
+
+def local_datetime_min():
+    """Get the minimum datetime of the day in the local timezone."""
+    return datetime.datetime.min.replace(tzinfo=local_timezone())
+
+
+def local_datetime_max():
+    """Get the maximum datetime of the day in the local timezone."""
+    return datetime.datetime.max.replace(tzinfo=local_timezone())
+
+
+def local_time_min():
+    """Get the minimum time of the day in the local timezone."""
+    return datetime.time.min.replace(tzinfo=local_timezone())
+
+
+def local_time_max():
+    """Get the maximum time of the day in the local timezone."""
+    return datetime.time.max.replace(tzinfo=local_timezone())
+
+
+### UTC TIME #############################################################################################
+
+
+def utc_datetime() -> datetime.datetime:
+    """Get current datetime in UTC."""
+    return datetime.datetime.now(tz=datetime.UTC)
+
+
+def utc_date() -> datetime.date:
+    """Get current date in UTC."""
+    return utc_datetime().date()
+
+
+def utc_time() -> datetime.time:
+    """Get current time in UTC."""
+    return utc_datetime().timetz()
+
+
+def utc_datetime_min():
+    """Get the minimum datetime of the day in UTC."""
+    return datetime.datetime.min.replace(tzinfo=datetime.UTC)
+
+
+def utc_datetime_max():
+    """Get the maximum datetime of the day in UTC."""
+    return datetime.datetime.max.replace(tzinfo=datetime.UTC)
+
+
+def utc_time_min():
+    """Get the minimum time of the day in UTC."""
+    return datetime.time.min.replace(tzinfo=datetime.UTC)
+
+
+def utc_time_max():
+    """Get the maximum time of the day in UTC."""
+    return datetime.time.max.replace(tzinfo=datetime.UTC)
+
+
+### COMMON UTILS #########################################################################################
+
+
+def combine(date: datetime.date, time: datetime.time) -> datetime.datetime:
+    """Combine a date and a timezone aware time to a datetime object."""
+    if time.utcoffset() is None:
+        raise ValueError("Time must be timezone-aware using `datetime.timezone` objects.")
+    return datetime.datetime.combine(date, time)
+
+
+def datetimes_equal(_dt_1: datetime.datetime, _dt_2: datetime.datetime, /, *, check_same_tz: bool = False) -> bool:
+    """
+    Check if two timezone-aware datetime objects are equal.
+
+    This is needed because equals checks for datetime objects can give false results
+    if `zoneinfo.ZoneInfo` objects are used for `tzinfo`:
+
+    ```python 3.11
+    import zoneinfo
+    import datetime
+
+    tz = zoneinfo.ZoneInfo("Europe/Helsinki")
+
+    dt_1 = datetime.datetime(2021, 1, 1, tzinfo=tz)
+    dt_2 = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    dt_3 = datetime.datetime(2021, 1, 1)
+
+    assert dt_1 >= dt_3  # Works
+    assert dt_1 <= dt_3  # Works??? This should be False, right?
+    assert dt_2 >= dt_3  # raises "TypeError: can't compare offset-naive and offset-aware times"
+    ```
+    """
+    if _dt_1.utcoffset() is None:
+        raise ValueError("First datetime must be timezone-aware using `datetime.timezone` objects.")
+    if _dt_2.utcoffset() is None:
+        raise ValueError("Second datetime must be timezone-aware using `datetime.timezone` objects.")
+    if check_same_tz and _dt_1.tzname() != _dt_2.tzname():
+        msg = f"Timezones of both datetimes must be the same. Got: {_dt_1.tzname()} and {_dt_2.tzname()}"
+        raise ValueError(msg)
+    return _dt_1 == _dt_2
+
+
+def times_equal(_t_1: datetime.time, _t_2: datetime.time, /, *, check_same_tz: bool = False) -> bool:
+    """
+    Check if two timezone-aware time objects are equal.
+
+    This is needed because equals checks for time objects can give false results
+    if `zoneinfo.ZoneInfo` objects are used for `tzinfo`:
+
+    ```python 3.11
+    import zoneinfo
+    import datetime
+
+    tz = zoneinfo.ZoneInfo("Europe/Helsinki")
+
+    t_1 = datetime.time(tzinfo=tz)
+    t_2 = datetime.time(tzinfo=datetime.UTC)
+    t_3 = datetime.time()
+
+    assert t_1 >= t_3  # Works
+    assert t_1 <= t_3  # Works??? This should be False, right?
+    assert t_2 >= t_3  # raises "TypeError: can't compare offset-naive and offset-aware times"
+    ```
+    """
+    if _t_1.utcoffset() is None:
+        msg = "First time must be timezone-aware using `datetime.timezone` objects."
+        raise ValueError(msg)
+    if _t_2.utcoffset() is None:
+        msg = "Second time must be timezone-aware using `datetime.timezone` objects."
+        raise ValueError(msg)
+    if check_same_tz and _t_1.tzname() != _t_2.tzname():
+        msg = f"Timezones of both times must be the same. Got: {_t_1.tzname()} and {_t_2.tzname()}"
+        raise ValueError(msg)
+    return _t_1 == _t_2
+
+
+def timedelta_to_json(delta: datetime.timedelta) -> str:
+    return str(delta).zfill(8)
+
+
+def timedelta_from_json(delta: str) -> datetime.timedelta:
+    try:
+        time_ = datetime.datetime.strptime(delta, "%H:%M:%S")
+    except ValueError:
+        time_ = datetime.datetime.strptime(delta, "%H:%M")
+
+    return datetime.timedelta(hours=time_.hour, minutes=time_.minute, seconds=time_.second)

--- a/common/date_utils.py
+++ b/common/date_utils.py
@@ -147,8 +147,7 @@ def datetimes_equal(_dt_1: datetime.datetime, _dt_2: datetime.datetime, /, *, ch
     """
     Check if two timezone-aware datetime objects are equal.
 
-    This is needed because equals checks for datetime objects can give false results
-    if `zoneinfo.ZoneInfo` objects are used for `tzinfo`:
+    This is needed because == / != checks for datetime objects don't check for timezone-awareness:
 
     ```python 3.11
     import zoneinfo
@@ -156,19 +155,21 @@ def datetimes_equal(_dt_1: datetime.datetime, _dt_2: datetime.datetime, /, *, ch
 
     tz = zoneinfo.ZoneInfo("Europe/Helsinki")
 
-    dt_1 = datetime.datetime(2021, 1, 1, tzinfo=tz)
-    dt_2 = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
-    dt_3 = datetime.datetime(2021, 1, 1)
+    dt_zi = datetime.datetime(2021, 1, 1, tzinfo=tz)
+    dt_tz = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    dt_naive = datetime.datetime(2021, 1, 1)
 
-    assert dt_1 >= dt_3  # Works
-    assert dt_1 <= dt_3  # Works??? This should be False, right?
-    assert dt_2 >= dt_3  # raises "TypeError: can't compare offset-naive and offset-aware times"
+    # There might not be true, since on datetime is timezone-aware and the other is not.
+    assert dt_zi != dt_naive
+    assert dt_tz != dt_naive
     ```
     """
     if _dt_1.utcoffset() is None:
-        raise ValueError("First datetime must be timezone-aware using `datetime.timezone` objects.")
+        msg = "First datetime must be timezone-aware using `datetime.timezone` objects."
+        raise ValueError(msg)
     if _dt_2.utcoffset() is None:
-        raise ValueError("Second datetime must be timezone-aware using `datetime.timezone` objects.")
+        msg = "Second datetime must be timezone-aware using `datetime.timezone` objects."
+        raise ValueError(msg)
     if check_same_tz and _dt_1.tzname() != _dt_2.tzname():
         msg = f"Timezones of both datetimes must be the same. Got: {_dt_1.tzname()} and {_dt_2.tzname()}"
         raise ValueError(msg)
@@ -179,8 +180,8 @@ def times_equal(_t_1: datetime.time, _t_2: datetime.time, /, *, check_same_tz: b
     """
     Check if two timezone-aware time objects are equal.
 
-    This is needed because equals checks for time objects can give false results
-    if `zoneinfo.ZoneInfo` objects are used for `tzinfo`:
+    This is needed because == / != checks for time objects don't check for timezone-awareness,
+    and / < / <= / > / >= checks can give false results if `zoneinfo.ZoneInfo` objects are used for `tzinfo`:
 
     ```python 3.11
     import zoneinfo
@@ -188,13 +189,13 @@ def times_equal(_t_1: datetime.time, _t_2: datetime.time, /, *, check_same_tz: b
 
     tz = zoneinfo.ZoneInfo("Europe/Helsinki")
 
-    t_1 = datetime.time(tzinfo=tz)
-    t_2 = datetime.time(tzinfo=datetime.UTC)
-    t_3 = datetime.time()
+    t_zi = datetime.time(tzinfo=tz)
+    t_tz = datetime.time(tzinfo=datetime.UTC)
+    t_naive = datetime.time()
 
-    assert t_1 >= t_3  # Works
-    assert t_1 <= t_3  # Works??? This should be False, right?
-    assert t_2 >= t_3  # raises "TypeError: can't compare offset-naive and offset-aware times"
+    assert t_zi >= t_naive  # Works
+    assert t_zi <= t_naive  # Works??? This should be False, right?
+    assert t_tz >= t_naive  # raises "TypeError: can't compare offset-naive and offset-aware times"
     ```
     """
     if _t_1.utcoffset() is None:

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,5 +1,4 @@
 from collections.abc import Sequence
-from datetime import datetime, timedelta
 from typing import Any, Literal
 
 from django.conf import settings
@@ -11,8 +10,6 @@ __all__ = [
     "get_field_to_related_field_mapping",
     "get_nested",
     "get_translation_fields",
-    "timedelta_from_json",
-    "timedelta_to_json",
 ]
 
 
@@ -42,19 +39,6 @@ def get_nested(obj: dict | list | None, /, *args: str | int, default: Any = None
 
     obj = obj or {}
     return get_nested(obj.get(arg), *args, default=default)
-
-
-def timedelta_to_json(delta: timedelta) -> str:
-    return str(delta).zfill(8)
-
-
-def timedelta_from_json(delta: str) -> timedelta:
-    try:
-        time_ = datetime.strptime(delta, "%H:%M:%S")
-    except ValueError:
-        time_ = datetime.strptime(delta, "%H:%M")
-
-    return timedelta(hours=time_.hour, minutes=time_.minute, seconds=time_.second)
 
 
 def comma_sep_str(values: Sequence[str]) -> str:

--- a/tests/test_graphql_api/test_application/helpers.py
+++ b/tests/test_graphql_api/test_application/helpers.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from applications.choices import ApplicantTypeChoice, WeekdayChoice
 from applications.models import Application, ApplicationRound
-from common.utils import timedelta_to_json
+from common.date_utils import timedelta_to_json
 from tests.factories import (
     AbilityGroupFactory,
     AgeGroupFactory,

--- a/tests/test_graphql_api/test_application_event/helpers.py
+++ b/tests/test_graphql_api/test_application_event/helpers.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from applications.choices import WeekdayChoice
 from applications.models import Application, ApplicationEvent
-from common.utils import timedelta_to_json
+from common.date_utils import timedelta_to_json
 from tests.factories import AbilityGroupFactory, AgeGroupFactory, ReservationPurposeFactory, ReservationUnitFactory
 from tests.gql_builders import build_mutation, build_query
 

--- a/tests/test_graphql_api/test_application_event/test_create.py
+++ b/tests/test_graphql_api/test_application_event/test_create.py
@@ -4,7 +4,7 @@ import pytest
 
 from applications.choices import ApplicationEventStatusChoice
 from applications.models import ApplicationEvent
-from common.utils import timedelta_from_json
+from common.date_utils import timedelta_from_json
 from tests.factories import ApplicationFactory
 from tests.test_graphql_api.test_application_event.helpers import CREATE_MUTATION, get_application_event_create_data
 

--- a/tests/test_graphql_api/test_application_event/test_update.py
+++ b/tests/test_graphql_api/test_application_event/test_update.py
@@ -4,7 +4,7 @@ import pytest
 
 from applications.choices import ApplicationEventStatusChoice
 from applications.models import ApplicationEvent
-from common.utils import timedelta_from_json
+from common.date_utils import timedelta_from_json
 from tests.factories import ApplicationEventFactory, EventReservationUnitFactory
 from tests.test_graphql_api.test_application_event.helpers import UPDATE_MUTATION, get_application_event_update_data
 

--- a/tests/test_utils/test_date_util.py
+++ b/tests/test_utils/test_date_util.py
@@ -1,7 +1,29 @@
 import datetime
+import zoneinfo
 
+import freezegun
 import pytest
 
+from common.date_utils import (
+    combine,
+    datetimes_equal,
+    local_date,
+    local_datetime,
+    local_datetime_max,
+    local_datetime_min,
+    local_time,
+    local_time_max,
+    local_time_min,
+    local_timezone,
+    times_equal,
+    utc_date,
+    utc_datetime,
+    utc_datetime_max,
+    utc_datetime_min,
+    utc_time,
+    utc_time_max,
+    utc_time_min,
+)
 from tilavarauspalvelu.utils.date_util import (
     InvalidWeekdayException,
     localized_short_weekday,
@@ -75,3 +97,343 @@ def test_localized_short_weekday_en():
     assert localized_short_weekday(4, lang_code) == "Fr"
     assert localized_short_weekday(5, lang_code) == "Sa"
     assert localized_short_weekday(6, lang_code) == "Su"
+
+
+# The following tests demonstrate some bugs between `datetime.timezone` and `zoneinfo.ZoneInfo` when
+# with comparing timezone-aware and timezone-naive datetimes/times. The date utils are needed because
+# of these bugs, so check that they still hold true. If they start failing, the helpers might
+# have become unnecessary.
+TIMEZONE = zoneinfo.ZoneInfo("Europe/Helsinki")
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_timezone(settings):
+    tz = local_timezone()
+    assert tz.utcoffset(None) == datetime.timedelta(seconds=7200)
+    assert tz.tzname(None) == settings.TIME_ZONE
+
+    # These should be the same, but aren't, so check that this is still the case.
+    assert tz.utcoffset(None) != TIMEZONE.utcoffset(None)
+    assert tz.tzname(None) != TIMEZONE.tzname(None)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_datetime():
+    tz = local_timezone()
+    dt_1 = local_datetime()
+    dt_2 = datetime.datetime(2024, 1, 1, hour=2, tzinfo=tz)
+    dt_3 = datetime.datetime(2024, 1, 1, hour=2, tzinfo=TIMEZONE)
+    dt_4 = datetime.datetime(2024, 1, 1, hour=2)
+
+    msg = "can't compare offset-naive and offset-aware datetimes"
+
+    assert dt_1 == dt_2
+    assert dt_1 >= dt_2
+    assert dt_1 <= dt_2
+
+    assert dt_1 == dt_3
+    assert dt_1 >= dt_3
+    assert dt_1 <= dt_3
+
+    assert dt_1 != dt_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_1 >= dt_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_1 <= dt_4
+
+    assert dt_3 != dt_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_3 >= dt_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_3 <= dt_4
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_date():
+    assert local_date() == datetime.date(2024, 1, 1)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_time():
+    tz = local_timezone()
+
+    t_1 = local_time()
+    t_2 = datetime.time(hour=2, tzinfo=tz)
+    t_3 = datetime.time(hour=2, tzinfo=TIMEZONE)
+    t_4 = datetime.time(hour=2)
+
+    msg = "can't compare offset-naive and offset-aware times"
+
+    assert t_1 == t_2
+    assert t_1 >= t_2
+    assert t_1 <= t_2
+
+    assert t_1 != t_3  # Should be equal, but isn't, so check that this is still the case.
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_1 >= t_3
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_1 <= t_3
+
+    assert t_1 != t_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_1 >= t_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_1 <= t_4
+
+    assert t_3 == t_4  # This should not be equal, but is, so check that this is still the case.
+    assert t_3 >= t_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+    assert t_3 <= t_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_datetime_min():
+    tz = local_timezone()
+    dt_min_1 = local_datetime_min()
+    dt_min_2 = datetime.datetime.min.replace(tzinfo=tz)
+    dt_min_3 = datetime.datetime.min.replace(tzinfo=TIMEZONE)
+    dt_min_4 = datetime.datetime.min
+
+    msg = "can't compare offset-naive and offset-aware datetimes"
+
+    assert dt_min_1 == dt_min_2
+    assert dt_min_1 >= dt_min_2
+    assert dt_min_1 <= dt_min_2
+
+    assert dt_min_1 != dt_min_3  # Should be equal, but isn't, so check that this is still the case.
+    assert not (dt_min_1 >= dt_min_3)  # Should be true, but isn't, so check that this is still the case.
+    assert dt_min_1 <= dt_min_3
+
+    assert dt_min_1 != dt_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_min_1 >= dt_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_min_1 <= dt_min_4
+
+    assert dt_min_3 != dt_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_min_3 >= dt_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_min_3 <= dt_min_4
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_datetime_max():
+    tz = local_timezone()
+    dt_max_1 = local_datetime_max()
+    dt_max_2 = datetime.datetime.max.replace(tzinfo=tz)
+    dt_max_3 = datetime.datetime.max.replace(tzinfo=TIMEZONE)
+    dt_max_4 = datetime.datetime.max
+
+    msg = "can't compare offset-naive and offset-aware datetimes"
+
+    assert dt_max_1 == dt_max_2
+    assert dt_max_1 >= dt_max_2
+    assert dt_max_1 <= dt_max_2
+
+    assert dt_max_1 == dt_max_3
+    assert dt_max_1 >= dt_max_3
+    assert dt_max_1 <= dt_max_3
+
+    assert dt_max_1 != dt_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_max_1 >= dt_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_max_1 <= dt_max_4
+
+    assert dt_max_3 != dt_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_max_3 >= dt_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert dt_max_3 <= dt_max_4
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_time_min():
+    tz = local_timezone()
+    t_min_1 = local_time_min()
+    t_min_2 = datetime.time.min.replace(tzinfo=tz)
+    t_min_3 = datetime.time.min.replace(tzinfo=TIMEZONE)
+    t_min_4 = datetime.time.min
+
+    msg = "can't compare offset-naive and offset-aware times"
+
+    assert t_min_1 == t_min_2
+    assert t_min_1 >= t_min_2
+    assert t_min_1 <= t_min_2
+
+    assert t_min_1 != t_min_3  # Should be equal, but isn't, so check that this is still the case.
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_min_1 >= t_min_3
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_min_1 <= t_min_3
+
+    assert t_min_1 != t_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_min_1 >= t_min_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_min_1 <= t_min_4
+
+    assert t_min_3 == t_min_4  # This should not be equal, but is, so check that this is still the case.
+    assert t_min_3 >= t_min_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+    assert t_min_3 <= t_min_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__local_time_max():
+    tz = local_timezone()
+    t_max_1 = local_time_max()
+    t_max_2 = datetime.time.max.replace(tzinfo=tz)
+    t_max_3 = datetime.time.max.replace(tzinfo=TIMEZONE)
+    t_max_4 = datetime.time.max
+
+    msg = "can't compare offset-naive and offset-aware times"
+
+    assert t_max_1 == t_max_2
+    assert t_max_1 >= t_max_2
+    assert t_max_1 <= t_max_2
+
+    assert t_max_1 != t_max_3  # Should be equal, but isn't, so check that this is still the case.
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_max_1 >= t_max_3
+    with pytest.raises(TypeError, match=msg):  # Should not raise, but does, so check that this is still the case.
+        assert t_max_1 <= t_max_3
+
+    assert t_max_1 != t_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_max_1 >= t_max_4
+    with pytest.raises(TypeError, match=msg):
+        assert t_max_1 <= t_max_4
+
+    assert t_max_3 == t_max_4  # This should not be equal, but is, so check that this is still the case.
+    assert t_max_3 >= t_max_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+    assert t_max_3 <= t_max_4  # This should raise a TypeError, but doesn't, so check that this is still the case.
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_datetime():
+    assert utc_datetime() == datetime.datetime.now(tz=datetime.UTC)
+    assert utc_datetime() >= datetime.datetime.now(tz=datetime.UTC)
+    assert utc_datetime() <= datetime.datetime.now(tz=datetime.UTC)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_date():
+    assert utc_date() == datetime.datetime.now(tz=datetime.UTC).date()
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_time():
+    assert utc_time() == datetime.datetime.now(tz=datetime.UTC).timetz()
+    assert utc_time() >= datetime.datetime.now(tz=datetime.UTC).timetz()
+    assert utc_time() <= datetime.datetime.now(tz=datetime.UTC).timetz()
+
+    msg = "can't compare offset-naive and offset-aware times"
+
+    assert utc_time() != datetime.datetime.now(tz=datetime.UTC).time()
+    with pytest.raises(TypeError, match=msg):
+        assert utc_time() >= datetime.datetime.now(tz=datetime.UTC).time()
+    with pytest.raises(TypeError, match=msg):
+        assert utc_time() <= datetime.datetime.now(tz=datetime.UTC).time()
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_datetime_min():
+    assert utc_datetime_min() == datetime.datetime.min.replace(tzinfo=datetime.UTC)
+    assert utc_datetime_min() >= datetime.datetime.min.replace(tzinfo=datetime.UTC)
+    assert utc_datetime_min() <= datetime.datetime.min.replace(tzinfo=datetime.UTC)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_datetime_max():
+    assert utc_datetime_max() == datetime.datetime.max.replace(tzinfo=datetime.UTC)
+    assert utc_datetime_max() >= datetime.datetime.max.replace(tzinfo=datetime.UTC)
+    assert utc_datetime_max() <= datetime.datetime.max.replace(tzinfo=datetime.UTC)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_time_min():
+    assert utc_time_min() == datetime.time.min.replace(tzinfo=datetime.UTC)
+    assert utc_time_min() >= datetime.time.min.replace(tzinfo=datetime.UTC)
+    assert utc_time_min() <= datetime.time.min.replace(tzinfo=datetime.UTC)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__utc_time_max():
+    assert utc_time_max() == datetime.time.max.replace(tzinfo=datetime.UTC)
+    assert utc_time_max() >= datetime.time.max.replace(tzinfo=datetime.UTC)
+    assert utc_time_max() <= datetime.time.max.replace(tzinfo=datetime.UTC)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__combine():
+    dt = combine(utc_date(), utc_time())
+    assert dt == datetime.datetime.now(tz=datetime.UTC)
+
+    msg = "Time must be timezone-aware using `datetime.timezone` objects."
+    with pytest.raises(ValueError, match=msg):
+        combine(utc_date(), datetime.time.min)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__datetimes_equal():
+    dt_zi = datetime.datetime(2021, 1, 1, tzinfo=TIMEZONE)
+    dt_tz = datetime.datetime(2021, 1, 1, tzinfo=datetime.UTC)
+    dt_naive = datetime.datetime(2021, 1, 1)
+
+    msg = "can't compare offset-naive and offset-aware datetimes"
+
+    with pytest.raises(TypeError, match=msg):
+        assert dt_zi >= dt_naive
+    with pytest.raises(TypeError, match=msg):
+        assert dt_zi <= dt_naive
+    with pytest.raises(TypeError, match=msg):
+        assert dt_tz >= dt_naive
+    with pytest.raises(TypeError, match=msg):
+        assert dt_tz <= dt_naive
+
+    assert dt_zi != dt_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+    assert dt_tz != dt_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+
+    msg = "First datetime must be timezone-aware using `datetime.timezone` objects."
+    with pytest.raises(ValueError, match=msg):
+        datetimes_equal(dt_naive, dt_tz)
+
+    datetimes_equal(dt_zi, dt_tz)
+
+    msg = "Second datetime must be timezone-aware using `datetime.timezone` objects."
+    with pytest.raises(ValueError, match=msg):
+        datetimes_equal(dt_tz, dt_naive)
+
+    datetimes_equal(dt_tz, dt_zi)
+
+
+@freezegun.freeze_time(datetime.datetime(2024, 1, 1, tzinfo=datetime.UTC))
+def test_date_utils__times_equal():
+    t_zi = datetime.time(tzinfo=TIMEZONE)
+    t_tz = datetime.time(tzinfo=datetime.UTC)
+    t_naive = datetime.time()
+
+    msg = "can't compare offset-naive and offset-aware times"
+
+    assert t_zi >= t_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+    assert t_zi <= t_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+
+    with pytest.raises(TypeError, match=msg):
+        assert t_tz >= t_naive
+    with pytest.raises(TypeError, match=msg):
+        assert t_tz <= t_naive
+
+    assert t_zi == t_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+    assert t_tz != t_naive  # Comparing timezone aware and naive times, so this should raise, but doesn't.
+
+    msg = "First time must be timezone-aware using `datetime.timezone` objects."
+    with pytest.raises(ValueError, match=msg):
+        times_equal(t_naive, t_tz)
+    with pytest.raises(ValueError, match=msg):
+        times_equal(t_zi, t_tz)  # Should not raise, but does, so check that this is still the case.
+
+    msg = "Second time must be timezone-aware using `datetime.timezone` objects."
+    with pytest.raises(ValueError, match=msg):
+        times_equal(t_tz, t_naive)
+    with pytest.raises(ValueError, match=msg):
+        times_equal(t_tz, t_zi)  # Should not raise, but does, so check that this is still the case.


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix issues where blocking reservations were not handled correctly when different timezone objects were used to make time objects timezone-aware. 
    - Added utilities that should allow handling these situations correctly

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated tests

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
