### PR TITLE
Fix reservation prefill failing due to null values

### DIFF
--- a/api/graphql/types/reservation/serializers/create_serializers.py
+++ b/api/graphql/types/reservation/serializers/create_serializers.py
@@ -234,7 +234,9 @@ class ReservationCreateSerializer(OldPrimaryKeySerializer, ReservationPriceMixin
             return
 
         if prefill_info is not None:
-            data.update(prefill_info)
+            for key, value in prefill_info.items():
+                if value is not None:
+                    data[key] = value
 
     def check_sku(self, current_sku, new_sku):
         if current_sku is not None and current_sku != new_sku:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes issues in profiling reservations from Helsinki profile if data received would be null, but the reservation field would require non-null value.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of what's the fastest way to test your changes."

- Automated tests
