### PR TITLE
Old pricing is hidden in GQL

### DIFF
--- a/tilavarauspalvelu/api/graphql/types/reservation_unit/serializers.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation_unit/serializers.py
@@ -317,7 +317,8 @@ class ReservationUnitSerializer(NestingModelSerializer):
     @staticmethod
     def handle_pricings(pricings: list[dict[Any, Any]], reservation_unit: ReservationUnit) -> None:
         with atomic():
-            # Delete future pricings that are not in the payload
+            # Delete future pricings that are not in the payload.
+            # Past or Active pricings can not be deleted.
             pricing_pks = [pricing.get("pk") for pricing in pricings if "pk" in pricing]
             ReservationUnitPricing.objects.filter(
                 reservation_unit=reservation_unit,

--- a/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
@@ -19,5 +19,4 @@ class ReservationUnitPricingNode(DjangoNode):
             "highest_price",
             "highest_price_net",
             "tax_percentage",
-            "status",
         ]

--- a/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
@@ -1,7 +1,10 @@
 import graphene
+from django.db import models
 from graphene_django_extensions import DjangoNode
 
 from tilavarauspalvelu.models import ReservationUnitPricing
+from tilavarauspalvelu.models.reservation_unit_pricing.queryset import ReservationUnitPricingQuerySet
+from tilavarauspalvelu.typing import GQLInfo
 
 
 class ReservationUnitPricingNode(DjangoNode):
@@ -20,3 +23,7 @@ class ReservationUnitPricingNode(DjangoNode):
             "highest_price_net",
             "tax_percentage",
         ]
+
+    @classmethod
+    def filter_queryset(cls, queryset: ReservationUnitPricingQuerySet, info: GQLInfo) -> models.QuerySet:
+        return queryset.exclude_past()

--- a/tilavarauspalvelu/models/reservation_unit_pricing/queryset.py
+++ b/tilavarauspalvelu/models/reservation_unit_pricing/queryset.py
@@ -7,8 +7,24 @@ __all__ = [
     "ReservationUnitPricingQuerySet",
 ]
 
+from utils.date_utils import local_date
 
-class ReservationUnitPricingQuerySet(models.QuerySet): ...
+
+class ReservationUnitPricingQuerySet(models.QuerySet):
+    def exclude_past(self) -> models.QuerySet:
+        """Return all currently active and future pricings."""
+        today = local_date()
+
+        return self.alias(
+            reservation_unit_active_pricing_begins_date=models.Subquery(
+                self.model.objects.filter(
+                    reservation_unit=models.OuterRef("reservation_unit"),
+                    begins__lte=today,
+                )
+                .values("begins")
+                .order_by("-begins")[:1]
+            )
+        ).filter(begins__gte=models.F("reservation_unit_active_pricing_begins_date"))
 
 
 class ReservationUnitPricingManager(models.Manager.from_queryset(ReservationUnitPricingQuerySet)): ...


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Hide old reservation unit pricings in the GQL API
- Remove already deprecated "status" from GQL API fields

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3660](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3660)


[TILA-3660]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3660?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ