### PR TITLE
Fix paths for new monitoring endpoints

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -50,9 +50,9 @@ urlpatterns = [
     ),
     path("tinymce/", include("tinymce.urls")),
     path("csrf/", csrf_view),
-    path("system-status/", include("health_check.urls", namespace="health_check")),
-    path("liveness/", liveness_check, name="liveness_check"),
-    path("readiness/", readiness_check, name="readiness_check"),
+    path("monitoring/system-status/", include("health_check.urls", namespace="health_check")),
+    path("monitoring/liveness/", liveness_check, name="liveness_check"),
+    path("monitoring/readiness/", readiness_check, name="readiness_check"),
 ]
 
 if settings.MOCK_VERKKOKAUPPA_API_ENABLED:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- This is done to not reserve as many top-level paths, since we share the same domain with the frontend

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- Requires changing OpenShift routing to route the /monitoring/ to the backend (already done). Otherwise the monitoring paths are not visible to the internet.

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
