### PR TITLE
Add reservation access code (de)activation calls

### DIFF
--- a/tests/test_graphql_api/test_reservation/test_approve.py
+++ b/tests/test_graphql_api/test_reservation/test_approve.py
@@ -2,15 +2,38 @@ from __future__ import annotations
 
 import pytest
 
-from tilavarauspalvelu.enums import ReservationStateChoice
+from tilavarauspalvelu.enums import AccessType, ReservationStateChoice
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError
 
 from tests.factories import ReservationFactory, ReservationUnitFactory
+from tests.helpers import patch_method
 
 from .helpers import APPROVE_MUTATION, get_approve_data
 
 pytestmark = [
     pytest.mark.django_db,
 ]
+
+
+@patch_method(PindoraClient.activate_reservation_access_code)
+def test_reservation__approve__succeeds(graphql):
+    reservation_unit = ReservationUnitFactory.create()
+    reservation = ReservationFactory.create(
+        state=ReservationStateChoice.REQUIRES_HANDLING,
+        reservation_units=[reservation_unit],
+    )
+
+    graphql.login_with_superuser()
+    data = get_approve_data(reservation)
+    response = graphql(APPROVE_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.CONFIRMED
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 0
 
 
 def test_reservation__approve__cant_approve_if_status_not_requires_handling(graphql):
@@ -83,3 +106,50 @@ def test_reservation__approve__succeeds_with_empty_handling_details(graphql):
 
     reservation.refresh_from_db()
     assert reservation.state == ReservationStateChoice.CONFIRMED
+
+
+@patch_method(PindoraClient.activate_reservation_access_code)
+def test_reservation__approve__succeeds__pindora_api__call_succeeds(graphql):
+    reservation_unit = ReservationUnitFactory.create(
+        access_type=AccessType.ACCESS_CODE,
+    )
+    reservation = ReservationFactory.create(
+        state=ReservationStateChoice.REQUIRES_HANDLING,
+        reservation_units=[reservation_unit],
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_approve_data(reservation)
+    response = graphql(APPROVE_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.CONFIRMED
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.activate_reservation_access_code, side_effect=PindoraAPIError("Error"))
+def test_reservation__approve__succeeds__pindora_api__call_fails(graphql):
+    reservation_unit = ReservationUnitFactory.create(
+        access_type=AccessType.ACCESS_CODE,
+    )
+    reservation = ReservationFactory.create(
+        state=ReservationStateChoice.REQUIRES_HANDLING,
+        reservation_units=[reservation_unit],
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_approve_data(reservation)
+    response = graphql(APPROVE_MUTATION, input_data=data)
+
+    # Request is still successful, even if Pindora API call fails
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.CONFIRMED
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1

--- a/tests/test_graphql_api/test_reservation/test_confirm.py
+++ b/tests/test_graphql_api/test_reservation/test_confirm.py
@@ -6,7 +6,15 @@ import pytest
 from django.test import override_settings
 from graphene_django_extensions.testing import build_mutation
 
-from tilavarauspalvelu.enums import OrderStatus, PaymentType, ReservationNotification, ReservationStateChoice
+from tilavarauspalvelu.enums import (
+    AccessType,
+    OrderStatus,
+    PaymentType,
+    ReservationNotification,
+    ReservationStateChoice,
+)
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError
 from tilavarauspalvelu.integrations.sentry import SentryLogger
 from tilavarauspalvelu.integrations.verkkokauppa.order.exceptions import CreateOrderError
 from tilavarauspalvelu.integrations.verkkokauppa.verkkokauppa_api_client import VerkkokauppaAPIClient
@@ -30,6 +38,7 @@ pytestmark = [
 
 
 @override_settings(SEND_EMAILS=True)
+@patch_method(PindoraClient.activate_reservation_access_code)
 def test_reservation__confirm__changes_state__confirmed(graphql, outbox):
     reservation = ReservationFactory.create_for_confirmation()
 
@@ -53,6 +62,8 @@ def test_reservation__confirm__changes_state__confirmed(graphql, outbox):
     assert outbox[0].subject == "Thank you for your booking at Varaamo"
     unit_name = reservation.reservation_units.first().unit.name
     assert outbox[1].subject == f"New booking {reservation.id} has been made for {unit_name}"
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 0
 
 
 @override_settings(SEND_EMAILS=True)
@@ -453,3 +464,40 @@ def test_reservation__confirm__without_price_and_with_free_pricing_does_not_requ
     assert reservation.state == ReservationStateChoice.CONFIRMED
 
     assert PaymentOrder.objects.count() == 0
+
+
+@patch_method(PindoraClient.activate_reservation_access_code)
+def test_reservation__confirm__pindora_api__call_succeeds(graphql):
+    reservation = ReservationFactory.create_for_confirmation(
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_confirm_data(reservation)
+    response = graphql(CONFIRM_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.CONFIRMED
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.activate_reservation_access_code, side_effect=PindoraAPIError("Error"))
+def test_reservation__confirm__pindora_api__call_fails(graphql):
+    reservation = ReservationFactory.create_for_confirmation(
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_confirm_data(reservation)
+    response = graphql(CONFIRM_MUTATION, input_data=data)
+
+    # Request is still successful, even if Pindora API call fails
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.CONFIRMED
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1

--- a/tests/test_graphql_api/test_reservation/test_requires_handling.py
+++ b/tests/test_graphql_api/test_reservation/test_requires_handling.py
@@ -3,9 +3,12 @@ from __future__ import annotations
 import pytest
 from django.test import override_settings
 
-from tilavarauspalvelu.enums import ReservationNotification, ReservationStateChoice
+from tilavarauspalvelu.enums import AccessType, ReservationNotification, ReservationStateChoice
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError, PindoraNotFoundError
 
 from tests.factories import ReservationFactory, UserFactory
+from tests.helpers import patch_method
 
 from .helpers import REQUIRE_HANDLING_MUTATION, get_require_handling_data
 
@@ -22,6 +25,7 @@ pytestmark = [
         ReservationStateChoice.DENIED,
     ],
 )
+@patch_method(PindoraClient.deactivate_reservation_access_code)
 def test_reservation__requires_handling__allowed_states(graphql, outbox, state):
     reservation = ReservationFactory.create_for_requires_handling(state=state)
 
@@ -42,6 +46,8 @@ def test_reservation__requires_handling__allowed_states(graphql, outbox, state):
 
     assert len(outbox) == 1
     assert outbox[0].subject == "Your booking is waiting for processing"
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 0
 
 
 @pytest.mark.parametrize(
@@ -71,3 +77,58 @@ def test_reservation__requires_handling__disallowed_states(graphql, state):
 
     reservation.refresh_from_db()
     assert reservation.state == state
+
+
+@patch_method(PindoraClient.deactivate_reservation_access_code)
+def test_reservation__requires_handling__pindora_api__call_succeeds(graphql):
+    reservation = ReservationFactory.create_for_requires_handling(
+        state=ReservationStateChoice.CONFIRMED,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    input_data = get_require_handling_data(reservation)
+    response = graphql(REQUIRE_HANDLING_MUTATION, input_data=input_data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.REQUIRES_HANDLING
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.deactivate_reservation_access_code, side_effect=PindoraAPIError("Pindora API error"))
+def test_reservation__requires_handling__pindora_api__call_fails(graphql):
+    reservation = ReservationFactory.create_for_requires_handling(
+        state=ReservationStateChoice.CONFIRMED,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    input_data = get_require_handling_data(reservation)
+    response = graphql(REQUIRE_HANDLING_MUTATION, input_data=input_data)
+
+    assert response.error_message() == "Pindora API error"
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.deactivate_reservation_access_code, side_effect=PindoraNotFoundError("Error"))
+def test_reservation__requires_handling__pindora_api__call_fails__404(graphql):
+    reservation = ReservationFactory.create_for_requires_handling(
+        state=ReservationStateChoice.CONFIRMED,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    input_data = get_require_handling_data(reservation)
+    response = graphql(REQUIRE_HANDLING_MUTATION, input_data=input_data)
+
+    # Request is still successful if Pindora fails with 404
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.state == ReservationStateChoice.REQUIRES_HANDLING
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 1

--- a/tests/test_graphql_api/test_reservation/test_staff_modify.py
+++ b/tests/test_graphql_api/test_reservation/test_staff_modify.py
@@ -4,10 +4,13 @@ import datetime
 
 import pytest
 
-from tilavarauspalvelu.enums import ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.enums import AccessType, ReservationStateChoice, ReservationTypeChoice
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError, PindoraNotFoundError
 from utils.date_utils import next_hour
 
 from tests.factories import ReservationFactory
+from tests.helpers import patch_method
 
 from .helpers import UPDATE_STAFF_MUTATION, get_staff_modify_data
 
@@ -27,6 +30,31 @@ def test_reservation__staff_modify(graphql):
 
     reservation.refresh_from_db()
     assert reservation.name == "foo"
+
+
+def test_reservation__staff_modify__wrong_state(graphql):
+    reservation = ReservationFactory.create_for_staff_update(state=ReservationStateChoice.CANCELLED)
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    assert response.error_message() == "Mutation was unsuccessful."
+    assert response.field_error_messages() == ["Reservation cannot be edited by staff members based on its state"]
+
+
+def test_reservation__staff_modify__end_date_passed(graphql):
+    end = next_hour(plus_hours=-1, plus_days=-1)
+    begin = end - datetime.timedelta(hours=1)
+
+    reservation = ReservationFactory.create_for_staff_update(begin=begin, end=end)
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    assert response.error_message() == "Mutation was unsuccessful."
+    assert response.field_error_messages() == ["Reservation cannot be changed anymore."]
 
 
 def test_reservation__staff_modify__normal_reservation_to_staff(graphql):
@@ -101,26 +129,107 @@ def test_reservation__staff_modify__blocked_reservation_to_normal(graphql):
     ]
 
 
-def test_reservation__staff_modify__wrong_state(graphql):
-    reservation = ReservationFactory.create_for_staff_update(state=ReservationStateChoice.CANCELLED)
+@patch_method(PindoraClient.activate_reservation_access_code)
+def test_reservation__staff_modify__blocked_reservation_to_staff(graphql):
+    reservation = ReservationFactory.create_for_staff_update(type=ReservationTypeChoice.BLOCKED)
 
     graphql.login_with_superuser()
-    data = get_staff_modify_data(reservation)
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.STAFF)
     response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
 
-    assert response.error_message() == "Mutation was unsuccessful."
-    assert response.field_error_messages() == ["Reservation cannot be edited by staff members based on its state"]
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.type == ReservationTypeChoice.STAFF
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 0
 
 
-def test_reservation__staff_modify__end_date_passed(graphql):
-    end = next_hour(plus_hours=-1, plus_days=-1)
-    begin = end - datetime.timedelta(hours=1)
-
-    reservation = ReservationFactory.create_for_staff_update(begin=begin, end=end)
+@patch_method(PindoraClient.activate_reservation_access_code)
+def test_reservation__staff_modify__blocked_reservation_to_staff__pindora_api__call_succeeds(graphql):
+    reservation = ReservationFactory.create_for_staff_update(
+        type=ReservationTypeChoice.BLOCKED,
+        access_type=AccessType.ACCESS_CODE,
+    )
 
     graphql.login_with_superuser()
-    data = get_staff_modify_data(reservation)
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.STAFF)
     response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
 
-    assert response.error_message() == "Mutation was unsuccessful."
-    assert response.field_error_messages() == ["Reservation cannot be changed anymore."]
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.type == ReservationTypeChoice.STAFF
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.activate_reservation_access_code, side_effect=PindoraAPIError("Pindora API error"))
+def test_reservation__staff_modify__blocked_reservation_to_staff__pindora_api__call_fails(graphql):
+    reservation = ReservationFactory.create_for_staff_update(
+        type=ReservationTypeChoice.BLOCKED,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.STAFF)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    assert response.error_message() == "Pindora API error"
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.activate_reservation_access_code, side_effect=PindoraNotFoundError("Error"))
+def test_reservation__staff_modify__blocked_reservation_to_staff__pindora_api__call_fails__404(graphql):
+    reservation = ReservationFactory.create_for_staff_update(
+        type=ReservationTypeChoice.BLOCKED,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.STAFF)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    # Request is still successful if Pindora fails with 404
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.type == ReservationTypeChoice.STAFF
+
+    assert PindoraClient.activate_reservation_access_code.call_count == 1
+
+
+@patch_method(PindoraClient.deactivate_reservation_access_code)
+def test_reservation__staff_modify__staff_reservation_to_blocked(graphql):
+    reservation = ReservationFactory.create_for_staff_update(type=ReservationTypeChoice.STAFF)
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.BLOCKED)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.type == ReservationTypeChoice.BLOCKED
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 0
+
+
+@patch_method(PindoraClient.deactivate_reservation_access_code)
+def test_reservation__staff_modify__staff_reservation_to_blocked__pindora_api__call_succeeds(graphql):
+    reservation = ReservationFactory.create_for_staff_update(
+        type=ReservationTypeChoice.STAFF,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_staff_modify_data(reservation, type=ReservationTypeChoice.BLOCKED)
+    response = graphql(UPDATE_STAFF_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    reservation.refresh_from_db()
+    assert reservation.type == ReservationTypeChoice.BLOCKED
+
+    assert PindoraClient.deactivate_reservation_access_code.call_count == 1

--- a/tilavarauspalvelu/api/graphql/types/reservation/serializers/approve_serializers.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation/serializers/approve_serializers.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+from contextlib import suppress
 from typing import TYPE_CHECKING
 
 from graphene_django_extensions import NestingModelSerializer
 from graphene_django_extensions.fields import EnumFriendlyChoiceField
 from rest_framework.fields import IntegerField
 
-from tilavarauspalvelu.enums import ReservationStateChoice
+from tilavarauspalvelu.enums import AccessType, ReservationStateChoice
 from tilavarauspalvelu.integrations.email.main import EmailService
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
 from tilavarauspalvelu.models import Reservation
 from utils.date_utils import local_datetime
 
@@ -55,6 +57,14 @@ class ReservationApproveSerializer(NestingModelSerializer):
 
     def update(self, instance: Reservation, validated_data: ReservationApproveData) -> Reservation:
         instance = super().update(instance=instance, validated_data=validated_data)
+
+        if self.instance.access_type == AccessType.ACCESS_CODE:
+            # Allow activation in Pindora to fail, will be handled by a background task.
+            with suppress(Exception):
+                PindoraClient.activate_reservation_access_code(reservation=instance)
+                instance.access_code_is_active = True
+                instance.save(update_fields=["access_code_is_active"])
+
         EmailService.send_reservation_approved_email(reservation=instance)
         EmailService.send_staff_notification_reservation_made_email(reservation=instance)
         return instance

--- a/tilavarauspalvelu/typing.py
+++ b/tilavarauspalvelu/typing.py
@@ -300,6 +300,7 @@ class StaffCreateReservationData(TypedDict):
     user: User
     reservee_used_ad_login: bool
     access_type: NotRequired[AccessType]
+    access_code_is_active: NotRequired[bool]
 
 
 class StaffReservationData(StaffCreateReservationData):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Activate / Deactivate reservation access code in reservation API when necessary.
    - Activate when a reservation is confirmed and doesn't require payment
    - Activate when a reservation has been paid and doesn't require handling
    - Activate when a reservation in approved in handling
    - Deactivate if staff moves a reservation back to handling
    - Activate if staff changes reservation type from blocked
    - Deactivate if staff changes reservation type to blocked

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3774](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3774)


[TILA-3774]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3774?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ