### PR TITLE
Hide orders of deleted reservations from the GQL

### DIFF
--- a/tilavarauspalvelu/api/graphql/schema.py
+++ b/tilavarauspalvelu/api/graphql/schema.py
@@ -242,7 +242,7 @@ class Query(graphene.ObjectType):
         return HelsinkiProfileDataNode.get_data(info, application_id=application_id, reservation_id=reservation_id)
 
     def resolve_order(root: None, info: GQLInfo, *, order_uuid: str, **kwargs: Any):
-        queryset = optimize(PaymentOrder.objects.filter(remote_id=order_uuid), info)
+        queryset = optimize(PaymentOrder.objects.filter(remote_id=order_uuid, reservation__isnull=False), info)
         order = next(iter(queryset), None)  # Avoids adding additional ordering.
         if order is None:
             msg = f"PaymentOrder-object with orderUuid='{order_uuid}' does not exist."


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Prevent querying orders of deleted reservations from the GQL API
  - Fixes an issue where querying an order of a deleted reservation caused python errors due to permissions checks trying to access the reservation's user

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- Slack
