### PR TITLE
Change RejectedOccurrenceFilterSet filters to accept multiple values

### DIFF
--- a/api/graphql/types/rejected_occurrence/filtersets.py
+++ b/api/graphql/types/rejected_occurrence/filtersets.py
@@ -7,12 +7,11 @@ from lookup_property import L
 
 from common.db import raw_prefixed_query
 from reservations.models import RejectedOccurrence
+from reservations.querysets import RejectedOccurrenceQuerySet
 
 __all__ = [
     "RejectedOccurrenceFilterSet",
 ]
-
-from reservations.querysets import RejectedOccurrenceQuerySet
 
 
 class RejectedOccurrenceFilterSet(ModelFilterSet):
@@ -28,8 +27,8 @@ class RejectedOccurrenceFilterSet(ModelFilterSet):
             "__application_round"
         )
     )
-    reservation_unit = IntChoiceFilter(field_name="recurring_reservation__reservation_unit")
-    unit = IntChoiceFilter(field_name="recurring_reservation__reservation_unit__unit")
+    reservation_unit = IntMultipleChoiceFilter(field_name="recurring_reservation__reservation_unit")
+    unit = IntMultipleChoiceFilter(field_name="recurring_reservation__reservation_unit__unit")
     text_search = django_filters.CharFilter(method="filter_text_search")
 
     class Meta:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Changes the `reservation_unit` and `unit` filters to accept multiple ids for filtering. Frontend required this change.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
