### PR TITLE
Add new schedule approve validation rules

### DIFF
--- a/actions/application_event.py
+++ b/actions/application_event.py
@@ -26,5 +26,5 @@ class ApplicationEventActions:
             raise ValidationError(_(f"Cannot create reservations for event based on its status: '{status.value}'"))
 
         schedule: "ApplicationEventSchedule"
-        for schedule in self.application_event.application_event_schedules.all().allocated():
+        for schedule in self.application_event.application_event_schedules.all().accepted():
             schedule.actions.create_reservation_for_schedule()

--- a/api/graphql/types/application_event_schedule/serializers.py
+++ b/api/graphql/types/application_event_schedule/serializers.py
@@ -1,3 +1,4 @@
+import datetime
 from collections import defaultdict
 from typing import Any
 
@@ -5,11 +6,15 @@ from rest_framework import serializers
 from rest_framework.settings import api_settings
 
 from applications.models import ApplicationEventSchedule
+from common.date_utils import time_difference, timedelta_to_json
 from common.serializers import TranslatedModelSerializer
+from reservation_units.models import ReservationUnit
 
 
 class ApplicationEventScheduleApproveSerializer(TranslatedModelSerializer):
     instance: ApplicationEventSchedule
+
+    force = serializers.BooleanField(default=False, required=False, write_only=True)
 
     class Meta:
         model = ApplicationEventSchedule
@@ -19,6 +24,7 @@ class ApplicationEventScheduleApproveSerializer(TranslatedModelSerializer):
             "allocated_begin",
             "allocated_end",
             "allocated_reservation_unit",
+            "force",
         ]
         # All fields should be set when approving a schedule
         extra_kwargs = {
@@ -30,7 +36,35 @@ class ApplicationEventScheduleApproveSerializer(TranslatedModelSerializer):
 
     def validate(self, data: dict[str, Any]) -> dict[str, Any]:
         errors: dict[str, list[str]] = defaultdict(list)
+        force: bool = data.pop("force", False)
 
+        self.validate_statuses(errors)
+        self.validate_reservation_unit(data["allocated_reservation_unit"], errors)
+        self.validate_not_already_allocated(
+            data["allocated_day"],
+            data["allocated_begin"],
+            data["allocated_end"],
+            data["allocated_reservation_unit"],
+            errors,
+        )
+        self.validate_no_events_on_the_same_day(data["allocated_day"], errors)
+
+        if not force:
+            self.validate_duration(data["allocated_begin"], data["allocated_end"], errors)
+            self.validate_with_events_accepted_schedules(data["allocated_day"], errors)
+            self.validate_within_wished_period(
+                data["allocated_day"],
+                data["allocated_begin"],
+                data["allocated_end"],
+                errors,
+            )
+
+        if errors:
+            raise serializers.ValidationError(errors)
+
+        return data
+
+    def validate_statuses(self, errors: dict[str, list[str]]) -> None:
         event_status = self.instance.application_event.status
         application_status = self.instance.application_event.application.status
 
@@ -42,13 +76,117 @@ class ApplicationEventScheduleApproveSerializer(TranslatedModelSerializer):
             msg = f"Schedule cannot be approved for application in status: '{application_status.value}'"
             errors[api_settings.NON_FIELD_ERRORS_KEY].append(msg)
 
-        if errors:
-            raise serializers.ValidationError(errors)
+    def validate_reservation_unit(self, reservation_unit: ReservationUnit, errors: dict[str, list[str]]) -> None:
+        includes_reservation_unit = self.instance.application_event.event_reservation_units.filter(
+            reservation_unit=reservation_unit,
+        ).exists()
 
-        return data
+        if not includes_reservation_unit:
+            msg = "Cannot allocate schedule for this reservation unit. Reservation unit is not included in the event."
+            errors["allocated_reservation_unit"].append(msg)
 
-    def update(self, instance: ApplicationEventSchedule, validated_data: dict[str, Any]):
-        return super().update(instance, validated_data)
+    def validate_not_already_allocated(
+        self,
+        day: int,
+        begin: datetime.time,
+        end: datetime.time,
+        reservation_unit: ReservationUnit,
+        errors: dict[str, list[str]],
+    ) -> None:
+        min_day = self.instance.application_event.begin
+        max_day = self.instance.application_event.end
+        if min_day is None or max_day is None:
+            msg = "Cannot allocate schedule for this day and time period. Event begin and end dates must be set."
+            errors[api_settings.NON_FIELD_ERRORS_KEY].append(msg)
+            return
+
+        has_overlapping_allocations = (
+            ApplicationEventSchedule.objects.exclude(pk=self.instance.pk)
+            .filter(
+                # Only fetch events that overlap with this event,
+                # see `opening_hours.utils.time_span_element.TimeSpanElement.overlaps_with`
+                application_event__begin__lt=max_day,
+                application_event__end__gt=min_day,
+                # TODO: [TILA-2904] can't be overlapping with common resource or space hierarchy.
+                allocated_reservation_unit=reservation_unit,
+            )
+            .has_overlapping_allocations(day=day, begin=begin, end=end)
+        )
+
+        if has_overlapping_allocations:
+            msg = (
+                "Cannot allocate schedule for this day and time period. "
+                "Given time period has already been allocated for another event "
+                "with the same reservation unit."
+            )
+            errors[api_settings.NON_FIELD_ERRORS_KEY].append(msg)
+
+    def validate_no_events_on_the_same_day(self, day: int, errors: dict[str, list[str]]) -> None:
+        events_schedules = self.instance.application_event.application_event_schedules.all()
+        other_schedules = events_schedules.exclude(pk=self.instance.pk)
+
+        accepted_same_day: int = other_schedules.filter(allocated_day=day).accepted().count()
+
+        if accepted_same_day != 0:
+            msg = "Cannot allocate multiple schedules on the same day for one event."
+            errors["allocated_day"].append(msg)
+
+    def validate_duration(self, begin: datetime.time, end: datetime.time, errors: dict[str, list[str]]) -> None:
+        duration = time_difference(end, begin)
+
+        if duration < self.instance.application_event.min_duration:
+            min_allowed = timedelta_to_json(self.instance.application_event.min_duration)
+            given_duration = timedelta_to_json(duration)
+            msg = (
+                f"Allocation duration too short. "
+                f"Minimum allowed is {min_allowed} "
+                f"while given duration is {given_duration}."
+            )
+            errors["allocated_end"].append(msg)
+
+        if duration > self.instance.application_event.max_duration:
+            max_allowed = timedelta_to_json(self.instance.application_event.max_duration)
+            given_duration = timedelta_to_json(duration)
+            msg = (
+                f"Allocation duration too long. "
+                f"Maximum allowed is {max_allowed} "
+                f"while given duration is {given_duration}."
+            )
+            errors["allocated_end"].append(msg)
+
+        if duration.total_seconds() % 900 != 0:
+            msg = "Allocation duration must be a multiple of 15 minutes."
+            errors["allocated_end"].append(msg)
+
+    def validate_with_events_accepted_schedules(self, day: int, errors: dict[str, list[str]]) -> None:
+        events_schedules = self.instance.application_event.application_event_schedules.all()
+        other_schedules = events_schedules.exclude(pk=self.instance.pk)
+
+        accepted: int = other_schedules.accepted().count()
+
+        if accepted >= (self.instance.application_event.events_per_week or 0):
+            msg = (
+                f"Cannot allocate more schedules for this event. "
+                f"Maximum allowed is {self.instance.application_event.events_per_week or 0}."
+            )
+            errors[api_settings.NON_FIELD_ERRORS_KEY].append(msg)
+
+    def validate_within_wished_period(
+        self,
+        day: int,
+        begin: datetime.time,
+        end: datetime.time,
+        errors: dict[str, list[str]],
+    ) -> None:
+        events_schedules = self.instance.application_event.application_event_schedules.all()
+
+        can_allocate: bool = events_schedules.allocation_fits_in_wished_periods(day=day, begin=begin, end=end)
+        if not can_allocate:
+            msg = (
+                "Cannot allocate schedule for this day and time period. "
+                "Given time period does not fit within applicants wished periods."
+            )
+            errors[api_settings.NON_FIELD_ERRORS_KEY].append(msg)
 
 
 class ApplicationEventScheduleDeclineSerializer(TranslatedModelSerializer):

--- a/common/date_utils.py
+++ b/common/date_utils.py
@@ -31,6 +31,7 @@ __all__ = [
     "timedelta_to_json",
     "timedelta_from_json",
     "time_as_timedelta",
+    "time_difference",
 ]
 
 
@@ -236,3 +237,12 @@ def time_as_timedelta(_input: datetime.datetime | datetime.time, /) -> datetime.
         seconds=_input.second,
         microseconds=_input.microsecond,
     )
+
+
+def time_difference(
+    _input_1: datetime.datetime | datetime.time,
+    _input_2: datetime.datetime | datetime.time,
+    /,
+) -> datetime.timedelta:
+    """Difference between two datetimes/times as timedelta."""
+    return time_as_timedelta(_input_1) - time_as_timedelta(_input_2)

--- a/tests/test_graphql_api/test_application_event_schedule/test_approve.py
+++ b/tests/test_graphql_api/test_application_event_schedule/test_approve.py
@@ -1,12 +1,18 @@
-import pytest
+import datetime
+from typing import Any
 
-from applications.choices import ApplicationEventStatusChoice
+import pytest
+from django.utils.timezone import get_default_timezone
+
+from applications.choices import ApplicationEventStatusChoice, WeekdayChoice
 from applications.models import Application, ApplicationEvent, ApplicationEventSchedule
+from reservation_units.models import ReservationUnit
 from tests.factories import (
     ApplicationEventFactory,
     ApplicationEventScheduleFactory,
     ApplicationFactory,
     ReservationUnitFactory,
+    SpaceFactory,
 )
 from tests.helpers import UserType
 
@@ -19,7 +25,22 @@ pytestmark = [
 ]
 
 
-def test_approve_application_event_schedule__can_approve_event_in_allocation(graphql):
+def approve_data(application: Application, *, begin: str, end: str, force: bool = False) -> dict[str, Any]:
+    """Generate approve mutation input data for the last schedule of the given application's first event."""
+    event: ApplicationEvent = application.application_events.first()
+    reservation_unit: ReservationUnit = event.event_reservation_units.first().reservation_unit
+    schedule: ApplicationEventSchedule = event.application_event_schedules.order_by("pk").last()
+    return {
+        "pk": schedule.pk,
+        "allocatedDay": schedule.day,
+        "allocatedBegin": begin,
+        "allocatedEnd": end,
+        "allocatedReservationUnit": reservation_unit.pk,
+        "force": force,
+    }
+
+
+def test_approve_schedule__can_approve_event_in_allocation(graphql):
     # given:
     # - There is an allocatable application event schedule
     # - A superuser is using the system
@@ -58,13 +79,14 @@ def test_approve_application_event_schedule__can_approve_event_in_allocation(gra
     assert event.status == ApplicationEventStatusChoice.APPROVED
 
 
-def test_approve_application_event_schedule__can_approve_already_approved_event(graphql):
+def test_approve_schedule__can_approve_already_approved_event(graphql):
     # given:
     # - There is an application event with one approved and one unallocated schedule
     # - A superuser is using the system
     reservation_unit = ReservationUnitFactory.create()
     event: ApplicationEvent = ApplicationEventFactory.create_in_status_approved(
         event_reservation_units__reservation_unit=reservation_unit,
+        events_per_week=2,
     )
     schedule: ApplicationEventSchedule = ApplicationEventScheduleFactory.create(application_event=event)
     graphql.login_user_based_on_type(UserType.SUPERUSER)
@@ -99,7 +121,7 @@ def test_approve_application_event_schedule__can_approve_already_approved_event(
     "missing_key",
     ["allocatedDay", "allocatedBegin", "allocatedEnd", "allocatedReservationUnit"],
 )
-def test_cannot_approve_application_event_schedule_with_incomplete_data(graphql, missing_key):
+def test_approve_schedule__incomplete_data(graphql, missing_key):
     # given:
     # - There is an allocatable application event schedule
     # - A superuser is using the system
@@ -128,7 +150,7 @@ def test_cannot_approve_application_event_schedule_with_incomplete_data(graphql,
     assert response.has_errors is True, response
 
 
-def test_cannot_approve_if_application_is_not_in_allocation(graphql):
+def test_approve_schedule__application_not_yet_in_allocation(graphql):
     # given:
     # - There is an open application that has been sent, but is not allocatable yet
     # - A superuser is using the system
@@ -158,7 +180,7 @@ def test_cannot_approve_if_application_is_not_in_allocation(graphql):
     ]
 
 
-def test_cannot_approve_if_application_is_not_in_unallocated(graphql):
+def test_approve_schedule__application_not_in_allocation_anymore(graphql):
     # given:
     # - There is an application event that has already been approved
     # - A superuser is using the system
@@ -183,4 +205,378 @@ def test_cannot_approve_if_application_is_not_in_unallocated(graphql):
     # - The response complains about the application and event being in the wrong status
     assert response.field_error_messages() == [
         "Schedule cannot be approved for application in status: 'HANDLED'",
+    ]
+
+
+def test_approve_schedule__cannot_approve_duration_longer_than_event_maximum(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule so that it's
+    #   longer than the maximum allowed duration.
+    input_data = approve_data(application, begin="10:00:00", end="12:15:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the duration being too long
+    assert response.field_error_messages("allocatedEnd") == [
+        "Allocation duration too long. Maximum allowed is 02:00:00 while given duration is 02:15:00."
+    ]
+
+
+def test_approve_schedule__can_approve_duration_longer_than_event_maximum_with_force_flag(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule so that it's
+    #   longer than the maximum allowed duration, but uses the force flag.
+    input_data = approve_data(application, begin="10:00:00", end="12:15:00", force=True)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__cannot_approve_duration_shorter_than_event_minimum(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule so that it's
+    #   shorter than the minimum allowed duration.
+    input_data = approve_data(application, begin="10:00:00", end="10:45:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the duration being too long
+    assert response.field_error_messages("allocatedEnd") == [
+        "Allocation duration too short. Minimum allowed is 01:00:00 while given duration is 00:45:00."
+    ]
+
+
+def test_approve_schedule__can_approve_duration_shorter_than_event_minimum_with_force_flag(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule so that it's
+    #   shorter than the minimum allowed duration, but uses the force flag.
+    input_data = approve_data(application, begin="10:00:00", end="10:45:00", force=True)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__cannot_approve_duration_not_multiple_of_15_minutes(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule which is not
+    #   a multiple of 15 minutes.
+    input_data = approve_data(application, begin="10:00:00", end="11:00:01")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the duration being too long
+    assert response.field_error_messages("allocatedEnd") == ["Allocation duration must be a multiple of 15 minutes."]
+
+
+def test_approve_schedule__can_approve_duration_not_multiple_of_15_minutes_with_force_flag(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule which is not
+    #   a multiple of 15 minutes, but uses the force flag.
+    input_data = approve_data(application, begin="10:00:00", end="11:00:01", force=True)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__cannot_approve_more_events_than_events_per_week(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation(pre_allocated=True)
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    ApplicationEventScheduleFactory.create(
+        day=WeekdayChoice.WEDNESDAY,
+        application_event=application.application_events.first(),
+    )
+
+    # when:
+    # - The user tries to allocate the schedule, but there are already
+    #   maximum number of schedules allocated.
+    input_data = approve_data(application, begin="12:00:00", end="14:00:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about too many events already being allocated
+    assert response.field_error_messages() == [
+        "Cannot allocate more schedules for this event. Maximum allowed is 2.",
+    ]
+
+
+def test_approve_schedule__can_approve_more_events_than_events_per_week_with_force_flag(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation(pre_allocated=True)
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    ApplicationEventScheduleFactory.create(
+        day=WeekdayChoice.WEDNESDAY,
+        application_event=application.application_events.first(),
+    )
+
+    # when:
+    # - The user tries to allocate the schedule, but there are already
+    #   maximum number of schedules allocated, but uses the force flag.
+    input_data = approve_data(application, begin="12:00:00", end="14:00:00", force=True)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__cannot_approve_event_outside_of_wished_period(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule, but it does not fall
+    #   within the applicants the wished periods.
+    input_data = approve_data(application, begin="14:00:00", end="15:00:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the allocated time being invalid.
+    assert response.field_error_messages() == [
+        "Cannot allocate schedule for this day and time period. "
+        "Given time period does not fit within applicants wished periods.",
+    ]
+
+
+def test_approve_schedule__can_approve_event_outside_of_wished_period_with_force_flag(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule, but it does not fall
+    #   within the applicants the wished periods, but uses the force flag.
+    input_data = approve_data(application, begin="14:00:00", end="15:00:00", force=True)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__approved_time_falls_on_two_back_to_back_wished_times(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    ApplicationEventScheduleFactory.create(
+        application_event=application.application_events.first(),
+        day=WeekdayChoice.MONDAY,
+        begin=datetime.time(14, 0, tzinfo=get_default_timezone()),
+        end=datetime.time(16, 0, tzinfo=get_default_timezone()),
+    )
+
+    # when:
+    # - The user tries to allocate the schedule, and it falls
+    #   on two of the applicants the wished periods.
+    input_data = approve_data(application, begin="13:00:00", end="15:00:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+def test_approve_schedule__approved_time_falls_on_two_separated_wished_times(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    ApplicationEventScheduleFactory.create(
+        application_event=application.application_events.first(),
+        day=WeekdayChoice.MONDAY,
+        begin=datetime.time(14, 30, tzinfo=get_default_timezone()),
+        end=datetime.time(16, 0, tzinfo=get_default_timezone()),
+    )
+
+    # when:
+    # - The user tries to allocate the schedule, and it falls
+    #   on two of the applicants the wished periods.
+    input_data = approve_data(application, begin="13:00:00", end="15:00:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the allocated time being invalid.
+    assert response.field_error_messages() == [
+        "Cannot allocate schedule for this day and time period. "
+        "Given time period does not fit within applicants wished periods.",
+    ]
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_approve_schedule__cannot_approve_to_reservation_unit_not_in_event_reservation_units(graphql, force):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule, but for a reservation unit
+    #   not in the event's event reservation units.
+    input_data = approve_data(application, begin="10:00:00", end="12:00:00", force=force)
+    input_data["allocatedReservationUnit"] = ReservationUnitFactory.create().pk
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the reservation unit not being included.
+    assert response.field_error_messages("allocatedReservationUnit") == [
+        "Cannot allocate schedule for this reservation unit. Reservation unit is not included in the event.",
+    ]
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_approve_schedule__cannot_approve_two_schedules_for_same_day(graphql, force):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation(events_per_week=3, pre_allocated=True)
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    ApplicationEventScheduleFactory.create(
+        day=WeekdayChoice.MONDAY,
+        application_event=application.application_events.first(),
+    )
+
+    # when:
+    # - The user tries to allocate the schedule, but allocation
+    #   is on the same day as another allocation for the same event.
+    input_data = approve_data(application, begin="12:00:00", end="14:00:00", force=force)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the allocations overlapping.
+    assert response.field_error_messages("allocatedDay") == [
+        "Cannot allocate multiple schedules on the same day for one event.",
+    ]
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_approve_schedule__cannot_approve_if_overlapping_with_another_approved_in_same_reservation_unit(graphql, force):
+    # given:
+    # - There is an allocatable application event schedule
+    # - There is an overlapping approved schedule for the same reservation unit
+    # - A superuser is using the system
+    reservation_unit = ReservationUnitFactory.create(spaces=[SpaceFactory.create()])
+    application = ApplicationFactory.create_application_ready_for_allocation(reservation_unit=reservation_unit)
+    ApplicationFactory.create_application_ready_for_allocation(
+        reservation_unit=reservation_unit,
+        pre_allocated=True,
+    )
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule, but there is already
+    #   an allocation for the same reservation unit at that time.
+    input_data = approve_data(application, begin="10:00:00", end="11:00:00", force=force)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about the there being another allocation already.
+    assert response.field_error_messages() == [
+        "Cannot allocate schedule for this day and time period. "
+        "Given time period has already been allocated for another event with the same reservation unit.",
+    ]
+
+
+def test_approve_schedule__can_approve_if_overlapping_with_another_approved_in_different_reservation_unit(graphql):
+    # given:
+    # - There is an allocatable application event schedule
+    # - There is an overlapping approved schedule for a different reservation unit
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    ApplicationFactory.create_application_ready_for_allocation(pre_allocated=True)
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # when:
+    # - The user tries to allocate the schedule, but there is already
+    #   an allocation for the same reservation unit at that time.
+    input_data = approve_data(application, begin="10:00:00", end="11:00:00")
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The allocation is successful
+    assert response.has_errors is False, response
+
+
+@pytest.mark.parametrize("force", [True, False])
+def test_approve_schedule__cannot_approve_if_event_doesnt_have_begin_and_end_dates(graphql, force):
+    # given:
+    # - There is an allocatable application event schedule
+    # - A superuser is using the system
+    application = ApplicationFactory.create_application_ready_for_allocation()
+    graphql.login_user_based_on_type(UserType.SUPERUSER)
+
+    # Event doesn't have start and end dates
+    event = application.application_events.first()
+    event.begin = None
+    event.end = None
+    event.save()
+
+    # when:
+    # - The user tries to allocate the schedule
+    input_data = approve_data(application, begin="10:00:00", end="11:00:00", force=force)
+    response = graphql(APPROVE_MUTATION, input_data=input_data)
+
+    # then:
+    # - The response complains about event begin and end dates
+    assert response.field_error_messages() == [
+        "Cannot allocate schedule for this day and time period. Event begin and end dates must be set."
     ]


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add new schedule approve validation rules:
    - These rules **_can_** be skipped with the `force` flag
        - Allocated duration cannot be less than `event.min_duration`
        - Allocated duration cannot be more than `event.max_duration`
        - Allocated duration must be a multiple of 15 minutes
        - Cannot allocate more events than `event.events_per_week`
        - Cannot allocate more than one event per day
        - Can only allocate on users' wished times
    - These rules **_cannot_** be skipped with the `force` flag
        - Cannot allocate to a reservation unit not included in the event's event reservation units
        - Cannot allocate an already allocated period for the same reservation unit in any overlapping schedule based on events begin and end times, even from other application rounds
            - Later: [Include common resource and space hierarchy in this](https://helsinkisolutionoffice.atlassian.net/browse/TILA-2904)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated tests

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-3061](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3061)


[TILA-3061]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ