### PR TITLE
Fix using default language for all staff notifications

### DIFF
--- a/email_notification/helpers/email_builder_application.py
+++ b/email_notification/helpers/email_builder_application.py
@@ -21,10 +21,16 @@ class ApplicationEmailContext(BaseEmailContext):
 
     # Builders
     @classmethod
-    def from_application(cls, application: Application) -> ApplicationEmailContext:
-        language: LanguageType = getattr(application.user, "preferred_language", None)
-        if not language:
-            language = settings.LANGUAGE_CODE
+    def from_application(
+        cls,
+        application: Application,
+        forced_language: LanguageType | None = None,
+    ) -> ApplicationEmailContext:
+        language = settings.LANGUAGE_CODE
+        if forced_language:
+            language = forced_language
+        elif user_language := getattr(application.user, "preferred_language", None):
+            language = user_language
 
         return ApplicationEmailContext(
             # Links
@@ -75,10 +81,16 @@ class ApplicationEmailBuilder(BaseEmailBuilder):
         super().__init__(template=template, context=context)
 
     @classmethod
-    def from_application(cls, *, template: EmailTemplate, application: Application) -> ApplicationEmailBuilder:
+    def from_application(
+        cls,
+        *,
+        template: EmailTemplate,
+        application: Application,
+        forced_language: LanguageType | None = None,
+    ) -> ApplicationEmailBuilder:
         return ApplicationEmailBuilder(
             template=template,
-            context=ApplicationEmailContext.from_application(application),
+            context=ApplicationEmailContext.from_application(application, forced_language=forced_language),
         )
 
     @classmethod

--- a/email_notification/helpers/email_builder_reservation.py
+++ b/email_notification/helpers/email_builder_reservation.py
@@ -53,9 +53,15 @@ class ReservationEmailContext(BaseEmailContext):
 
     # Builders
     @classmethod
-    def from_reservation(cls, reservation: Reservation) -> ReservationEmailContext:
+    def from_reservation(
+        cls,
+        reservation: Reservation,
+        forced_language: LanguageType | None = None,
+    ) -> ReservationEmailContext:
         language = settings.LANGUAGE_CODE
-        if reservation.reservee_language:
+        if forced_language:
+            language = forced_language
+        elif reservation.reservee_language:
             language = reservation.reservee_language
         elif reservation.user and reservation.user.preferred_language:
             language = reservation.user.preferred_language
@@ -237,10 +243,16 @@ class ReservationEmailBuilder(BaseEmailBuilder):
         super().__init__(template=template, context=context)
 
     @classmethod
-    def from_reservation(cls, *, template: EmailTemplate, reservation: Reservation) -> ReservationEmailBuilder:
+    def from_reservation(
+        cls,
+        *,
+        template: EmailTemplate,
+        reservation: Reservation,
+        forced_language: LanguageType | None = None,
+    ) -> ReservationEmailBuilder:
         return ReservationEmailBuilder(
             template=template,
-            context=ReservationEmailContext.from_reservation(reservation),
+            context=ReservationEmailContext.from_reservation(reservation, forced_language=forced_language),
         )
 
     @classmethod

--- a/email_notification/helpers/email_sender.py
+++ b/email_notification/helpers/email_sender.py
@@ -46,7 +46,7 @@ class EmailNotificationSender:
             msg = f"Unable to send '{email_type}' notification, there is no EmailTemplate defined for it."
             raise SendEmailNotificationError(msg)
 
-    def send_reservation_email(self, *, reservation: Reservation):
+    def send_reservation_email(self, *, reservation: Reservation, forced_language: LanguageType | None = None):
         if self.recipients is None:
             # Get recipients from the reservation
             self.recipients = []
@@ -59,6 +59,7 @@ class EmailNotificationSender:
         message_builder = ReservationEmailBuilder.from_reservation(
             template=self.email_template,
             reservation=reservation,
+            forced_language=forced_language,
         )
 
         self._send_email(message_builder)
@@ -75,7 +76,7 @@ class EmailNotificationSender:
             )
             self._send_email(message_builder)
 
-    def send_application_email(self, *, application: Application):
+    def send_application_email(self, *, application: Application, forced_language: LanguageType | None = None):
         # Get recipients from the application
         if self.recipients is None:
             self.recipients = []
@@ -88,6 +89,7 @@ class EmailNotificationSender:
         message_builder = ApplicationEmailBuilder.from_application(
             template=self.email_template,
             application=application,
+            forced_language=forced_language,
         )
 
         self._send_email(message_builder)

--- a/email_notification/tasks.py
+++ b/email_notification/tasks.py
@@ -43,7 +43,7 @@ def send_staff_reservation_email_task(
         return
 
     email_notification_sender = EmailNotificationSender(email_type=email_type, recipients=recipients)
-    email_notification_sender.send_reservation_email(reservation=reservation)
+    email_notification_sender.send_reservation_email(reservation=reservation, forced_language=settings.LANGUAGE_CODE)
 
 
 def _get_reservation_staff_notification_recipients(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Use default language for all staff emails (before the reservee language was incorrectly used for the staff emails)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated tests

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)"

- [TILA-2666](https://helsinkisolutionoffice.atlassian.net/browse/TILA-2666)


[TILA-2666]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ