### PR TITLE
Update access code in Pindora on reservation reschedule

### DIFF
--- a/tests/test_graphql_api/test_reservation/test_adjust_time.py
+++ b/tests/test_graphql_api/test_reservation/test_adjust_time.py
@@ -7,8 +7,9 @@ import freezegun
 import pytest
 from django.test import override_settings
 
-from tilavarauspalvelu.enums import ReservationStartInterval, ReservationStateChoice
+from tilavarauspalvelu.enums import AccessType, ReservationStartInterval, ReservationStateChoice
 from tilavarauspalvelu.integrations.email.main import EmailService
+from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
 from tilavarauspalvelu.models import Reservation, ReservationUnitHierarchy
 from utils.date_utils import DEFAULT_TIMEZONE, local_date, local_datetime
 
@@ -501,3 +502,107 @@ def test_reservation__adjust_time__update_reservation_buffer_on_adjust(graphql):
     # New reservation unit buffers are applied automatically on adjust.
     assert reservation.buffer_time_before == datetime.timedelta(hours=2)
     assert reservation.buffer_time_after == datetime.timedelta(hours=2)
+
+
+@patch_method(PindoraClient.reschedule_reservation)
+@patch_method(PindoraClient.deactivate_reservation_access_code)
+def test_reservation__adjust_time__same_access_type(graphql):
+    reservation = ReservationFactory.create_for_time_adjustment(
+        access_type=AccessType.ACCESS_CODE,
+        reservation_units__access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_adjust_data(reservation)
+    response = graphql(ADJUST_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    assert PindoraClient.reschedule_reservation.called is True
+    assert PindoraClient.deactivate_reservation_access_code.called is False
+
+
+@patch_method(PindoraClient.reschedule_reservation)
+@patch_method(PindoraClient.deactivate_reservation_access_code)
+def test_reservation__adjust_time__same_access_type__requires_handling(graphql):
+    reservation = ReservationFactory.create_for_time_adjustment(
+        access_type=AccessType.ACCESS_CODE,
+        reservation_units__access_type=AccessType.ACCESS_CODE,
+        reservation_units__require_reservation_handling=True,
+    )
+
+    graphql.login_with_superuser()
+    data = get_adjust_data(reservation)
+    response = graphql(ADJUST_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    assert PindoraClient.reschedule_reservation.called is True
+    assert PindoraClient.deactivate_reservation_access_code.called is True
+
+
+@patch_method(
+    PindoraClient.create_reservation,
+    return_value={"access_code_generated_at": datetime.datetime(2025, 1, 1, tzinfo=DEFAULT_TIMEZONE)},
+)
+def test_reservation__adjust_time__change_to_access_code(graphql):
+    reservation = ReservationFactory.create_for_time_adjustment(
+        access_type=AccessType.UNRESTRICTED,
+        reservation_units__access_type=AccessType.ACCESS_CODE,
+    )
+
+    graphql.login_with_superuser()
+    data = get_adjust_data(reservation)
+    response = graphql(ADJUST_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    assert PindoraClient.create_reservation.called is True
+    assert PindoraClient.create_reservation.call_args.kwargs["is_active"] is True
+
+    reservation.refresh_from_db()
+    assert reservation.access_code_generated_at == datetime.datetime(2025, 1, 1, tzinfo=DEFAULT_TIMEZONE)
+
+
+@patch_method(
+    PindoraClient.create_reservation,
+    return_value={"access_code_generated_at": datetime.datetime(2025, 1, 1, tzinfo=DEFAULT_TIMEZONE)},
+)
+def test_reservation__adjust_time__change_to_access_code__requires_handling(graphql):
+    reservation = ReservationFactory.create_for_time_adjustment(
+        access_type=AccessType.UNRESTRICTED,
+        reservation_units__access_type=AccessType.ACCESS_CODE,
+        reservation_units__require_reservation_handling=True,
+    )
+
+    graphql.login_with_superuser()
+    data = get_adjust_data(reservation)
+    response = graphql(ADJUST_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    assert PindoraClient.create_reservation.called is True
+    assert PindoraClient.create_reservation.call_args.kwargs["is_active"] is False
+
+    reservation.refresh_from_db()
+    assert reservation.access_code_generated_at == datetime.datetime(2025, 1, 1, tzinfo=DEFAULT_TIMEZONE)
+
+
+@patch_method(PindoraClient.delete_reservation)
+def test_reservation__adjust_time__change_from_access_code(graphql):
+    reservation = ReservationFactory.create_for_time_adjustment(
+        access_type=AccessType.ACCESS_CODE,
+        reservation_units__access_type=AccessType.UNRESTRICTED,
+        access_code_generated_at=datetime.datetime(2025, 1, 1, tzinfo=DEFAULT_TIMEZONE),
+    )
+
+    graphql.login_with_superuser()
+    data = get_adjust_data(reservation)
+    response = graphql(ADJUST_MUTATION, input_data=data)
+
+    assert response.has_errors is False, response.errors
+
+    assert PindoraClient.delete_reservation.called is True
+
+    reservation.refresh_from_db()
+    assert reservation.access_code_generated_at is None

--- a/tilavarauspalvelu/typing.py
+++ b/tilavarauspalvelu/typing.py
@@ -223,6 +223,7 @@ class ReservationAdjustTimeData(TypedDict):
     state: NotRequired[ReservationStateChoice]
     buffer_time_before: NotRequired[datetime.timedelta]
     buffer_time_after: NotRequired[datetime.timedelta]
+    access_type: NotRequired[AccessType]
 
 
 class ReservationApproveData(TypedDict):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Notify Pindora about the time of the reservation if required
  - If access type remains 'ACCESS_CODE', reschedule the reservation
  - If access type no longer 'ACCESS_CODE', delete the reservation
  - If access type now 'ACCESS_CODE', create the access code

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3782](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3782)


[TILA-3782]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ