### PR TITLE
Fix `anonymize_old_users_task` task name

### DIFF
--- a/tilavarauspalvelu/tasks.py
+++ b/tilavarauspalvelu/tasks.py
@@ -714,6 +714,6 @@ def send_user_anonymization_email_task():
     EmailService.send_user_anonymization_emails()
 
 
-@app.task(name="deactivate_old_permissions")
+@app.task(name="anonymize_old_users")
 def anonymize_old_users_task() -> None:
     User.objects.anonymize_inactive_users()


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- See title. Prevents scheduling the task due to copy-pasta name.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
