### PR TITLE
Django Admin: Fix removing empty timeslots

### DIFF
--- a/reservation_units/admin/reservation_unit/form.py
+++ b/reservation_units/admin/reservation_unit/form.py
@@ -11,10 +11,10 @@ from terms_of_use.models import TermsOfUse
 
 
 def remove_empty_timeslots(timeslots: list[dict[str, str]]) -> None:
-    # Iterate in reverse order so that items can be deleted without affecting the loop
-    for i, timeslot in enumerate(reversed(timeslots)):
-        if timeslot == {"begin": "", "end": ""}:
-            del timeslots[i]
+    empty_timeslot = {"begin": "", "end": ""}
+
+    while empty_timeslot in timeslots:
+        timeslots.remove(empty_timeslot)
 
 
 class TimeslotForm(forms.Form):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix removing empty timeslots in Django Admin
  - Before `timeslots` were looped and `i` timeslot was deleted, which was wrong since the list was looped in reverse order

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
