### PR TITLE
Give JSON from CSRF endpoint if no `redirect_to` is given

### DIFF
--- a/tilavarauspalvelu/api/rest/views.py
+++ b/tilavarauspalvelu/api/rest/views.py
@@ -47,7 +47,7 @@ def reservation_ical(request: WSGIRequest, pk: int) -> FileResponse | JsonRespon
 
 @require_GET
 @csrf_exempt  # NOSONAR
-def csrf_view(request: WSGIRequest) -> HttpResponseRedirect:  # NOSONAR
+def csrf_view(request: WSGIRequest) -> HttpResponseRedirect | JsonResponse:  # NOSONAR
     """View for updating the CSRF cookie."""
     # From: https://fractalideas.com/blog/making-react-and-django-play-well-together-single-page-app-model/
     # > You may wonder whether this endpoint creates a security vulnerability.
@@ -55,7 +55,7 @@ def csrf_view(request: WSGIRequest) -> HttpResponseRedirect:  # NOSONAR
     # > the CSRF token on a traditional Django website. The browser's same-origin policy
     # > prevents an attacker from getting access to the token with a cross-origin request.
     # Additionally, our backend's CORS policy only allows cross-origin requests from the frontend.
-    redirect_to: str = request.GET.get("redirect_to", "/")
+    redirect_to: str | None = request.GET.get("redirect_to", None)
     # Set these META-flags to force `django.middleware.csrf.CsrfViewMiddleware` to update the CSRF cookie.
     request.META["CSRF_COOKIE_NEEDS_UPDATE"] = True
     request.META["CSRF_COOKIE"] = get_token(request)
@@ -64,6 +64,8 @@ def csrf_view(request: WSGIRequest) -> HttpResponseRedirect:  # NOSONAR
     # during local development, which is considered a different origin, and thus the CSRF cookie is not
     # shared automatically like it is in production.
     headers = {"NewCSRFToken": request.META["CSRF_COOKIE"]}
+    if redirect_to is None:
+        return JsonResponse(data={"csrfToken": request.META["CSRF_COOKIE"]}, status=200, headers=headers)
     return HttpResponseRedirect(redirect_to=redirect_to, headers=headers)
 
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Allow querying CSRF endpoints without triggering redirects if no redirect URL is given. Required since fetch API doesn't allow reading headers from redirect requests, where the CSRF token is currently located.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
