### PR TITLE
Correct text related to resetting applications and application rounds

### DIFF
--- a/applications/admin/application.py
+++ b/applications/admin/application.py
@@ -104,7 +104,7 @@ class ApplicationAdmin(admin.ModelAdmin):
         context = {
             **self.admin_site.each_context(request),
             "title": _("Are you sure?"),
-            "subtitle": _("Are you sure you want reset allocations?"),
+            "subtitle": _("Are you sure you want reset allocations for these applications?"),
             "queryset": queryset,
             "opts": self.model._meta,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,

--- a/applications/admin/application_round.py
+++ b/applications/admin/application_round.py
@@ -83,7 +83,7 @@ class ApplicationRoundAdmin(ExtraButtonsMixin, TranslationAdmin):
 
         return response
 
-    @admin.action(description=_("Reset application round allocations"))
+    @admin.action(description=_("Reset application round"))
     def reset_application_rounds(self, request: WSGIRequest, queryset: QuerySet) -> TemplateResponse | None:
         # Coming from confirmation page, perform the action
         if request.POST.get("confirmed"):
@@ -113,7 +113,7 @@ class ApplicationRoundAdmin(ExtraButtonsMixin, TranslationAdmin):
         context = {
             **self.admin_site.each_context(request),
             "title": _("Are you sure?"),
-            "subtitle": _("Are you sure you want reset allocations?"),
+            "subtitle": _("Are you sure you want to reset these application rounds?"),
             "queryset": queryset,
             "opts": self.model._meta,
             "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,

--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -51,9 +51,9 @@ msgstr "Nollaa hakemuksen allokoinnit"
 msgid "Are you sure?"
 msgstr "Oletko varma?"
 
-#: applications/admin/application.py applications/admin/application_round.py
-msgid "Are you sure you want reset allocations?"
-msgstr "Oletko varma, että haluat nollata allokoinnit?"
+#: applications/admin/application.py
+msgid "Are you sure you want reset allocations for these applications?"
+msgstr "Oletko varma, että haluat nollata näiden hakemusten allokoinnit?"
 
 #: applications/admin/application_round.py
 #: applications/admin/filters/allocated_time_slot.py
@@ -63,8 +63,12 @@ msgid "Application Round"
 msgstr "Kausivarauskierros"
 
 #: applications/admin/application_round.py
-msgid "Reset application round allocations"
-msgstr "Nollaa kausivarauskierroksen allokoinnit"
+msgid "Reset application round"
+msgstr "Nollaa kausivarauskierros"
+
+#: applications/admin/application_round.py
+msgid "Are you sure you want to reset these application rounds?"
+msgstr "Oletko varma, että haluat nollata nämä kausivarauskierrokset?"
 
 #: applications/admin/filters/allocated_time_slot.py
 #: applications/admin/filters/application.py


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Resetting no longer only resets allocations but can also remove recurring reservations. Correct the confirmation page to reflect this.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

