### PR TITLE
Fix CI failing due to misconfigured apt repo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,10 @@ jobs:
         run: poetry config virtualenvs.in-project true
 
       - name: "Install additional libraries"
+        # TODO: Remove this workaround when the issue is fixed in Microsoft repo.
+        #       https://github.com/microsoft/linux-package-repositories/issues/130
         run: |
+          sudo rm /etc/apt/sources.list.d/microsoft-prod.list | true
           sudo apt-get update
           sudo apt install -y --no-install-recommends gdal-bin gettext
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Temporary fix for CI faling due to [misconfigured Microsoft apt repo for Ubuntu 22.04](https://github.com/microsoft/linux-package-repositories/issues/130).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- CI should not fail.
