### PR TITLE
Add custom Storage to convert non-ASCII filenames to ASCII

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -169,7 +169,7 @@ class Common(Environment):
 
     STORAGES = {
         "default": {
-            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "BACKEND": "config.storage.FileSystemStorageASCII",
         },
         "staticfiles": {
             "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",

--- a/config/storage.py
+++ b/config/storage.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import unicodedata
+
+from django.core.files.storage import FileSystemStorage
+
+
+class FileSystemStorageASCII(FileSystemStorage):
+    def get_valid_name(self, name: str) -> str:
+        name = super().get_valid_name(name)
+        # Apply additional normalization to convert non-ASCII characters to ASCII
+        return unicodedata.normalize("NFKD", name).encode("ascii", "ignore").decode("ascii")


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes [issues](https://sentry.hel.fi/organizations/city-of-helsinki/issues/49772/?environment=prod&project=16&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&stream_index=1) in saving images with filenames containing non-ASCII letters by adding a custom FileStorage backend that has additional normalization to replace non-ASCII letters in filenames before saving them

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Test in that said images can be uploaded in Platta envs

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3781](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3781)


[TILA-3781]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ