### PR TITLE
Add traceback logging for graphql errors

### DIFF
--- a/api/graphql/types/reservation_units/mutations.py
+++ b/api/graphql/types/reservation_units/mutations.py
@@ -1,3 +1,5 @@
+import logging
+
 import graphene
 from auditlog.models import LogEntry
 from django.conf import settings
@@ -5,22 +7,17 @@ from graphene_django.rest_framework.mutation import SerializerMutation
 from graphql import GraphQLError
 
 from api.graphql.extensions.legacy_helpers import OldAuthSerializerMutation
-from api.graphql.types.reservation_units.permissions import (
-    ReservationUnitPermission,
-)
+from api.graphql.types.reservation_units.permissions import ReservationUnitPermission
 from api.graphql.types.reservation_units.serializers import (
     ReservationUnitCreateSerializer,
     ReservationUnitUpdateSerializer,
 )
-from api.graphql.types.reservation_units.types import (
-    ReservationUnitType,
-)
+from api.graphql.types.reservation_units.types import ReservationUnitType
 from opening_hours.errors import HaukiAPIError, HaukiRequestError
 from opening_hours.utils.hauki_resource_hash_updater import HaukiResourceHashUpdater
 from reservation_units.models import (
     ReservationUnit,
 )
-from tilavarauspalvelu.utils import logging
 
 logger = logging.getLogger(__name__)
 

--- a/opening_hours/management/commands/update_hauki_hashes.py
+++ b/opening_hours/management/commands/update_hauki_hashes.py
@@ -1,11 +1,11 @@
+import logging
 from typing import Any
 
 from django.core.management.base import BaseCommand
 
 from opening_hours.utils.hauki_resource_hash_updater import HaukiResourceHashUpdater
-from tilavarauspalvelu.utils.logging import getLogger
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):

--- a/opening_hours/utils/hauki_api_client.py
+++ b/opening_hours/utils/hauki_api_client.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import logging
 from typing import NotRequired, TypedDict, Unpack
 
 from django.conf import settings
@@ -12,7 +13,6 @@ from opening_hours.utils.hauki_api_types import (
     HaukiAPIResource,
     HaukiAPIResourceListResponse,
 )
-from tilavarauspalvelu.utils import logging
 
 __all__ = [
     "HaukiAPIClient",

--- a/opening_hours/utils/hauki_resource_hash_updater.py
+++ b/opening_hours/utils/hauki_resource_hash_updater.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import datetime, time
 
 from django.utils import timezone
@@ -8,9 +9,8 @@ from opening_hours.models import OriginHaukiResource
 from opening_hours.utils.hauki_api_client import HaukiAPIClient
 from opening_hours.utils.hauki_api_types import HaukiAPIResource, HaukiAPIResourceListResponse
 from opening_hours.utils.reservable_time_span_client import ReservableTimeSpanClient
-from tilavarauspalvelu.utils.logging import getLogger
 
-logger = getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEZONE = get_default_timezone()
 

--- a/tilavarauspalvelu/logging.py
+++ b/tilavarauspalvelu/logging.py
@@ -1,0 +1,29 @@
+import logging
+from pathlib import Path
+
+BASE_PATH = str(Path(__file__).resolve().parent.parent)
+
+
+class TVPFormatter(logging.Formatter):
+    def format(self, record):
+        self._style._defaults = {"dotpath": self.get_dotpath(record)}
+        return super().format(record)
+
+    def get_dotpath(self, record: logging.LogRecord) -> str:
+        """Try to fetch the full dot import path for the module the log happened at."""
+        # For library logs
+        split_path = record.pathname.split("site-packages")
+        if len(split_path) > 1:
+            return self.format_dotpath(split_path[-1][1:])
+
+        # For our logs
+        split_path = record.pathname.split(str(BASE_PATH))
+        if len(split_path) > 1:
+            return self.format_dotpath(split_path[-1][1:])
+
+        # Fall back to the module name, which doesn't include the full path info
+        return record.module
+
+    @staticmethod
+    def format_dotpath(path: str) -> str:
+        return path.removesuffix(".py").replace("/", ".").replace("\\", ".")

--- a/tilavarauspalvelu/middleware.py
+++ b/tilavarauspalvelu/middleware.py
@@ -1,5 +1,10 @@
+import logging
+import traceback
+
 from django.conf import settings
 from sentry_sdk import capture_exception
+
+logger = logging.getLogger(__name__)
 
 
 class MultipleProxyMiddleware:
@@ -37,5 +42,6 @@ class GraphQLSentryMiddleware:
         try:
             return next(root, info, **kwargs)
         except Exception as err:
+            logger.info(traceback.format_exc())
             capture_exception(err)
             return err

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -10,8 +10,6 @@ from django.utils.translation import gettext_lazy as _
 from helusers import defaults
 from sentry_sdk.integrations.django import DjangoIntegration
 
-from .utils.logging import getLogger
-
 # This is a temporary fix for graphene_permissions to avoid ImportError when importing ResolveInfo
 # This can be removed when graphene_permissions is updated to import ResolveInfo from the correct package.
 graphql.ResolveInfo = graphql.GraphQLResolveInfo
@@ -340,7 +338,8 @@ LOGGING = {
     "filters": {},
     "formatters": {
         "common": {
-            "format": "{asctime} | {levelname} | {module}.{funcName}:{lineno} | {message}",
+            "()": "tilavarauspalvelu.logging.TVPFormatter",
+            "format": "{asctime} | {levelname} | {dotpath}.{funcName}:{lineno} | {message}",
             "datefmt": "%Y-%m-%dT%H:%M:%S%z",
             "style": "{",
         },

--- a/tilavarauspalvelu/utils/logging.py
+++ b/tilavarauspalvelu/utils/logging.py
@@ -1,6 +1,0 @@
-import logging
-
-
-def getLogger(name: str) -> logging.Logger:
-    """Returns a new logger with tilavaraus prefix in the name"""
-    return logging.getLogger(f"tilavaraus.{name}")


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Log error traceback for GraphQL errors in Sentry middleware. This should help debugging during tests.
- Simplify Django logging configuration to the base minimum we need.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Nothing to test

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- TILA-####
