### PR TITLE
Fix issue in first reservable time calculation when duration exactly minimum

### DIFF
--- a/reservation_units/utils/first_reservable_time_helper.py
+++ b/reservation_units/utils/first_reservable_time_helper.py
@@ -610,7 +610,7 @@ class ReservableTimeSpanFirstReservableTimeHelper:
                     reservable_time_span.end_datetime -= overlap
 
                 # Reservable Time Span is now shorter than the minimum duration, so we can't use it.
-                if reservable_time_span.duration_minutes <= minimum_duration_minutes:
+                if reservable_time_span.duration_minutes < minimum_duration_minutes:
                     break
 
             # In case of an invalid start time due to normalisation, move to the next valid start time


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes issue in the first reservable time calculation where the algorithm would give the wrong first reservable time based on surrounding reservations and the minimum reservable time. This happened due to exiting too early when shortening a reservable time span based on surrounding reservations, leaving the reservable time span just long enough to fit a reservation, when subsequent reservations would have made it actually shorter, meaning another reservable time span should have been used instead. TL;DR: An off-by-one error.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None
