### PR TITLE
Fix admin autocomplete modals not working with `extra_context`

### DIFF
--- a/tilavarauspalvelu/urls.py
+++ b/tilavarauspalvelu/urls.py
@@ -8,6 +8,10 @@ from graphene_file_upload.django import FileUploadGraphQLView
 from api.legacy_rest_api.urls import legacy_outer
 from api.webhooks.urls import webhook_router
 
+# Mock the autocomplete view to be able to include `extra_context` for other pages
+real_autocomplete_view = admin.site.autocomplete_view
+admin.site.autocomplete_view = lambda request, extra_context: real_autocomplete_view(request)
+
 urlpatterns = [
     path("graphql/", csrf_exempt(FileUploadGraphQLView.as_view(graphiql=settings.DEBUG))),  # NOSONAR
     path("admin/", admin.site.urls, {"extra_context": {"version": settings.APP_VERSION}}),


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix admin panel autocomplete modals not working with `extra_context`.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Tested locally by going into e.g. `/admin/permissions/unitrole/add` and trying to select a unit group. Autocomplete should now work.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
