### PR TITLE
Create access code for staff reservations

### DIFF
--- a/tests/test_graphql_api/test_reservation/test_staff_create.py
+++ b/tests/test_graphql_api/test_reservation/test_staff_create.py
@@ -5,9 +5,11 @@ import datetime
 import freezegun
 import pytest
 
-from tilavarauspalvelu.enums import CustomerTypeChoice, ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.enums import AccessType, CustomerTypeChoice, ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError
 from tilavarauspalvelu.models import Reservation, ReservationUnitHierarchy
-from utils.date_utils import DEFAULT_TIMEZONE, local_datetime, next_hour
+from utils.date_utils import DEFAULT_TIMEZONE, local_date, local_datetime, next_hour
 
 from tests.factories import (
     AgeGroupFactory,
@@ -20,6 +22,7 @@ from tests.factories import (
     SpaceFactory,
     UserFactory,
 )
+from tests.helpers import patch_method
 
 from .helpers import CREATE_STAFF_MUTATION, get_staff_create_data
 
@@ -480,3 +483,110 @@ def test_reservation__staff_create__reservee_used_ad_login(graphql, amr, expecte
 
     reservation = Reservation.objects.get(pk=response.first_query_object["pk"])
     assert reservation.reservee_used_ad_login is expected
+
+
+@patch_method(
+    PindoraClient.create_reservation,
+    return_value={"access_code_generated_at": datetime.datetime(2023, 1, 1, tzinfo=DEFAULT_TIMEZONE)},
+)
+def test_reservation__staff_create__access_type__access_code(graphql):
+    reservation_unit = ReservationUnitFactory.create(access_type=AccessType.ACCESS_CODE)
+
+    graphql.login_with_superuser()
+    data = get_staff_create_data(reservation_unit)
+    response = graphql(CREATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation = Reservation.objects.get(pk=response.first_query_object["pk"])
+
+    assert reservation.access_type == AccessType.ACCESS_CODE
+    assert reservation.access_code_generated_at == datetime.datetime(2023, 1, 1, tzinfo=DEFAULT_TIMEZONE)
+
+    PindoraClient.create_reservation.assert_called_with(reservation=reservation, is_active=True)
+
+
+@patch_method(PindoraClient.create_reservation)
+def test_reservation__staff_create__access_type__changed_to_access_code_in_the_future(graphql):
+    today = local_date()
+
+    reservation_unit = ReservationUnitFactory.create(
+        access_type=AccessType.ACCESS_CODE,
+        access_type_start_date=today + datetime.timedelta(days=1),
+    )
+
+    graphql.login_with_superuser()
+    data = get_staff_create_data(reservation_unit)
+    response = graphql(CREATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation = Reservation.objects.get(pk=response.first_query_object["pk"])
+
+    assert reservation.access_type == AccessType.UNRESTRICTED
+    assert reservation.access_code_generated_at is None
+
+    assert PindoraClient.create_reservation.call_count == 0
+
+
+@patch_method(PindoraClient.create_reservation)
+def test_reservation__staff_create__access_type__access_code_has_ended(graphql):
+    today = local_date()
+
+    reservation_unit = ReservationUnitFactory.create(
+        access_type=AccessType.ACCESS_CODE,
+        access_type_end_date=today - datetime.timedelta(days=1),
+    )
+
+    graphql.login_with_superuser()
+    data = get_staff_create_data(reservation_unit)
+    response = graphql(CREATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation = Reservation.objects.get(pk=response.first_query_object["pk"])
+
+    assert reservation.access_type == AccessType.UNRESTRICTED
+    assert reservation.access_code_generated_at is None
+
+    assert PindoraClient.create_reservation.call_count == 0
+
+
+@patch_method(
+    PindoraClient.create_reservation,
+    return_value={"access_code_generated_at": datetime.datetime(2023, 1, 1, tzinfo=DEFAULT_TIMEZONE)},
+)
+def test_reservation__staff_create__access_type__access_code__blocked(graphql):
+    reservation_unit = ReservationUnitFactory.create(access_type=AccessType.ACCESS_CODE)
+
+    graphql.login_with_superuser()
+    data = get_staff_create_data(reservation_unit, type=ReservationTypeChoice.BLOCKED)
+    response = graphql(CREATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation = Reservation.objects.get(pk=response.first_query_object["pk"])
+
+    assert reservation.access_type == AccessType.ACCESS_CODE
+    assert reservation.access_code_generated_at == datetime.datetime(2023, 1, 1, tzinfo=DEFAULT_TIMEZONE)
+
+    PindoraClient.create_reservation.assert_called_with(reservation=reservation, is_active=False)
+
+
+@patch_method(PindoraClient.create_reservation, side_effect=PindoraAPIError())
+def test_reservation__staff_create__access_type__access_code__create_reservation_on_pindora_failure(graphql):
+    reservation_unit = ReservationUnitFactory.create(access_type=AccessType.ACCESS_CODE)
+
+    graphql.login_with_superuser()
+    data = get_staff_create_data(reservation_unit)
+    response = graphql(CREATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is True
+    assert response.error_message() == "Pindora client error"
+
+    # Reservation is still created, but it doesn't know an access code was generated.
+    reservation: Reservation | None = Reservation.objects.first()
+    assert reservation is not None
+
+    assert reservation.access_type == AccessType.ACCESS_CODE
+    assert reservation.access_code_generated_at is None

--- a/tilavarauspalvelu/api/graphql/types/reservation/serializers/staff_create_serializers.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation/serializers/staff_create_serializers.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 import datetime
 from typing import TYPE_CHECKING
 
+from django.db import transaction
 from graphene_django_extensions import NestingModelSerializer
 from graphene_django_extensions.fields import EnumFriendlyChoiceField, IntegerPrimaryKeyField
 from rest_framework.fields import IntegerField
 
-from tilavarauspalvelu.enums import CustomerTypeChoice, ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.enums import AccessType, CustomerTypeChoice, ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
 from tilavarauspalvelu.models import AgeGroup, City, Reservation, ReservationPurpose, ReservationUnit
 from utils.date_utils import DEFAULT_TIMEZONE, local_datetime
 
@@ -145,11 +147,23 @@ class ReservationStaffCreateSerializer(NestingModelSerializer):
         data["state"] = ReservationStateChoice.CONFIRMED
         data["user"] = user
         data["reservee_used_ad_login"] = False if id_token is None else id_token.is_ad_login
+        data["access_type"] = reservation_unit.actions.get_access_type_at(begin)
 
         return data
 
     def create(self, validated_data: StaffCreateReservationData) -> Reservation:
-        reservation_unit: ReservationUnit = validated_data.pop("reservation_unit")
-        reservation = super().create(validated_data)
-        reservation.reservation_units.set([reservation_unit])
+        # Must be able to link reservation unit to the reservation
+        with transaction.atomic():
+            reservation_unit: ReservationUnit = validated_data.pop("reservation_unit")
+            reservation: Reservation = super().create(validated_data)
+            reservation.reservation_units.set([reservation_unit])
+
+        # Don't fail reservation creation if Pindora request fails, but return an error in the response.
+        if reservation.access_type == AccessType.ACCESS_CODE:
+            is_active = reservation.type != ReservationTypeChoice.BLOCKED
+            response = PindoraClient.create_reservation(reservation=reservation, is_active=is_active)
+
+            reservation.access_code_generated_at = response["access_code_generated_at"]
+            reservation.save(update_fields=["access_code_generated_at"])
+
         return reservation


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Create an access code in Pindora for staff reservations
- Differences compared to customer reservations:
   - Always create the reservation, even if Pindora request fails
   - Create reservation access code in an active state, except if reservation type is "BLOCKED"

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3773](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3773)


[TILA-3773]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ