### PR TITLE
Replace unit group name filter with language-specific versions

### DIFF
--- a/api/graphql/types/unit/filtersets.py
+++ b/api/graphql/types/unit/filtersets.py
@@ -10,6 +10,7 @@ from common.db import SubqueryCount
 from reservation_units.enums import ReservationKind
 from reservation_units.models import ReservationUnit
 from reservations.models import Reservation
+from spaces.querysets.unit import UnitQuerySet
 
 __all__ = [
     "UnitFilterSet",
@@ -47,7 +48,9 @@ class UnitFilterSet(ModelFilterSet):
             "rank",
             "reservation_count",
             "reservation_units_count",
-            ("unit_groups__name", "unit_group_name"),
+            "unit_group_name_fi",
+            "unit_group_name_en",
+            "unit_group_name_sv",
         ]
 
     def filter_by_only_with_permission(self, qs: models.QuerySet, name: str, value: bool) -> models.QuerySet:
@@ -146,3 +149,15 @@ class UnitFilterSet(ModelFilterSet):
                 Reservation.objects.filter(reservation_unit__unit=models.OuterRef("pk")).values("id"),
             ),
         ).order_by(models.OrderBy(models.F("reservation_count"), descending=desc))
+
+    @staticmethod
+    def order_by_unit_group_name_fi(qs: UnitQuerySet, desc: bool) -> models.QuerySet:
+        return qs.order_by_unit_group_name(language="fi", desc=desc)
+
+    @staticmethod
+    def order_by_unit_group_name_en(qs: UnitQuerySet, desc: bool) -> models.QuerySet:
+        return qs.order_by_unit_group_name(language="en", desc=desc)
+
+    @staticmethod
+    def order_by_unit_group_name_sv(qs: UnitQuerySet, desc: bool) -> models.QuerySet:
+        return qs.order_by_unit_group_name(language="sv", desc=desc)

--- a/spaces/models/unit.py
+++ b/spaces/models/unit.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.db import models
 
+from spaces.querysets.unit import UnitQuerySet
+
 __all__ = [
     "Unit",
     "UnitGroup",
@@ -46,6 +48,8 @@ class Unit(models.Model):
         null=True,
         blank=True,
     )
+
+    objects = UnitQuerySet.as_manager()
 
     name_fi: str | None
     name_en: str | None

--- a/spaces/querysets/unit.py
+++ b/spaces/querysets/unit.py
@@ -1,0 +1,21 @@
+from typing import Literal, Self
+
+from django.db import models
+
+
+class UnitQuerySet(models.QuerySet):
+    def order_by_unit_group_name(self, *, language: Literal["fi", "en", "sv"], desc: bool = False) -> Self:
+        from spaces.models import UnitGroup
+
+        return self.alias(
+            **{
+                f"unit_group_name_{language}": models.Subquery(
+                    queryset=(
+                        # Use the name of the linked unit group which is first alphabetically
+                        UnitGroup.objects.filter(units=models.OuterRef("pk"))
+                        .order_by(f"name_{language}")
+                        .values(f"name_{language}")[:1]
+                    ),
+                )
+            }
+        ).order_by(models.OrderBy(models.F(f"unit_group_name_{language}"), descending=desc))


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes unit's unit group name ordering filters by replacing them with language-specific versions
- Use the alphabetically first unit group linked to the unit as the unit group name

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- Frontend needs to change to support the new language-specific filters
    - https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1241

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
