### PR TITLE
Fix ReservationUnits in common hierarchy by Resource but with unrelated Space

### DIFF
--- a/reservations/querysets.py
+++ b/reservations/querysets.py
@@ -121,6 +121,10 @@ class ReservationQuerySet(QuerySet):
                 # Get the full family of the space.
                 family: set[SpacePK] = space_to_family.get(space_id)
 
+                # Space is not related in common hierarchy with any of the reservation units, skip it.
+                if family is None:
+                    continue
+
                 for reservation_unit_info in reservation_unit_infos:
                     # If any space from the family is a direct space on the reservation unit,
                     # add a timespan from the reservation to the reservation unit, but only once.


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes a bug that was discovered in manual testing
- This bug occurred when:
  - Two ReservationUnits are in common hierarchy by a Resource
  - The second ReservationUnit has a Space, which is completely unrelated to the other ReservationUnits Spaces
  - The GraphQL query includes other filters (such as `pk`, `name_fi`, etc.) which filter out the second ReservationUnit


## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated tests

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

None
