### PR TITLE
Add new login params

### DIFF
--- a/config/auth.py
+++ b/config/auth.py
@@ -35,9 +35,18 @@ class ProxyTunnistamoOIDCAuthBackend(TunnistamoOIDCAuth):
 
     def auth_params(self, state: str | None = None) -> dict[str, str]:
         params = super().auth_params(state)
-        lang = self.strategy.request_data().get("ui_locales")
+
+        request_data = self.strategy.request_data()
+
+        # Parameters from `tilavarauspalvelu.api.helauth.views.login_view`.
+        lang = request_data.get("ui_locales")
+        login_method_hint = request_data.get("kc_idp_hint")
+
         if lang:
             params["ui_locales"] = lang
+        if login_method_hint:
+            params["kc_idp_hint"] = login_method_hint
+
         return params
 
     def get_end_session_url(self, request: WSGIRequest, id_token: str) -> str | None:

--- a/config/auth.py
+++ b/config/auth.py
@@ -33,6 +33,13 @@ class ProxyTunnistamoOIDCAuthBackend(TunnistamoOIDCAuth):
     def get_user(self, user_id: Any = None) -> User | None:
         return get_user(user_id) if user_id is not None else None
 
+    def auth_params(self, state: str | None = None) -> dict[str, str]:
+        params = super().auth_params(state)
+        lang = self.strategy.request_data().get("ui_locales")
+        if lang:
+            params["ui_locales"] = lang
+        return params
+
     def get_end_session_url(self, request: WSGIRequest, id_token: str) -> str | None:
         url = self.oidc_config().get("end_session_endpoint")
 

--- a/tests/test_graphql_api/test_application_section/test_filtering.py
+++ b/tests/test_graphql_api/test_application_section/test_filtering.py
@@ -718,8 +718,8 @@ def test_application_section__filter__by_age_group(graphql):
     # given:
     # - There is an application with two application sections with different age groups
     # - A superuser is using the system
-    age_group_1 = AgeGroupFactory.create()
-    age_group_2 = AgeGroupFactory.create()
+    age_group_1 = AgeGroupFactory.create(minimum=18, maximum=100)
+    age_group_2 = AgeGroupFactory.create(minimum=0, maximum=17)
     application = ApplicationFactory.create_in_status_draft(application_sections=[])
     section_1 = ApplicationSectionFactory.create_in_status_unallocated(application=application, age_group=age_group_1)
     ApplicationSectionFactory.create_in_status_unallocated(application=application, age_group=age_group_2)
@@ -742,8 +742,8 @@ def test_application_section__filter__by_age_group__multiple(graphql):
     # given:
     # - There is an application with two application sections with different age groups
     # - A superuser is using the system
-    age_group_1 = AgeGroupFactory.create()
-    age_group_2 = AgeGroupFactory.create()
+    age_group_1 = AgeGroupFactory.create(minimum=18, maximum=100)
+    age_group_2 = AgeGroupFactory.create(minimum=0, maximum=17)
     application = ApplicationFactory.create_in_status_draft(application_sections=[])
     section_1 = ApplicationSectionFactory.create_in_status_unallocated(application=application, age_group=age_group_1)
     section_2 = ApplicationSectionFactory.create_in_status_unallocated(application=application, age_group=age_group_2)

--- a/tests/test_graphql_api/test_recurring_reservation/test_update_series.py
+++ b/tests/test_graphql_api/test_recurring_reservation/test_update_series.py
@@ -19,8 +19,8 @@ pytestmark = [
 
 
 def test_recurring_reservations__update_series(graphql):
-    age_group_1 = AgeGroupFactory.create()
-    age_group_2 = AgeGroupFactory.create()
+    age_group_1 = AgeGroupFactory.create(minimum=18, maximum=100)
+    age_group_2 = AgeGroupFactory.create(minimum=0, maximum=17)
     purpose_1 = ReservationPurposeFactory.create()
     purpose_2 = ReservationPurposeFactory.create()
     city_1 = CityFactory.create()

--- a/tilavarauspalvelu/api/helauth/urls.py
+++ b/tilavarauspalvelu/api/helauth/urls.py
@@ -4,13 +4,12 @@
 # `helusers.tunnistamo_oidc.TunnistamoOIDCAuth` is specifically included in the
 # `AUTHENTICATION_BACKENDS` setting.
 from django.urls import path
-from helusers.views import LoginView
 
-from .views import logout_view
+from .views import login_view, logout_view
 
 app_name = "helusers"
 
 urlpatterns = [
-    path("login/", LoginView.as_view(), name="auth_login"),
+    path("login/", login_view, name="auth_login"),
     path("logout/", logout_view, name="auth_logout"),
 ]

--- a/tilavarauspalvelu/api/helauth/views.py
+++ b/tilavarauspalvelu/api/helauth/views.py
@@ -31,6 +31,11 @@ def login_view(request: WSGIRequest) -> HttpResponseRedirect:
     if lang:
         url = update_query_params(url, ui_locales=lang)
 
+    login_method_hint: str | None = request.GET.get("ui")
+    if login_method_hint == "customer":
+        # For `kc_idp_hint`, see: https://www.keycloak.org/docs/latest/server_admin/#_client_suggested_idp
+        url = update_query_params(url, kc_idp_hint="suomi_fi")
+
     return HttpResponseRedirect(url)
 
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- `lang` param can be used to set keycloak UI language from the frontend
- `ui` parameter can be used to select which UI is making the login (`customer` or `admin`).
    - If `customer`, hints to use `suomi.fi` login
    - if `admin`, currently does nothing
    - If hint is wrong, should display the login selection as normal
    - Currently this is not working in Helsinki tunnistus, maybe it will be fixed at some point?

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3570](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3570)
- [TILA-3568](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3568)


[TILA-3570]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ