### PR TITLE
Change reservation unit text search to use AND instead of OR

### DIFF
--- a/tests/test_graphql_api/test_reservation_unit/test_text_search.py
+++ b/tests/test_graphql_api/test_reservation_unit/test_text_search.py
@@ -211,7 +211,12 @@ class Params(NamedTuple):
         ),
         "match different grammatical case": Params(
             text_search="tila pukinmäessä",
-            reservation_unit_data=SearchableData(description="sijaitsee pukinmäen kirjaston vieressä"),
+            reservation_unit_data=SearchableData(description="tila sijaitsee pukinmäen kirjaston vieressä"),
+        ),
+        "not all search terms are found": Params(
+            text_search="tenniskenttä kannelmäki",
+            reservation_unit_data=SearchableData(description="Tämä on uusi tenniskenttä"),
+            has_results=False,
         ),
     })
 )

--- a/tilavarauspalvelu/api/graphql/types/reservation_unit/filtersets.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation_unit/filtersets.py
@@ -141,7 +141,7 @@ class ReservationUnitFilterSet(ModelFilterSet, ReservationUnitFilterSetMixin):
 
     def get_text_search(self, qs: ReservationUnitQuerySet, name: str, value: str) -> QuerySet:
         language = get_text_search_language(self.request)
-        search = build_search(value)
+        search = build_search(value, separator="&")
         query = SearchQuery(value=search, config=language, search_type="raw")
         match language:
             # Do search mostly with full text search, but also search some columns with containment search.

--- a/utils/db.py
+++ b/utils/db.py
@@ -285,12 +285,16 @@ def text_search(
     return qs.annotate(ts_vector=vector, ts_rank=rank).filter(q)
 
 
-def build_search(text: str) -> str:
+def build_search(text: str, *, separator: Literal["|", "&", "<->"] = "|") -> str:
     """
     Build raw postgres full text search query from text.
 
     Quote search terms and do prefix matching.
-    Match all search terms with the OR operator.
+    Match all search terms with the given operator:
+      | = or
+      & = and
+      <-> = Followed by
+      <3> = Followed by less than 3 "words" away (<1> same as <->)
 
     Replace single quotes and hyphens in words with spaces so they are treated as whitespace in the search,
     e.g. "Moe's" becomes "Moe s" and "3D-printer" becomes "3D printer".
@@ -302,4 +306,4 @@ def build_search(text: str) -> str:
         if value:
             value = f"'{value}':*"
             search_terms.append(value)
-    return " | ".join(search_terms)
+    return f" {separator} ".join(search_terms)


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- This works more like the previous search, with the omission of commas being used to search in OR-fashion (not used based on search history)
- Should likely be changed back to OR when we have a "similarity" ordering so that results containing more of the given words are shown first, but those that contain some of them can still be shown (This should also weigh finding the search word from 
the name of the reservation unit more than from the description for example)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
