### PR TITLE
Add `allow_cascade=True` to test data creation flush

### DIFF
--- a/common/management/commands/data_creation/main.py
+++ b/common/management/commands/data_creation/main.py
@@ -128,4 +128,4 @@ def create_test_data(flush: bool = True) -> None:
 
 @with_logs("Flushing database...", "Database flushed!")
 def _clear_database() -> None:
-    call_command("flush", "--noinput")
+    call_command("flush", "--noinput", allow_cascade=True)

--- a/common/management/commands/data_creation/main.py
+++ b/common/management/commands/data_creation/main.py
@@ -1,4 +1,5 @@
 # ruff: noqa: S311
+import os
 
 from django.core.management import call_command
 
@@ -128,4 +129,8 @@ def create_test_data(flush: bool = True) -> None:
 
 @with_logs("Flushing database...", "Database flushed!")
 def _clear_database() -> None:
+    if os.getenv("DJANGO_SETTINGS_ENVIRONMENT") == "Production":
+        msg = "Hey! This is the production environment! Don't just go flushing the database! >:("
+        raise RuntimeError(msg)
+
     call_command("flush", "--noinput", allow_cascade=True)


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- This is required to make db flush work in certain edge cases. Required to flush data in dev for test data creation.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Tested already in Dev by editing a file there.
 
## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
