### PR TITLE
Make CI environment require `DATABASE_URL`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,14 +107,16 @@ jobs:
         run: poetry run python manage.py makemigrations --check --no-color --no-input --dry-run
         env:
           DJANGO_SETTINGS_ENVIRONMENT: CI
+          DATABASE_URL: postgis://tvp:tvp@localhost:5432/tvp
 
       - name: "Test for missing translation"
         run: poetry run python -m tilavarauspalvelu.hooks.translations_done
         env:
           DJANGO_SETTINGS_ENVIRONMENT: CI
+          DATABASE_URL: postgis://tvp:tvp@localhost:5432/tvp
 
       - name: "Run pytest with coverage"
-        run: poetry run pytest --cov=. --cov-report=xml --cov-branch --disable-warnings
+        run: poetry run pytest --cov=. --cov-report=xml --cov-branch --disable-warnings --skip-slow
         env:
           DJANGO_SETTINGS_ENVIRONMENT: AutomatedTests
 

--- a/tilavarauspalvelu/settings.py
+++ b/tilavarauspalvelu/settings.py
@@ -2,7 +2,6 @@
 import zoneinfo
 from pathlib import Path
 
-import dj_database_url
 from django.utils.translation import gettext_lazy
 from env_config import Environment, values
 from helusers.defaults import SOCIAL_AUTH_PIPELINE
@@ -790,12 +789,12 @@ class Build(EmptyDefaults, Common, use_environ=True):
 
 
 class CI(EmptyDefaults, Common, use_environ=True):
-    """Settings for non-test commands in GitHub Actions CI environment."""
+    """Settings for commands in GitHub Actions and Azure Pipelines CI environment."""
 
-    DEBUG = True
+    DEBUG = False
 
-    # Migration check requires the database
-    DATABASES = {"default": dj_database_url.parse(url="postgis://tvp:tvp@localhost:5432/tvp")}
+    # Migrations require the database
+    DATABASES = values.DatabaseURLValue()
 
 
 class Platta(Common, use_environ=True):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- This allows using the CI environment in Azure Pipelines for running deploy mid-hooks, which make database our migrations.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None
