### PR TITLE
Add cancelled status label to recurring reservation lists

### DIFF
--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 import { format } from "date-fns";
 import {
-  ReservationStateChoice,
   type ReservationQuery,
+  ReservationStateChoice,
   useRecurringReservationQuery,
   UserPermissionChoice,
 } from "@gql/gql-types";
@@ -41,7 +41,7 @@ export function RecurringReservationsView({
   onChange,
   onReservationUpdated,
   reservationToCopy,
-}: Props) {
+}: Readonly<Props>) {
   const { t } = useTranslation();
   const { setModalContent } = useModal();
 
@@ -166,7 +166,8 @@ export function RecurringReservationsView({
       date: startDate,
       startTime: format(startDate, "H:mm"),
       endTime: format(endDate, "H:mm"),
-      isRemoved: x.state === "DENIED",
+      isRemoved: x.state === ReservationStateChoice.Denied,
+      isCancelled: x.state === ReservationStateChoice.Cancelled,
       buttons,
     };
   });

--- a/apps/admin-ui/src/component/ReservationListButton.tsx
+++ b/apps/admin-ui/src/component/ReservationListButton.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Button,
+  ButtonPresetTheme,
   ButtonSize,
   ButtonVariant,
   IconArrowUndo,
@@ -17,16 +18,17 @@ export function ReservationListButton({
   type,
   callback,
   t,
-}: {
+}: Readonly<{
   type: "remove" | "deny" | "restore" | "change" | "show";
   callback: () => void;
   // Pass the TFunc because the amount of buttons change and hooks break
   t: TFunction;
-}) {
+}>) {
   const btnCommon = {
     variant: ButtonVariant.Supplementary,
     onClick: callback,
     size: ButtonSize.Small,
+    theme: ButtonPresetTheme.Black,
   } as const;
 
   switch (type) {

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -426,7 +426,7 @@ const translations: ITranslations = {
         // TODO these should be in the common translations (enum)
         RejectionReadinessChoice: {
           INTERVAL_NOT_ALLOWED: ["Aloitusaika ei sallittu"],
-          OVERLAPPING_RESERVATIONS: ["Päivämäärä ei saatavilla"],
+          OVERLAPPING_RESERVATIONS: ["Ei saatavilla"],
           RESERVATION_UNIT_CLOSED: ["Suljettu"],
         },
         failureMessages: {

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -406,8 +406,9 @@ const translations: ITranslations = {
       pageTitle: ["Tee toistuva varaus"],
       addNewReservation: ["Lisää uusi varaus"],
       Confirmation: {
-        removed: ["Poistettu"],
+        removed: ["Hylätty"],
         overlapping: ["Ei saatavilla"],
+        cancelled: ["Peruttu"],
         title: ["Toistuva varaus tehty"],
         allFailedTitle: ["Toistuvaa varausta ei voitu tehdä"],
         failedSubtitle: ["Epäonnistuneet varaukset"],

--- a/apps/admin-ui/src/spa/reservations/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/index.tsx
@@ -54,6 +54,12 @@ const Accordion = styled(AccordionBase).attrs({
   > div > div:not([class^="LoadingSpinner-module_loadingSpinner"]) {
     width: 100%;
   }
+  && {
+    --icon-size: 24px;
+    [class^="Accordion-module_accordionHeader__"] {
+      --icon-size: 32px;
+    }
+  }
 `;
 
 function DataWrapper({

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -225,6 +225,7 @@
       "reservationUnit": "Space",
       "rejected": "Rejected",
       "modified": "Modified",
+      "cancelled": "Cancelled",
       "showAllReservations": "Show all bookings",
       "cancelApplication": "Cancel all bookings",
       "reservationUnitsTitle": "Location",

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -221,6 +221,7 @@
       "reservationUnit": "Tila",
       "rejected": "Hylätty",
       "modified": "Muokattu",
+      "cancelled": "Peruttu",
       "showAllReservations": "Näytä kaikki varaukset",
       "cancelApplication": "Peru kaikki varaukset",
       "reservationUnitsTitle": "Toimipiste",

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -219,6 +219,7 @@
       "reservationUnit": "Utrymme",
       "rejected": "Avslagen",
       "modified": "Ändrad",
+      "cancelled": "Avbokad",
       "showAllReservations": "Visa alla bokningar",
       "cancelApplication": "Avboka alla bokningar",
       "reservationUnitsTitle": "Verksamhetsställe",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Recreating: https://github.com/City-of-Helsinki/tilavarauspalvelu-ui/pull/1646
- Adds a "Cancelled" StatusLabelto recurring reservation listings, when the user has cancelled a reservation (vs e.g. being denied.
- Changes the overlapping reservations StatusLabel text to simply "Ei saatavilla"

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- As a user with a recurring reservation series, cancel a reservation -> it should have a StatusLabel "Cancelled"
- As admin go see the same recurring reservation, and open the "Toistokerrat" accordion. It should also have a StatusLabel instead of the edit-, show in calendar- and deny-buttons

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3758](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3758)


[TILA-3758]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ