### PR TITLE
Create an access code when approving a reservation without one

### DIFF
--- a/tilavarauspalvelu/api/graphql/types/reservation/serializers/requires_handling_serializers.py
+++ b/tilavarauspalvelu/api/graphql/types/reservation/serializers/requires_handling_serializers.py
@@ -50,7 +50,8 @@ class ReservationRequiresHandlingSerializer(NestingModelSerializer):
         return data
 
     def update(self, instance: Reservation, validated_data: dict[str, Any]) -> Reservation:
-        if self.instance.access_type == AccessType.ACCESS_CODE:
+        # Denied reservations shouldn't have an access code. It will be regenerated if the reservation is approved.
+        if self.instance.access_type == AccessType.ACCESS_CODE and instance.access_code_generated_at is not None:
             # Allow reservation modification to succeed if reservation doesn't exist in Pindora.
             with suppress(PindoraNotFoundError):
                 PindoraClient.deactivate_reservation_access_code(reservation=instance)

--- a/tilavarauspalvelu/typing.py
+++ b/tilavarauspalvelu/typing.py
@@ -234,6 +234,8 @@ class ReservationApproveData(TypedDict):
 
     state: NotRequired[ReservationStateChoice]
     handled_at: NotRequired[datetime.datetime]
+    access_code_generated_at: NotRequired[datetime.datetime | None]
+    access_code_is_active: NotRequired[bool]
 
 
 class ReservationCancellationData(TypedDict):


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Create an access code when approving a reservation without one. This can happen in a denied reservation returns to handling and is then approved.
- Modify return to handling mutation to not make the deactivate call if access code was removed.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3796](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3796)


[TILA-3796]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ