### PR TITLE
Fix usable reservation unit options lookup property

### DIFF
--- a/api/graphql/types/reservation_unit/filtersets.py
+++ b/api/graphql/types/reservation_unit/filtersets.py
@@ -114,7 +114,9 @@ class ReservationUnitFilterSet(ModelFilterSet):
 
     @staticmethod
     def get_text_search(qs: ReservationUnitQuerySet, name: str, value: str) -> QuerySet:
-        query_str = build_elastic_query_str(value)
+        query_str = build_elastic_query_str(search_words=value)
+        if not query_str:
+            return qs
         sq = SearchQuery.do_search("reservation_units", {"query_string": {"query": query_str}})
         return qs.from_search_results(sq)
 

--- a/api/graphql/types/reservation_unit/types.py
+++ b/api/graphql/types/reservation_unit/types.py
@@ -191,6 +191,9 @@ class ReservationUnitNode(DjangoNode):
         return None
 
     def resolve_hauki_url(root: ReservationUnit, info: GQLInfo) -> str | None:
+        if root.origin_hauki_resource is None:
+            return None
+
         return generate_hauki_link(root.uuid, info.context.user.email, root.unit.hauki_department_id)
 
     def resolve_reservable_time_spans(

--- a/applications/models/application_section.py
+++ b/applications/models/application_section.py
@@ -224,7 +224,13 @@ class ApplicationSection(SerializableMixin, models.Model):
         from .reservation_unit_option import ReservationUnitOption
 
         usable_reservation_unit_options = Coalesce(
-            SubqueryCount(queryset=ReservationUnitOption.objects.filter(rejected=False, locked=False).values("id")),
+            SubqueryCount(
+                queryset=(
+                    ReservationUnitOption.objects.filter(application_section=models.OuterRef("pk"))
+                    .filter(rejected=False, locked=False)
+                    .values("id")
+                )
+            ),
             models.Value(0),
         )
         return usable_reservation_unit_options  # type: ignore[return-value]

--- a/elastic_django/reservation_units/query_builder.py
+++ b/elastic_django/reservation_units/query_builder.py
@@ -4,33 +4,54 @@ __all__ = [
 ]
 
 
+def _clean_split(text: str, delimiter: str) -> list[str]:
+    """Split text by delimiter and remove empty strings."""
+    return [w.strip() for w in text.split(delimiter) if w.strip()]
+
+
 def build_elastic_query_str(search_words: str) -> str:
     """Search parameters are split with comma and should be treated as separate searches => OR."""
-    values = [w.strip() for w in search_words.split(",")]
+    comma_split_values = _clean_split(search_words, ",")
 
-    words = values[0].split(" ")
-    query_str = parse_search_words(words)
+    all_or_query_strings: list[str] = []
+    for term in comma_split_values:
+        words = _clean_split(term, " ")
+        query_str = parse_search_words(words)
+        all_or_query_strings.append(query_str)
 
-    for term in values[1:]:
-        query_str += " OR "
-        words = term.strip().split(" ")
-        query_str += parse_search_words(words)
-
-    return query_str.strip()
+    return " OR ".join(all_or_query_strings)
 
 
 def parse_search_words(words: list[str]) -> str:
+    """
+    Search words are split with spaces and should be treated as the same search => AND.
+
+    The first word should begin with asterisk, and the last word should end with asterisk.
+    If there are multiple words, they should all be wrapped in parentheses.
+
+    Examples:
+        >>> parse_search_words(["Word"])
+        >>> "(*Word*)"
+
+        >>> parse_search_words(["First", "Last"])
+        >>> "((*First) AND (Last*))"
+
+        >>> parse_search_words(["First", "Middle", "Last"])
+        >>> "((*First) AND (Middle) AND (Last*))"
+    """
     if len(words) == 1:
-        q_str = f"(*{words[0].strip()}*)"
+        return f"(*{words[0]}*)"
 
-        return q_str
+    all_and_query_strings: list[str] = []
+    for i, word in enumerate(words):
+        if i == 0:
+            # Add asterisk to the first word
+            all_and_query_strings.append(f"(*{word})")
+        elif i == len(words) - 1:
+            # Add asterisk to the last word
+            all_and_query_strings.append(f"({word}*)")
+        else:
+            all_and_query_strings.append(f"({word})")
 
-    q_str = f"((*{words[0].strip()}) "
-
-    for w in words[1 : len(words) - 1]:
-        w.strip()
-        q_str += f"AND ({w}) "
-
-    q_str += f"AND ({words[len(words) - 1].strip()}*))"
-
-    return q_str
+    query_str = " AND ".join(all_and_query_strings)
+    return f"({query_str})"

--- a/opening_hours/tests/test_hauki_link_generator.py
+++ b/opening_hours/tests/test_hauki_link_generator.py
@@ -13,7 +13,7 @@ ORGANIZATION = "parent-organisation"
 
 @freeze_time("2021-01-01 12:00:00", tz_offset=2)
 def test__hauki__link_generation__signature():
-    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
+    link = generate_hauki_link(reservation_unit_uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
     params = dict(parse.parse_qsl(link))
 
     assert hmac.compare_digest(VALID_SIGNATURE, params["hsa_signature"]) is True
@@ -21,14 +21,14 @@ def test__hauki__link_generation__signature():
 
 @freeze_time("2021-01-01 14:00:00", tz_offset=2)
 def test__hauki__link_generation__signature_with_incorrect_datetime():
-    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
+    link = generate_hauki_link(reservation_unit_uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
     params = dict(parse.parse_qsl(link))
 
     assert hmac.compare_digest(VALID_SIGNATURE, params["hsa_signature"]) is False
 
 
 def test__hauki__link_generation__params():
-    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
+    link = generate_hauki_link(reservation_unit_uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
     params = dict(parse.parse_qsl(link))
 
     assert params["hsa_organization"] == settings.HAUKI_ORGANISATION_ID
@@ -40,12 +40,12 @@ def test__hauki__link_generation__params():
 def test__hauki__link_generation__missing_settings_values(setting):
     setattr(settings, setting, None)
 
-    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
+    link = generate_hauki_link(reservation_unit_uuid="123", username="foo@bar.com", organization_id=ORGANIZATION)
 
     assert link is None
 
 
 def test__hauki__link_generation__organization_none():
-    link = generate_hauki_link(uuid="123", username="foo@bar.com", organization_id=None)
+    link = generate_hauki_link(reservation_unit_uuid="123", username="foo@bar.com", organization_id=None)
 
     assert link is None

--- a/tests/test_graphql_api/test_reservation_unit/test_hauki_integration.py
+++ b/tests/test_graphql_api/test_reservation_unit/test_hauki_integration.py
@@ -103,9 +103,11 @@ def test_reservation_unit__query__hauki_url__regular_user(graphql):
 def test_reservation_unit__query__hauki_url__superuser(graphql, settings):
     user = graphql.login_with_superuser()
 
+    origin_hauki_resource = OriginHaukiResourceFactory.create(id="987")
     reservation_unit = ReservationUnitFactory.create(
         unit__tprek_department_id="ORGANISATION",
         uuid="3774af34-9916-40f2-acc7-68db5a627710",
+        origin_hauki_resource=origin_hauki_resource,
     )
 
     global_id = to_global_id("ReservationUnitNode", reservation_unit.pk)
@@ -131,3 +133,19 @@ def test_reservation_unit__query__hauki_url__superuser(graphql, settings):
     )
 
     assert response.first_query_object == {"haukiUrl": url}
+
+
+def test_reservation_unit__query__hauki_url__superuser__no_hauki_resource(graphql):
+    reservation_unit = ReservationUnitFactory.create(
+        unit__tprek_department_id="ORGANISATION",
+        uuid="3774af34-9916-40f2-acc7-68db5a627710",
+        origin_hauki_resource=None,
+    )
+
+    global_id = to_global_id("ReservationUnitNode", reservation_unit.pk)
+    query = reservation_unit_query(fields="haukiUrl", id=global_id)
+    graphql.login_with_superuser()
+    response = graphql(query)
+
+    assert response.has_errors is False, response.errors
+    assert response.first_query_object == {"haukiUrl": None}

--- a/tests/test_utils/test_reservation_unit_query_builder.py
+++ b/tests/test_utils/test_reservation_unit_query_builder.py
@@ -1,31 +1,41 @@
 from elastic_django.reservation_units.query_builder import build_elastic_query_str
 
 
-def test_parse_search_word_when_one_search_word():
+def test_build_elastic_query_str__one_search_word():
     query_str = build_elastic_query_str("search")
     assert query_str == "(*search*)"
 
 
-def test_parse_search_word_when_two_search_word():
+def test_build_elastic_query_str__two_search_word():
     query_str = build_elastic_query_str("search this")
     assert query_str == "((*search) AND (this*))"
 
 
-def test_parse_search_word_when_three_search_word():
+def test_build_elastic_query_str__three_search_word():
     query_str = build_elastic_query_str("search this too")
     assert query_str == "((*search) AND (this) AND (too*))"
 
 
-def test_parse_search_word_when_four_search_word():
+def test_build_elastic_query_str__four_search_word():
     query_str = build_elastic_query_str("search this too much")
     assert query_str == "((*search) AND (this) AND (too) AND (much*))"
 
 
-def test_parse_search_word_when_comma_separated_search():
+def test_build_elastic_query_str__comma_separated_search():
     query_str = build_elastic_query_str("search, this, too, much")
     assert query_str == "(*search*) OR (*this*) OR (*too*) OR (*much*)"
 
 
-def test_parse_search_word_when_comma_separated_search_with_multiple_words():
+def test_build_elastic_query_str__comma_separated_search_with_multiple_words():
     query_str = build_elastic_query_str("search this, too, much")
     assert query_str == "((*search) AND (this*)) OR (*too*) OR (*much*)"
+
+
+def test_build_elastic_query_str__two_search_words__with_multiple_spaces():
+    query_str = build_elastic_query_str("search   this  ")
+    assert query_str == "((*search) AND (this*))"
+
+
+def test_build_elastic_query_str__two_search_words__with_multiple_commas():
+    query_str = build_elastic_query_str("search, ,, this ,")
+    assert query_str == "(*search*) OR (*this*)"


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes issue in `usable_reservation_unit_options` lookup property where it would check for all reservation unit options instead the specific applications sections. This fixes incorrectly showing `IN_ALLOCATION` as section status when all its options are rejected/locked.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3339][TILA]


[TILA]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3339

[TILA-3339]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ