### PR TITLE
Switch to ECR for pulling docker images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM public.ecr.aws/docker/library/python:3.12-slim-bullseye AS base
 
 # Make sure we build as the root user.
 USER root


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- This is done due to hitting pull rate limits for Docker Hub (for unauthenticated users) in Azure Pipelines. At the time, this is 100 pulls per 6 hours, which is shared with all Platta developers. ECR offers 1 pull per second (for unauthenticated users), which we shouldn't hit too often since CI also has retries for pulling images.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Builds should work in GitHub CI and Azure Pipelines

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
