### PR TITLE
Fix the rank migration not updating the rank field for 0 or none valaues

### DIFF
--- a/tilavarauspalvelu/migrations/0028_fix_rank_fields.py
+++ b/tilavarauspalvelu/migrations/0028_fix_rank_fields.py
@@ -23,6 +23,7 @@ def forwards_func(apps, schema_editor):
 
         objs = []
         for i, obj in enumerate(qs, start=max_rank + 1):
+            objs.append(obj)
             obj.rank = i
 
         model.objects.bulk_update(objs, ["rank"])


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix the rank migration not updating the rank field for 0 or none valaues

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- None

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3542](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3542)
- [TILA-3543](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3543)
- [TILA-3552](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3552)
