### PR TITLE
Fix Mock Verkkokauppa not implemented to Reservation Delete mutation

### DIFF
--- a/tilavarauspalvelu/api/graphql/types/reservation/serializers/confirm_serializers.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation/serializers/confirm_serializers.py
@@ -144,14 +144,13 @@ class ReservationConfirmSerializer(ReservationUpdateSerializer):
                     reservation=self.instance,
                 )
             else:
-                verkkokauppa_order: Order
                 if settings.MOCK_VERKKOKAUPPA_API_ENABLED:
-                    verkkokauppa_order = create_mock_verkkokauppa_order(self.instance)
+                    verkkokauppa_order: Order = create_mock_verkkokauppa_order(self.instance)
                 else:
                     order_params: CreateOrderParams = get_verkkokauppa_order_params(self.instance)
 
                     try:
-                        verkkokauppa_order = VerkkokauppaAPIClient.create_order(order_params=order_params)
+                        verkkokauppa_order: Order = VerkkokauppaAPIClient.create_order(order_params=order_params)
                     except CreateOrderError as err:
                         SentryLogger.log_exception(
                             err, details="Creating order in Verkkokauppa failed", reservation_id=self.instance.pk

--- a/tilavarauspalvelu/api/webhooks/views.py
+++ b/tilavarauspalvelu/api/webhooks/views.py
@@ -102,9 +102,7 @@ class WebhookOrderCancelViewSet(viewsets.ViewSet):
             SentryLogger.log_message(f"Verkkokauppa: {msg}", details=serializer.validated_data)
             return Response(data={"message": msg}, status=400)
 
-        payment_order.status = OrderStatus.CANCELLED
-        payment_order.processed_at = local_datetime()
-        payment_order.save(update_fields=["status", "processed_at"])
+        payment_order.actions.set_order_as_cancelled()
 
         return Response(data={"message": "Order cancellation completed successfully"}, status=200)
 

--- a/tilavarauspalvelu/models/payment_order/actions.py
+++ b/tilavarauspalvelu/models/payment_order/actions.py
@@ -40,6 +40,11 @@ class PaymentOrderActions:
             )
             raise
 
+    def set_order_as_cancelled(self) -> None:
+        self.payment_order.status = OrderStatus.CANCELLED
+        self.payment_order.processed_at = local_datetime()
+        self.payment_order.save(update_fields=["status", "processed_at"])
+
     def cancel_order_in_webshop(self) -> Order | None:
         try:
             return VerkkokauppaAPIClient.cancel_order(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Mock verkkokauppa stuff was not implemented to ReservationDeleteMutation, this fixes that

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- Slack
