### PR TITLE
ReservationUnit reservation begins/ends doesn't affect published filter

### DIFF
--- a/api/graphql/types/unit/filtersets.py
+++ b/api/graphql/types/unit/filtersets.py
@@ -117,11 +117,6 @@ class UnitFilterSet(ModelFilterSet):
                 & Q(reservationunit__is_draft=False)
                 & (Q(reservationunit__publish_begins__isnull=True) | Q(reservationunit__publish_begins__lte=now))
                 & (Q(reservationunit__publish_ends__isnull=True) | Q(reservationunit__publish_ends__gt=now))
-                & (
-                    Q(reservationunit__reservation_begins__isnull=True)
-                    | Q(reservationunit__reservation_begins__lte=now)
-                )
-                & (Q(reservationunit__reservation_ends__isnull=True) | Q(reservationunit__reservation_ends__gt=now))
             )
 
         else:
@@ -130,8 +125,6 @@ class UnitFilterSet(ModelFilterSet):
                 | Q(reservationunit__is_draft=True)
                 | (Q(reservationunit__publish_begins__gte=now))
                 | (Q(reservationunit__publish_ends__lt=now))
-                | (Q(reservationunit__reservation_begins__lte=now))
-                | (Q(reservationunit__reservation_ends__gt=now))
             )
 
         # Prevent multiple joins, see explanation above.

--- a/tests/test_graphql_api/test_unit/test_filtering.py
+++ b/tests/test_graphql_api/test_unit/test_filtering.py
@@ -51,13 +51,18 @@ def test_units__filter__by_published_reservation_units(graphql):
     unit_1 = UnitFactory.create(name="1")
     unit_2 = UnitFactory.create(name="2")
     unit_3 = UnitFactory.create(name="3")
+    unit_4 = UnitFactory.create(name="4")
 
     publish_date = datetime.datetime.now(tz=get_default_timezone())
 
+    # Returned
     ReservationUnitFactory.create(unit=unit_1)
     ReservationUnitFactory.create(publish_begins=publish_date, unit=unit_2)
-    ReservationUnitFactory.create(is_archived=True, unit=unit_3)
-    ReservationUnitFactory.create(publish_begins=publish_date + datetime.timedelta(days=30), unit=unit_3)
+    ReservationUnitFactory.create(reservation_begins=publish_date + datetime.timedelta(days=30), unit=unit_3)
+
+    # Filtered out
+    ReservationUnitFactory.create(is_archived=True, unit=unit_4)
+    ReservationUnitFactory.create(publish_begins=publish_date + datetime.timedelta(days=30), unit=unit_4)
 
     graphql.login_user_based_on_type(UserType.SUPERUSER)
 
@@ -66,9 +71,10 @@ def test_units__filter__by_published_reservation_units(graphql):
 
     assert response.has_errors is False
 
-    assert len(response.edges) == 2
+    assert len(response.edges) == 3
     assert response.node(0) == {"pk": unit_1.pk}
     assert response.node(1) == {"pk": unit_2.pk}
+    assert response.node(2) == {"pk": unit_3.pk}
 
 
 def test_units__filter__by_own_reservations(graphql):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix Unit `publishedReservationUnit` filter incorrectly excluding units where the ReservationUnit is published but not yet reservable

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3501](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3501)


[TILA-3501]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ