### PR TITLE
Fix a couple of reservation admin reservation unit refs

### DIFF
--- a/tilavarauspalvelu/admin/reservation/admin.py
+++ b/tilavarauspalvelu/admin/reservation/admin.py
@@ -85,8 +85,8 @@ class ReservationAdmin(admin.ModelAdmin):
         ("state", MultiSelectFilter),
         RecurringReservationListFilter,
         PaidReservationListFilter,
-        ("reservation_unit__unit", MultiSelectRelatedOnlyDropdownFilter),
-        ("reservation_unit", MultiSelectRelatedOnlyDropdownFilter),
+        ("reservation_units__unit", MultiSelectRelatedOnlyDropdownFilter),
+        ("reservation_units", MultiSelectRelatedOnlyDropdownFilter),
     ]
 
     # Form
@@ -197,7 +197,7 @@ class ReservationAdmin(admin.ModelAdmin):
     inlines = [PaymentOrderInline]
 
     def get_queryset(self, request):
-        return super().get_queryset(request).prefetch_related("reservation_unit")
+        return super().get_queryset(request).prefetch_related("reservation_units")
 
     def get_search_results(
         self,
@@ -212,7 +212,7 @@ class ReservationAdmin(admin.ModelAdmin):
 
         return queryset, may_have_duplicates
 
-    @admin.display(ordering="reservation_unit__name")
+    @admin.display(ordering="reservation_units__name")
     def reservation_units(self, obj: Reservation) -> str:
         return ", ".join([str(reservation_unit) for reservation_unit in obj.reservation_units.all()])
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- See title. Crashes reservation admin page otherwise.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
