### PR TITLE
Extend company code exclusion to units in tax percentage update task

### DIFF
--- a/reservation_units/tasks.py
+++ b/reservation_units/tasks.py
@@ -51,6 +51,7 @@ def update_reservation_unit_pricings_tax_percentage(
             | Q(highest_price__gt=0)
         )
         .exclude(reservation_unit__payment_accounting__company_code__in=ignored_company_codes)
+        .exclude(reservation_unit__unit__payment_accounting__company_code__in=ignored_company_codes)
         .order_by("reservation_unit_id", "-begins")
         .distinct("reservation_unit_id")
     )

--- a/tests/factories/unit.py
+++ b/tests/factories/unit.py
@@ -6,7 +6,7 @@ from factory import fuzzy
 
 from spaces.models import ServiceSector, Unit, UnitGroup
 
-from ._base import GenericDjangoModelFactory
+from ._base import GenericDjangoModelFactory, NullableSubFactory
 
 __all__ = [
     "UnitFactory",
@@ -27,8 +27,8 @@ class UnitFactory(GenericDjangoModelFactory[Unit]):
     email = ""
     phone = ""
     rank = 0
-    payment_merchant = None
-    payment_accounting = None
+    payment_merchant = NullableSubFactory("tests.factories.PaymentMerchantFactory", null=True)
+    payment_accounting = NullableSubFactory("tests.factories.PaymentAccountingFactory", null=True)
     origin_hauki_resource = None
 
     @factory.post_generation

--- a/tests/test_models/test_reservation_unit_pricing_updates.py
+++ b/tests/test_models/test_reservation_unit_pricing_updates.py
@@ -155,16 +155,23 @@ def test_reservation_unit__update_pricings__tax_percentage__free_pricing_is_igno
     assert ReservationUnitPricing.objects.count() == 1
 
 
-def test_reservation_unit__update_pricings__tax_percentage__ignored_company_codes():
+@pytest.mark.parametrize(
+    "company_code_path",
+    [
+        "reservation_unit__payment_accounting__company_code",
+        "reservation_unit__unit__payment_accounting__company_code",
+    ],
+)
+def test_reservation_unit__update_pricings__tax_percentage__ignored_company_codes(company_code_path):
     pricing_1 = ReservationUnitPricingFactory.create(
         begins=datetime.date(2024, 1, 1),
         tax_percentage__value=CURRENT_TAX,
-        reservation_unit__payment_accounting__company_code="1234",
+        **{company_code_path: "1234"},
     )
     pricing_2 = ReservationUnitPricingFactory.create(
         begins=datetime.date(2024, 1, 1),
         tax_percentage__value=CURRENT_TAX,
-        reservation_unit__payment_accounting__company_code="5678",
+        **{company_code_path: "5678"},
     )
 
     update_reservation_unit_pricings_tax_percentage(str(TAX_CHANGE_DATE), str(CURRENT_TAX), str(FUTURE_TAX), ["5678"])


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- The task `company_code` ignore is now applied to `PaymentAccounting`s through `Unit` relation also

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3519](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3519)


[TILA-3519]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ