### PR TITLE
Fix merge overlapping timespans

### DIFF
--- a/locale/fi/LC_MESSAGES/django.po
+++ b/locale/fi/LC_MESSAGES/django.po
@@ -1022,7 +1022,7 @@ msgstr "Alku- ja lopetusaikojen tulee olla 60 minuutin monikertoja."
 
 #: applications/tasks.py
 msgid "Core business"
-msgstr "Ydinliiketoiminta"
+msgstr "Ydintoiminta"
 
 #: applications/validators.py
 msgid "This field is required."

--- a/opening_hours/utils/reservable_time_span_client.py
+++ b/opening_hours/utils/reservable_time_span_client.py
@@ -163,9 +163,6 @@ class ReservableTimeSpanClient:
         return ReservableTimeSpan.objects.bulk_create(reservable_time_spans)
 
     def _merge_overlapping_closed_time_spans(self, parsed_time_spans: list[TimeSpanElement]) -> list[TimeSpanElement]:
-        closed_time_spans: list[TimeSpanElement] = [
-            timespan
-            for timespan in sorted(parsed_time_spans, key=lambda x: x.start_datetime)
-            if not timespan.is_reservable
-        ]
-        return merge_overlapping_time_span_elements(closed_time_spans)
+        return merge_overlapping_time_span_elements(
+            timespan for timespan in parsed_time_spans if not timespan.is_reservable
+        )

--- a/reservations/signals.py
+++ b/reservations/signals.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
 
@@ -7,6 +8,9 @@ from reservations.statistic_utils import create_or_update_reservation_statistics
 
 @receiver(post_save, sender=Reservation, dispatch_uid="update_reservation_statistics_on_save")
 def update_reservation_statistics_on_save(sender, instance=None, raw=False, **kwargs) -> None:
+    if not settings.SAVE_RESERVATION_STATISTICS:
+        return
+
     if raw:
         return
 
@@ -30,6 +34,9 @@ def update_reservation_statistics_on_save(sender, instance=None, raw=False, **kw
     dispatch_uid="update_reservation_statistics_on_runit_change",
 )
 def update_reservation_statistics_on_runit_change(sender, instance=None, action="", reverse=False, **kwargs) -> None:
+    if not settings.SAVE_RESERVATION_STATISTICS:
+        return
+
     raw = kwargs.get("raw", False)
     if action == "post_add" and reverse is False and raw is False:
         create_or_update_reservation_statistics(instance.pk)

--- a/spaces/signals.py
+++ b/spaces/signals.py
@@ -8,14 +8,15 @@ from spaces.models import Space
 
 
 @receiver([post_save, post_delete], sender=Space, dispatch_uid="space_modify")
-def space_modify(instance: Space, *args: Any, **kwargs: Any):
-    tree_id = instance.parent.tree_id if instance.parent else instance.tree_id
-    try:
-        instance.__class__.objects.partial_rebuild(tree_id)
-    except RuntimeError:
-        # If the tree now has more than one root node,
-        # we need to rebuild the whole tree.
-        instance.__class__.objects.rebuild()
+def space_modify(instance: Space, *args: Any, **kwargs: Any) -> None:
+    if settings.REBUILD_SPACE_HIERARCHY:
+        tree_id = instance.parent.tree_id if instance.parent else instance.tree_id
+        try:
+            instance.__class__.objects.partial_rebuild(tree_id)
+        except RuntimeError:
+            # If the tree now has more than one root node,
+            # we need to rebuild the whole tree.
+            instance.__class__.objects.rebuild()
 
     # Refresh the reservation unit hierarchy since spaces have changed.
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY:

--- a/tests/test_external_services/test_hauki/test_merge_overlapping_time_span_elements.py
+++ b/tests/test_external_services/test_hauki/test_merge_overlapping_time_span_elements.py
@@ -10,21 +10,21 @@ from tests.test_external_services.test_hauki.test_reservable_time_spans_client i
 def test__merge_overlapping_time_span_elements__no_buffers__ends_and_starts_at_the_same_time():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=14),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=14),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         ),
     ]
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         )
     ]
@@ -33,21 +33,21 @@ def test__merge_overlapping_time_span_elements__no_buffers__ends_and_starts_at_t
 def test__merge_overlapping_time_span_elements__no_buffers__overlapping():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=15),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=13),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=13),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         ),
     ]
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         )
     ]
@@ -56,21 +56,21 @@ def test__merge_overlapping_time_span_elements__no_buffers__overlapping():
 def test__merge_overlapping_time_span_elements__no_buffers__fully_inside():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=10),
-            end_datetime=_get_date(day=1, hour=20),
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=20),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         ),
     ]
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=10),
-            end_datetime=_get_date(day=1, hour=20),
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=20),
             is_reservable=False,
         )
     ]
@@ -79,13 +79,13 @@ def test__merge_overlapping_time_span_elements__no_buffers__fully_inside():
 def test__merge_overlapping_time_span_elements__no_buffers__not_combined():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=14),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=14),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=15),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=15),
+            end_datetime=_get_date(hour=16),
             is_reservable=False,
         ),
     ]
@@ -99,15 +99,15 @@ def test__merge_overlapping_time_span_elements__no_buffers__not_combined():
 def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_same_time():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=14),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=14),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
@@ -116,8 +116,8 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
@@ -128,15 +128,15 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_same_time__before_buffer_shortened():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=14),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=14),
             buffer_time_before=timedelta(hours=1),  # 11:00
             buffer_time_after=timedelta(hours=1),  # 15:00
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=4),  # 10:00
             buffer_time_after=timedelta(hours=4),  # 20:00
             is_reservable=False,
@@ -145,8 +145,8 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=2),  # 10:00
             buffer_time_after=timedelta(hours=4),  # 20:00
             is_reservable=False,
@@ -157,15 +157,15 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_same_time__after_buffer_shortened():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=14),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=14),
             buffer_time_before=timedelta(hours=4),  # 08:00
             buffer_time_after=timedelta(hours=4),  # 18:00
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=1),  # 13:00
             buffer_time_after=timedelta(hours=1),  # 17:00
             is_reservable=False,
@@ -174,8 +174,8 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=4),  # 08:00
             buffer_time_after=timedelta(hours=2),  # 18:00
             is_reservable=False,
@@ -186,15 +186,15 @@ def test__merge_overlapping_time_span_elements__buffers__start_and_end_at_the_sa
 def test__merge_overlapping_time_span_elements__buffers__overlapping():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=13),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=13),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
@@ -203,8 +203,8 @@ def test__merge_overlapping_time_span_elements__buffers__overlapping():
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=16),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=16),
             buffer_time_before=timedelta(hours=1),
             buffer_time_after=timedelta(hours=1),
             is_reservable=False,
@@ -215,15 +215,15 @@ def test__merge_overlapping_time_span_elements__buffers__overlapping():
 def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reservation_in_before_buffer__no_changes():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(hours=4),
             buffer_time_after=timedelta(),
             is_reservable=False,
@@ -236,15 +236,15 @@ def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reserv
 def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reservation_in_after_buffer__no_changes():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(hours=4),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
             is_reservable=False,
@@ -257,15 +257,15 @@ def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reserv
 def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reservation_in_before_buffer__shortened():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(hours=2),  # 12:00
             buffer_time_after=timedelta(),
             is_reservable=False,
@@ -274,15 +274,15 @@ def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reserv
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(hours=1),  # 13:00
             buffer_time_after=timedelta(),
             is_reservable=False,
@@ -293,15 +293,15 @@ def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reserv
 def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reservation_in_after_buffer__shortened():
     time_span_elements = [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(hours=2),  # 15:00
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
             is_reservable=False,
@@ -310,17 +310,76 @@ def test__merge_overlapping_time_span_elements__buffers__not_overlapping__reserv
 
     assert merge_overlapping_time_span_elements(time_span_elements) == [
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=12),
-            end_datetime=_get_date(day=1, hour=13),
+            start_datetime=_get_date(hour=12),
+            end_datetime=_get_date(hour=13),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(hours=1),  # 14:00
             is_reservable=False,
         ),
         TimeSpanElement(
-            start_datetime=_get_date(day=1, hour=14),
-            end_datetime=_get_date(day=1, hour=15),
+            start_datetime=_get_date(hour=14),
+            end_datetime=_get_date(hour=15),
             buffer_time_before=timedelta(),
             buffer_time_after=timedelta(),
+            is_reservable=False,
+        ),
+    ]
+
+
+def test__merge_overlapping_time_span_elements__buffers__fully_inside__buffers_are_preserved():
+    time_span_elements = [
+        TimeSpanElement(
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=20),
+            buffer_time_before=timedelta(),
+            buffer_time_after=timedelta(),
+            is_reservable=False,
+        ),
+        TimeSpanElement(
+            start_datetime=_get_date(hour=11),
+            end_datetime=_get_date(hour=19),
+            buffer_time_before=timedelta(hours=2),  # 09:00
+            buffer_time_after=timedelta(hours=2),  # 21:00
+            is_reservable=False,
+        ),
+    ]
+
+    assert merge_overlapping_time_span_elements(time_span_elements) == [
+        TimeSpanElement(
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=20),
+            buffer_time_before=timedelta(hours=1),  # 09:00
+            buffer_time_after=timedelta(hours=1),  # 21:00
+            is_reservable=False,
+        ),
+    ]
+
+
+def test__merge_overlapping_time_span_elements__buffers__fully_inside__buffer_are_adjusted():
+    # TODO: Add images to tests
+    time_span_elements = [
+        TimeSpanElement(
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=20),
+            buffer_time_before=timedelta(hours=2),
+            buffer_time_after=timedelta(hours=2),
+            is_reservable=False,
+        ),
+        TimeSpanElement(
+            start_datetime=_get_date(hour=11),
+            end_datetime=_get_date(hour=21),
+            buffer_time_before=timedelta(),
+            buffer_time_after=timedelta(),
+            is_reservable=False,
+        ),
+    ]
+
+    assert merge_overlapping_time_span_elements(time_span_elements) == [
+        TimeSpanElement(
+            start_datetime=_get_date(hour=10),
+            end_datetime=_get_date(hour=21),
+            buffer_time_before=timedelta(hours=2),  # 08:00
+            buffer_time_after=timedelta(hours=1),  # 22:00
             is_reservable=False,
         ),
     ]

--- a/tests/test_models/test_reservation_statistics.py
+++ b/tests/test_models/test_reservation_statistics.py
@@ -22,7 +22,9 @@ pytestmark = [
 ]
 
 
-def test_statistics__create__reservation_creation_creates_statistics():
+def test_statistics__create__reservation_creation_creates_statistics(settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
     reservation_unit = ReservationUnitFactory.create(name="resu", unit=UnitFactory(name="mesta", tprek_id="1234"))
     recurring = RecurringReservationFactory.create(application_event_schedule=None)
     reservation = ReservationFactory.create(
@@ -103,7 +105,9 @@ def test_statistics__create__reservation_creation_creates_statistics():
     assert stat.buffer_time_after == reservation.buffer_time_after
 
 
-def test_statistics__update__purpose():
+def test_statistics__update__purpose(settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
     reservation = ReservationFactory.create()
 
     stat = ReservationStatistic.objects.first()
@@ -116,7 +120,9 @@ def test_statistics__update__purpose():
     assert stat.purpose == reservation.purpose
 
 
-def test_statistics__update__cancel_reason_text():
+def test_statistics__update__cancel_reason_text(settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
     reservation = ReservationFactory.create()
 
     stat = ReservationStatistic.objects.first()
@@ -129,7 +135,9 @@ def test_statistics__update__cancel_reason_text():
     assert stat.cancel_reason_text == "cancel"
 
 
-def test_statistics__update__reservation_unit_updates_statistics():
+def test_statistics__update__reservation_unit_updates_statistics(settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
     reservation_unit = ReservationUnitFactory.create(name="Test reservation unit", unit__name="Test unit")
     reservation = ReservationFactory.create(name="Test reservation", reservation_unit=[reservation_unit])
 

--- a/tests/test_tasks/test_prune_reservation_statistics.py
+++ b/tests/test_tasks/test_prune_reservation_statistics.py
@@ -12,7 +12,9 @@ pytestmark = [
 ]
 
 
-def test_prune_reservation_statistics__deletes_in_the_given_time():
+def test_prune_reservation_statistics__deletes_in_the_given_time(settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
     five_years_ago = local_datetime() - relativedelta(years=5)
     four_years_ago = local_datetime() - relativedelta(years=4)
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes `merge_overlapping_time_span_elements` function messing up first reservable time calculation. 
    - Previously, the function would merge time spans by modifying existing time spans, which are shared among multiple reservation units through the reservation unit hierarchy. This effect would compound with reservation time spans from sibling reservations units (i.e. don't affect each other, but do affect their parent) starting to affect each other.
    - This PR fixes that by copying the merged time spans inside the `merge_overlapping_time_span_elements` function.
    - Currently, there is no test to verify this, but one should be made in #1252
    - Also fixes a small issues with the merging function itself in certain edge cases (see 739ae36aeea2adeaaa059689d5603b3acc27744d)

- Adds settings for disabling code running in signals. This can be used when loading data to local databases, removing signaling code while this is happening.

- Fixes the Finnish translation for "code business"

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
