### PR TITLE
Fix reservation generation breaking with unregistered organisations

### DIFF
--- a/applications/tasks.py
+++ b/applications/tasks.py
@@ -103,7 +103,7 @@ def generate_reservation_series_from_allocations(application_round_id: int) -> N
 
             organisation: Organisation | None = getattr(application, "organisation", None)
             organisation_name: str = getattr(organisation, "name", "")
-            organisation_identifier: str | None = getattr(organisation, "identifier", None)
+            organisation_identifier: str = getattr(organisation, "identifier", "") or ""
             organisation_address: Address | None = getattr(organisation, "address", None)
             organisation_address_street: str = getattr(organisation_address, "street_address", "")
             organisation_address_city: str = getattr(organisation_address, "city", "")
@@ -155,7 +155,7 @@ def generate_reservation_series_from_allocations(application_round_id: int) -> N
             else:
                 reservation_details["reservee_organisation_name"] = organisation_name
                 reservation_details["reservee_id"] = organisation_identifier
-                reservation_details["reservee_is_unregistered_association"] = organisation_identifier is None
+                reservation_details["reservee_is_unregistered_association"] = not organisation_identifier
                 reservation_details["reservee_address_street"] = organisation_address_street
                 reservation_details["reservee_address_city"] = organisation_address_city
                 reservation_details["reservee_address_zip"] = organisation_address_zip


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes a null-constraint error with moving `Organisation.identifier` to `Reservation.reservee_id` for unregistered organisations. This previously broke reservation generation from applications.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
