### PR TITLE
Add accessType to search pages

### DIFF
--- a/apps/ui/components/search/ReservationUnitCard.tsx
+++ b/apps/ui/components/search/ReservationUnitCard.tsx
@@ -7,6 +7,7 @@ import {
   IconSize,
   ButtonSize,
   ButtonVariant,
+  IconLock,
 } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
@@ -32,7 +33,7 @@ export function ReservationUnitCard({
   selectReservationUnit,
   containsReservationUnit,
   removeReservationUnit,
-}: CardProps): JSX.Element {
+}: Readonly<CardProps>): JSX.Element {
   const { t } = useTranslation();
 
   const name = getReservationUnitName(reservationUnit);
@@ -79,6 +80,20 @@ export function ReservationUnitCard({
       }),
     });
   }
+  if (reservationUnit.currentAccessType) {
+    infos.push({
+      icon: (
+        <IconLock
+          aria-hidden="false"
+          aria-label={t("reservationUnit:accessType")}
+          size={IconSize.Small}
+        />
+      ),
+      value: t(
+        `reservationUnit:accessTypes.${reservationUnit.currentAccessType}`
+      ),
+    });
+  }
 
   const buttons = [];
   if (containsReservationUnit(reservationUnit)) {
@@ -86,7 +101,7 @@ export function ReservationUnitCard({
       <Button
         size={ButtonSize.Small}
         variant={ButtonVariant.Primary}
-        iconEnd={<IconCheck aria-hidden="true" />}
+        iconEnd={<IconCheck />}
         onClick={() => removeReservationUnit(reservationUnit)}
         data-testid="reservation-unit-card__button--select"
         key={t("common:removeReservationUnit")}
@@ -99,7 +114,7 @@ export function ReservationUnitCard({
       <Button
         size={ButtonSize.Small}
         variant={ButtonVariant.Secondary}
-        iconEnd={<IconPlus aria-hidden="true" />}
+        iconEnd={<IconPlus />}
         onClick={() => selectReservationUnit(reservationUnit)}
         data-testid="reservation-unit-card__button--select"
         key={t("common:selectReservationUnit")}
@@ -116,7 +131,7 @@ export function ReservationUnitCard({
       data-testid="reservation-unit-card__button--link"
       key="show"
     >
-      <IconLinkExternal aria-hidden="true" />
+      <IconLinkExternal />
       {t("common:show")}
     </ButtonLikeLink>
   );

--- a/apps/ui/components/search/SeasonalSearchForm.tsx
+++ b/apps/ui/components/search/SeasonalSearchForm.tsx
@@ -12,14 +12,11 @@ import { useSearchModify } from "@/hooks/useSearchValues";
 import { FilterTagList } from "./FilterTagList";
 import { ControlledSelect } from "common/src/components/form/ControlledSelect";
 import { BottomContainer, Filters, StyledSubmitButton } from "./styled";
-import {
-  mapQueryParamToNumber,
-  mapQueryParamToNumberArray,
-  mapSingleParamToFormValue,
-} from "@/modules/search";
+import { mapParamToNumber } from "@/modules/search";
 import SingleLabelInputGroup from "@/components/common/SingleLabelInputGroup";
-import { type URLSearchParams } from "node:url";
-import { useSearchParams } from "next/navigation";
+import { type ReadonlyURLSearchParams, useSearchParams } from "next/navigation";
+import { AccessType } from "@gql/gql-types";
+import { toNumber } from "common/src/helpers";
 
 const filterOrder = [
   "applicationRound",
@@ -29,6 +26,7 @@ const filterOrder = [
   "reservationUnitTypes",
   "unit",
   "purposes",
+  "accessType",
 ] as const;
 
 type FormValues = {
@@ -38,19 +36,22 @@ type FormValues = {
   reservationUnitTypes: number[];
   purposes: number[];
   textSearch: string;
+  accessType: string[];
 };
 
 // TODO combine as much as possible with the one in single-search (move them to a common place)
-function mapQueryToForm(query: URLSearchParams): FormValues {
+function mapQueryToForm(params: ReadonlyURLSearchParams): FormValues {
   return {
-    purposes: mapQueryParamToNumberArray(query.getAll("purposes")),
-    unit: mapQueryParamToNumberArray(query.getAll("unit")),
-    reservationUnitTypes: mapQueryParamToNumberArray(
-      query.getAll("reservationUnitTypes")
+    purposes: mapParamToNumber(params.getAll("purposes"), 1),
+    unit: mapParamToNumber(params.getAll("unit"), 1),
+    reservationUnitTypes: mapParamToNumber(
+      params.getAll("reservationUnitTypes"),
+      1
     ),
-    minPersons: mapQueryParamToNumber(query.getAll("minPersons")),
-    maxPersons: mapQueryParamToNumber(query.getAll("maxPersons")),
-    textSearch: mapSingleParamToFormValue(query.getAll("textSearch")) ?? "",
+    minPersons: toNumber(params.get("minPersons")),
+    maxPersons: toNumber(params.get("maxPersons")),
+    textSearch: params.get("textSearch") ?? "",
+    accessType: params.getAll("accessType"),
   };
 }
 
@@ -60,12 +61,12 @@ export function SeasonalSearchForm({
   purposeOptions,
   unitOptions,
   isLoading,
-}: {
+}: Readonly<{
   reservationUnitTypeOptions: OptionType[];
   purposeOptions: OptionType[];
   unitOptions: OptionType[];
   isLoading: boolean;
-}): JSX.Element | null {
+}>): JSX.Element | null {
   const { t } = useTranslation();
 
   const { handleSearch } = useSearchModify();
@@ -79,6 +80,11 @@ export function SeasonalSearchForm({
     handleSearch(criteria, true);
   };
 
+  const accessTypeOptions = Object.values(AccessType).map((value) => ({
+    value,
+    label: t(`reservationUnit:accessTypes.${value}`),
+  }));
+
   const translateTag = (key: string, value: string): string | undefined => {
     switch (key) {
       case "unit":
@@ -88,6 +94,8 @@ export function SeasonalSearchForm({
           ?.label;
       case "purposes":
         return purposeOptions.find((n) => String(n.value) === value)?.label;
+      case "accessType":
+        return accessTypeOptions.find((n) => String(n.value) === value)?.label;
       default:
         return "";
     }
@@ -97,6 +105,7 @@ export function SeasonalSearchForm({
     "unit",
     "reservationUnitTypes",
     "purposes",
+    "accessType",
   ] as const;
   const hideList = ["id", "order", "sort", "ref"] as const;
 
@@ -158,6 +167,14 @@ export function SeasonalSearchForm({
           control={control}
           options={purposeOptions}
           label={t("searchForm:purposesFilter")}
+        />
+        <ControlledSelect
+          multiselect
+          clearable
+          name="accessType"
+          control={control}
+          options={accessTypeOptions}
+          label={t("searchForm:accessTypeFilter")}
         />
       </Filters>
       <BottomContainer>

--- a/apps/ui/components/search/SingleSearchForm.tsx
+++ b/apps/ui/components/search/SingleSearchForm.tsx
@@ -14,10 +14,8 @@ import SingleLabelInputGroup from "@/components/common/SingleLabelInputGroup";
 import { useSearchModify } from "@/hooks/useSearchValues";
 import { ControlledSelect } from "common/src/components/form/ControlledSelect";
 import {
-  mapQueryParamToNumber,
-  mapQueryParamToNumberArray,
+  mapParamToNumber,
   mapSingleBooleanParamToFormValue,
-  mapSingleParamToFormValue,
 } from "@/modules/search";
 import {
   BottomContainer,
@@ -26,6 +24,8 @@ import {
   StyledSubmitButton,
 } from "./styled";
 import { useSearchParams, type ReadonlyURLSearchParams } from "next/navigation";
+import { AccessType } from "@gql/gql-types";
+import { toNumber } from "common/src/helpers";
 
 const StyledCheckBox = styled(Checkbox)`
   margin: 0 !important;
@@ -39,6 +39,7 @@ type FormValues = {
   unit: number[];
   equipments: number[];
   reservationUnitTypes: number[];
+  accessType: string[];
   timeBegin: string | null;
   timeEnd: string | null;
   startDate: string | null;
@@ -51,27 +52,29 @@ type FormValues = {
 };
 
 function mapQueryToForm(params: ReadonlyURLSearchParams): FormValues {
-  const dur = mapQueryParamToNumber(params.getAll("duration"));
+  const dur = toNumber(params.get("duration"));
   const duration = dur != null && dur > 0 ? dur : null;
   const showOnlyReservable =
     mapSingleBooleanParamToFormValue(params.getAll("showOnlyReservable")) ??
     true;
   return {
-    purposes: mapQueryParamToNumberArray(params.getAll("purposes")),
-    unit: mapQueryParamToNumberArray(params.getAll("unit")),
-    equipments: mapQueryParamToNumberArray(params.getAll("equipments")),
-    reservationUnitTypes: mapQueryParamToNumberArray(
-      params.getAll("reservationUnitTypes")
+    purposes: mapParamToNumber(params.getAll("purposes"), 1),
+    unit: mapParamToNumber(params.getAll("unit"), 1),
+    equipments: mapParamToNumber(params.getAll("equipments"), 1),
+    reservationUnitTypes: mapParamToNumber(
+      params.getAll("reservationUnitTypes"),
+      1
     ),
-    timeBegin: mapSingleParamToFormValue(params.getAll("timeBegin")),
-    timeEnd: mapSingleParamToFormValue(params.getAll("timeEnd")),
-    startDate: mapSingleParamToFormValue(params.getAll("startDate")),
-    endDate: mapSingleParamToFormValue(params.getAll("endDate")),
+    accessType: params.getAll("accessType"),
+    timeBegin: params.get("timeBegin"),
+    timeEnd: params.get("timeEnd"),
+    startDate: params.get("startDate"),
+    endDate: params.get("endDate"),
     duration,
-    minPersons: mapQueryParamToNumber(params.getAll("minPersons")),
-    maxPersons: mapQueryParamToNumber(params.getAll("maxPersons")),
+    minPersons: toNumber(params.get("minPersons")),
+    maxPersons: toNumber(params.get("maxPersons")),
     showOnlyReservable,
-    textSearch: mapSingleParamToFormValue(params.getAll("textSearch")) ?? "",
+    textSearch: params.get("textSearch") ?? "",
   };
 }
 
@@ -89,12 +92,14 @@ const filterOrder = [
   "unit",
   "purposes",
   "equipments",
+  "accessType",
 ] as const;
 const multiSelectFilters = [
   "unit",
   "reservationUnitTypes",
   "purposes",
   "equipments",
+  "accessType",
 ] as const;
 // we don't want to show "showOnlyReservable" as a FilterTag, as it has its own checkbox in the form
 const hideTagList = ["showOnlyReservable", "order", "sort", "ref"];
@@ -106,13 +111,13 @@ export function SingleSearchForm({
   unitOptions,
   equipmentsOptions,
   isLoading,
-}: {
+}: Readonly<{
   reservationUnitTypeOptions: Array<{ value: number; label: string }>;
   purposeOptions: Array<{ value: number; label: string }>;
   unitOptions: Array<{ value: number; label: string }>;
   equipmentsOptions: Array<{ value: number; label: string }>;
   isLoading: boolean;
-}): JSX.Element | null {
+}>): JSX.Element | null {
   const { handleSearch } = useSearchModify();
   const { t } = useTranslation();
   const searchValues = useSearchParams();
@@ -121,6 +126,10 @@ export function SingleSearchForm({
   const form = useForm<FormValues>({
     values: formValues,
   });
+  const accessTypeOptions = Object.values(AccessType).map((value) => ({
+    value,
+    label: t(`reservationUnit:accessTypes.${value}`),
+  }));
 
   const { handleSubmit, setValue, getValues, control, register } = form;
   const unitTypeOptions = reservationUnitTypeOptions;
@@ -142,6 +151,8 @@ export function SingleSearchForm({
         return equipmentsOptions.find((n) => compFn(n, value))?.label;
       case "duration":
         return durationOptions.find((n) => compFn(n, value))?.label;
+      case "accessType":
+        return accessTypeOptions.find((n) => compFn(n, value))?.label;
       case "startDate":
       case "endDate":
       case "timeBegin":
@@ -287,6 +298,14 @@ export function SingleSearchForm({
                 handleSubmit(onSearch)();
               }
             }}
+          />
+          <ControlledSelect
+            multiselect
+            clearable
+            name="accessType"
+            control={control}
+            options={accessTypeOptions}
+            label={t("searchForm:accessTypeFilter")}
           />
         </OptionalFilters>
         <Controller

--- a/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
+++ b/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
@@ -1,4 +1,10 @@
-import { IconArrowRight, IconEuroSign, IconGroup, IconSize } from "hds-react";
+import {
+  IconArrowRight,
+  IconEuroSign,
+  IconGroup,
+  IconLock,
+  IconSize,
+} from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import NextImage from "next/image";
@@ -32,9 +38,9 @@ interface PropsT {
 
 function StatusTag({
   data,
-}: {
+}: Readonly<{
   data: { closed: boolean; availableAt: string };
-}): JSX.Element {
+}>): JSX.Element {
   const { t } = useTranslation();
   const { closed, availableAt } = data;
 
@@ -142,7 +148,12 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
   }
   if (unitPrice) {
     infos.push({
-      icon: <IconEuroSign aria-label={t("prices:reservationUnitPriceLabel")} />,
+      icon: (
+        <IconEuroSign
+          aria-hidden="false"
+          aria-label={t("prices:reservationUnitPriceLabel")}
+        />
+      ),
       value: unitPrice,
     });
   }
@@ -150,6 +161,7 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
     infos.push({
       icon: (
         <IconGroup
+          aria-hidden="false"
           aria-label={t("reservationUnitCard:maxPersons", {
             maxPersons: reservationUnit.maxPersons,
           })}
@@ -159,6 +171,20 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
       value: t("reservationUnitCard:maxPersons", {
         count: reservationUnit.maxPersons,
       }),
+    });
+  }
+  if (reservationUnit.currentAccessType) {
+    infos.push({
+      icon: (
+        <IconLock
+          aria-hidden="false"
+          aria-label={t("reservationUnit:accessType")}
+          size={IconSize.Small}
+        />
+      ),
+      value: t(
+        `reservationUnit:accessTypes.${reservationUnit.currentAccessType}`
+      ),
     });
   }
 

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6824,6 +6824,11 @@ export type SearchReservationUnitsQueryVariables = Exact<{
     | Array<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
   >;
+  accessType?: InputMaybe<
+    Array<InputMaybe<AccessType>> | InputMaybe<AccessType>
+  >;
+  accessTypeStartDate?: InputMaybe<Scalars["Date"]["input"]>;
+  accessTypeEndDate?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
@@ -10850,6 +10855,9 @@ export const SearchReservationUnitsDocument = gql`
     $reservationUnitType: [Int]
     $purposes: [Int]
     $equipments: [Int]
+    $accessType: [AccessType]
+    $accessTypeStartDate: Date
+    $accessTypeEndDate: Date
     $reservableDateStart: Date
     $reservableDateEnd: Date
     $reservableTimeStart: Time
@@ -10876,6 +10884,9 @@ export const SearchReservationUnitsDocument = gql`
       reservationUnitType: $reservationUnitType
       purposes: $purposes
       equipments: $equipments
+      accessType: $accessType
+      accessTypeStartDate: $accessTypeStartDate
+      accessTypeEndDate: $accessTypeEndDate
       reservableDateStart: $reservableDateStart
       reservableDateEnd: $reservableDateEnd
       reservableTimeStart: $reservableTimeStart
@@ -10935,6 +10946,9 @@ export const SearchReservationUnitsDocument = gql`
  *      reservationUnitType: // value for 'reservationUnitType'
  *      purposes: // value for 'purposes'
  *      equipments: // value for 'equipments'
+ *      accessType: // value for 'accessType'
+ *      accessTypeStartDate: // value for 'accessTypeStartDate'
+ *      accessTypeEndDate: // value for 'accessTypeEndDate'
  *      reservableDateStart: // value for 'reservableDateStart'
  *      reservableDateEnd: // value for 'reservableDateEnd'
  *      reservableTimeStart: // value for 'reservableTimeStart'

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6757,6 +6757,7 @@ export type ReservationUnitPageQuery = {
 
 export type ReservationUnitCardFieldsFragment = {
   maxPersons?: number | null;
+  currentAccessType?: AccessType | null;
   id: string;
   pk?: number | null;
   nameFi?: string | null;
@@ -6856,6 +6857,7 @@ export type SearchReservationUnitsQuery = {
         reservationEnds?: string | null;
         isClosed?: boolean | null;
         firstReservableDatetime?: string | null;
+        currentAccessType?: AccessType | null;
         maxPersons?: number | null;
         id: string;
         pk?: number | null;
@@ -8961,6 +8963,7 @@ export const ReservationUnitCardFieldsFragmentDoc = gql`
       ...Image
     }
     maxPersons
+    currentAccessType
   }
   ${ReservationUnitNameFieldsFragmentDoc}
   ${UnitNameFieldsI18NFragmentDoc}
@@ -10909,6 +10912,7 @@ export const SearchReservationUnitsDocument = gql`
           reservationEnds
           isClosed
           firstReservableDatetime
+          currentAccessType
           pricings {
             ...PricingFields
           }

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -190,6 +190,9 @@ export const SEARCH_RESERVATION_UNITS = gql`
     $reservationUnitType: [Int]
     $purposes: [Int]
     $equipments: [Int]
+    $accessType: [AccessType]
+    $accessTypeStartDate: Date
+    $accessTypeEndDate: Date
     $reservableDateStart: Date
     $reservableDateEnd: Date
     $reservableTimeStart: Time
@@ -216,6 +219,9 @@ export const SEARCH_RESERVATION_UNITS = gql`
       reservationUnitType: $reservationUnitType
       purposes: $purposes
       equipments: $equipments
+      accessType: $accessType
+      accessTypeStartDate: $accessTypeStartDate
+      accessTypeEndDate: $accessTypeEndDate
       reservableDateStart: $reservableDateStart
       reservableDateEnd: $reservableDateEnd
       reservableTimeStart: $reservableTimeStart

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -172,6 +172,7 @@ export const RESERVATION_UNIT_CARD_FRAGMENT = gql`
       ...Image
     }
     maxPersons
+    currentAccessType
   }
 `;
 
@@ -244,6 +245,7 @@ export const SEARCH_RESERVATION_UNITS = gql`
           reservationEnds
           isClosed
           firstReservableDatetime
+          currentAccessType
           pricings {
             ...PricingFields
           }

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -154,7 +154,10 @@ type ProcessVariablesParams =
       language: string;
       kind: ReservationKind.Season;
       applicationRound: number;
+      reservationPeriodBegin: string;
+      reservationPeriodEnd: string;
     };
+
 export function processVariables({
   values,
   language,
@@ -193,6 +196,14 @@ export function processVariables({
     ignoreMaybeArray(values.getAll("showOnlyReservable")) !== "false";
   const applicationRound =
     "applicationRound" in rest && isSeasonal ? rest.applicationRound : null;
+  const reservationPeriodBegin =
+    "reservationPeriodBegin" in rest && isSeasonal
+      ? rest.reservationPeriodBegin
+      : null;
+  const reservationPeriodEnd =
+    "reservationPeriodEnd" in rest && isSeasonal
+      ? rest.reservationPeriodEnd
+      : null;
   const timeEnd = ignoreMaybeArray(values.getAll("timeEnd"));
   const timeBegin = ignoreMaybeArray(values.getAll("timeBegin"));
   const accessType = values.getAll("accessType").map(transformAccessTypeSafe);
@@ -217,8 +228,10 @@ export function processVariables({
     reservationUnitType: reservationUnitTypes,
     equipments,
     accessType,
-    accessTypeStartDate: reservableDateStart,
-    accessTypeEndDate: reservableDateEnd,
+    accessTypeStartDate: isSeasonal
+      ? reservationPeriodBegin
+      : reservableDateStart,
+    accessTypeEndDate: isSeasonal ? reservationPeriodEnd : reservableDateEnd,
     ...(startDate != null
       ? {
           reservableDateStart,
@@ -260,15 +273,6 @@ export function processVariables({
   };
 }
 
-export function mapSingleParamToFormValue(
-  param: string | string[] | undefined
-): string | null {
-  if (param == null) return null;
-  if (param === "") return null;
-  if (Array.isArray(param)) return param.join(",");
-  return param;
-}
-
 // default to false if the param is present but not true, null if not present
 export function mapSingleBooleanParamToFormValue(
   param: string | string[] | undefined
@@ -284,39 +288,6 @@ export function mapSingleBooleanParamToFormValue(
   return param === "true";
 }
 
-export function mapQueryParamToStringArray(
-  param: string | string[] | undefined
-): string[] {
-  if (param == null) return [];
-  if (param === "") return [];
-  if (Array.isArray(param)) return param;
-  return [param];
-}
-
-export function mapQueryParamToNumber(
-  param: string | string[] | undefined
-): number | null {
-  if (param == null) return null;
-  if (param === "") return null;
-  if (Array.isArray(param)) {
-    return toNumber(param[0]);
-  }
-  return toNumber(param);
-}
-
-export function mapQueryParamToNumberArray(
-  param: string | string[] | undefined
-): number[] {
-  if (param == null) return [];
-  if (param === "") return [];
-  if (Array.isArray(param)) {
-    return param.map(Number).filter(Number.isInteger);
-  }
-  const v = Number(param);
-  if (Number.isNaN(v)) {
-    return [];
-  }
-  return [v];
 export function mapParamToNumber(param: string[], min?: number): number[] {
   const numbers = param.map(Number).filter(Number.isInteger);
   return min != null ? numbers.filter((n) => n >= min) : numbers;

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -1,26 +1,27 @@
 /// This file contains the search query for reservation units
 /// e.g. the common search pages (both seasonal and single)
 import {
-  type LocalizationLanguages,
+  filterNonNullable,
   getLocalizationLang,
-  toNumber,
   ignoreMaybeArray,
+  type LocalizationLanguages,
+  toNumber,
 } from "common/src/helpers";
 import {
+  AccessType,
+  EquipmentOrderingChoices,
+  OptionsDocument,
+  type OptionsQuery,
+  PurposeOrderingChoices,
   type QueryReservationUnitsArgs,
   ReservationKind,
   ReservationUnitOrderingChoices,
-  type OptionsQuery,
-  OptionsDocument,
-  EquipmentOrderingChoices,
-  UnitOrderingChoices,
   ReservationUnitTypeOrderingChoices,
-  PurposeOrderingChoices,
+  SearchFormParamsUnitDocument,
   SearchFormParamsUnitQuery,
   SearchFormParamsUnitQueryVariables,
-  SearchFormParamsUnitDocument,
+  UnitOrderingChoices,
 } from "@gql/gql-types";
-import { filterNonNullable } from "common/src/helpers";
 import {
   convertLanguageCode,
   getTranslationSafe,
@@ -74,6 +75,21 @@ function transformOrderByTypeRank(
   return desc
     ? ReservationUnitOrderingChoices.TypeRankDesc
     : ReservationUnitOrderingChoices.TypeRankAsc;
+}
+
+function transformAccessTypeSafe(t: string): AccessType | null {
+  switch (t) {
+    case AccessType.AccessCode:
+      return AccessType.AccessCode;
+    case AccessType.PhysicalKey:
+      return AccessType.PhysicalKey;
+    case AccessType.OpenedByStaff:
+      return AccessType.OpenedByStaff;
+    case AccessType.Unrestricted:
+      return AccessType.Unrestricted;
+    default:
+      return null;
+  }
 }
 
 function transformOrderBy(
@@ -179,6 +195,7 @@ export function processVariables({
     "applicationRound" in rest && isSeasonal ? rest.applicationRound : null;
   const timeEnd = ignoreMaybeArray(values.getAll("timeEnd"));
   const timeBegin = ignoreMaybeArray(values.getAll("timeBegin"));
+  const accessType = values.getAll("accessType").map(transformAccessTypeSafe);
   return {
     ...(textSearch !== ""
       ? {
@@ -199,6 +216,9 @@ export function processVariables({
     unit,
     reservationUnitType: reservationUnitTypes,
     equipments,
+    accessType,
+    accessTypeStartDate: reservableDateStart,
+    accessTypeEndDate: reservableDateEnd,
     ...(startDate != null
       ? {
           reservableDateStart,
@@ -264,6 +284,15 @@ export function mapSingleBooleanParamToFormValue(
   return param === "true";
 }
 
+export function mapQueryParamToStringArray(
+  param: string | string[] | undefined
+): string[] {
+  if (param == null) return [];
+  if (param === "") return [];
+  if (Array.isArray(param)) return param;
+  return [param];
+}
+
 export function mapQueryParamToNumber(
   param: string | string[] | undefined
 ): number | null {
@@ -288,6 +317,9 @@ export function mapQueryParamToNumberArray(
     return [];
   }
   return [v];
+export function mapParamToNumber(param: string[], min?: number): number[] {
+  const numbers = param.map(Number).filter(Number.isInteger);
+  return min != null ? numbers.filter((n) => n >= min) : numbers;
 }
 
 export async function getSearchOptions(

--- a/apps/ui/pages/recurring/[id]/index.tsx
+++ b/apps/ui/pages/recurring/[id]/index.tsx
@@ -12,7 +12,11 @@ import {
   type ApplicationRoundsUiQueryVariables,
   ApplicationRoundsUiDocument,
 } from "@gql/gql-types";
-import { filterNonNullable } from "common/src/helpers";
+import {
+  filterNonNullable,
+  ignoreMaybeArray,
+  toNumber,
+} from "common/src/helpers";
 import { SeasonalSearchForm } from "@/components/search/SeasonalSearchForm";
 import { createApolloClient } from "@/modules/apolloClient";
 import { ReservationUnitCard } from "@/components/search/ReservationUnitCard";
@@ -20,11 +24,7 @@ import { useReservationUnitList } from "@/hooks";
 import { ListWithPagination } from "@/components/common/ListWithPagination";
 import StartApplicationBar from "@/components/common/StartApplicationBar";
 import { getCommonServerSideProps } from "@/modules/serverUtils";
-import {
-  getSearchOptions,
-  mapQueryParamToNumber,
-  processVariables,
-} from "@/modules/search";
+import { getSearchOptions, processVariables } from "@/modules/search";
 import { useSearchQuery } from "@/hooks/useSearchQuery";
 import { SortingComponent } from "@/components/SortingComponent";
 import { useRouter } from "next/router";
@@ -70,12 +70,12 @@ function SeasonalSearch({
   unitOptions,
   reservationUnitTypeOptions,
   purposeOptions,
-}: Props): JSX.Element {
+}: Readonly<Props>): JSX.Element {
   const { t, i18n } = useTranslation();
   const router = useRouter();
   const searchValues = useSearchParams();
 
-  const applicationRoundPk = mapQueryParamToNumber(router.query.id);
+  const applicationRoundPk = toNumber(ignoreMaybeArray(router.query.id));
   const selectedApplicationRound = applicationRounds.find(
     (ar) => ar.pk === applicationRoundPk
   );
@@ -93,6 +93,9 @@ function SeasonalSearch({
     language: i18n.language,
     kind: ReservationKind.Season,
     applicationRound: applicationRoundPk ?? 0,
+    reservationPeriodBegin:
+      selectedApplicationRound?.reservationPeriodBegin ?? "",
+    reservationPeriodEnd: selectedApplicationRound?.reservationPeriodEnd ?? "",
   });
   const query = useSearchQuery(variables);
   const { data, isLoading, error, fetchMore, previousData } = query;

--- a/apps/ui/pages/reservation/cancel.tsx
+++ b/apps/ui/pages/reservation/cancel.tsx
@@ -8,7 +8,6 @@ import {
   getReservationByOrderUuid,
 } from "@/modules/serverUtils";
 import { useTranslation } from "next-i18next";
-import { mapSingleParamToFormValue } from "@/modules/search";
 import { createApolloClient } from "@/modules/apolloClient";
 import {
   DeleteReservationDocument,
@@ -17,6 +16,7 @@ import {
 } from "@/gql/gql-types";
 import { Breadcrumb } from "@/components/common/Breadcrumb";
 import { reservationsPrefix } from "@/modules/urls";
+import { ignoreMaybeArray } from "common/src/helpers";
 
 // This is the callback page from webstore if user cancels the order
 // TODO this would be nicer if we could use a reservation/[id]/cancelled page (or reservation/[id])
@@ -49,7 +49,7 @@ function Cancel({ apiBaseUrl }: NarrowedProps): JSX.Element {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
-  const orderId = mapSingleParamToFormValue(query.orderId);
+  const orderId = ignoreMaybeArray(query.orderId);
 
   const notFoundValue = {
     notFound: true,

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -42,7 +42,7 @@ function SearchSingle({
   reservationUnitTypeOptions,
   purposeOptions,
   equipmentsOptions,
-}: Props): JSX.Element {
+}: Readonly<Props>): JSX.Element {
   const { t, i18n } = useTranslation();
 
   const searchValues = useSearchParams();

--- a/apps/ui/pages/success.tsx
+++ b/apps/ui/pages/success.tsx
@@ -11,10 +11,10 @@ import {
 } from "@/modules/serverUtils";
 import { getReservationPath } from "@/modules/urls";
 import { createApolloClient } from "@/modules/apolloClient";
-import { mapSingleParamToFormValue } from "@/modules/search";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { CenterSpinner } from "common/styles/util";
+import { ignoreMaybeArray } from "common/src/helpers";
 
 // TODO should be moved to /reservations/success
 // but because this is webstore callback page we need to leave the url (use an url rewrite)
@@ -23,7 +23,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
 
-  const orderId = mapSingleParamToFormValue(query.orderId);
+  const orderId = ignoreMaybeArray(query.orderId);
   const notFoundValue = {
     notFound: true,
     props: {

--- a/apps/ui/public/locales/en/reservationUnit.json
+++ b/apps/ui/public/locales/en/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Can only be booked seasonally",
     "futureOpening": "You can make bookings for this item starting on {{date}}."
   },
+  "accessType": "Access to the space",
   "accessTypes": {
     "ACCESS_CODE": "Door code",
     "PHYSICAL_KEY": "Key",

--- a/apps/ui/public/locales/en/reservationUnit.json
+++ b/apps/ui/public/locales/en/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "This item is not available for booking at the moment.",
     "onlyRecurring": "Can only be booked seasonally",
     "futureOpening": "You can make bookings for this item starting on {{date}}."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Door code",
+    "PHYSICAL_KEY": "Key",
+    "OPENED_BY_STAFF": "Staff",
+    "UNRESTRICTED": "Direct access"
   }
 }

--- a/apps/ui/public/locales/en/searchForm.json
+++ b/apps/ui/public/locales/en/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Purpose of use",
   "equipmentsFilter": "Equipment",
   "durationFilter": "Duration",
+  "accessTypeFilter": "Access to the space",
   "beginTimeIsBeforeEndTime": "The start time must be before the end time",
   "resetForm": "Clear",
   "filters": {

--- a/apps/ui/public/locales/fi/reservationUnit.json
+++ b/apps/ui/public/locales/fi/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Varattavissa vain kausittain.",
     "futureOpening": "Voit tehdä varauksen tähän kohteeseen {{date}} alkaen."
   },
+  "accessType": "Pääsy tilaan",
   "accessTypes": {
     "ACCESS_CODE": "Ovikoodi",
     "PHYSICAL_KEY": "Avain",

--- a/apps/ui/public/locales/fi/reservationUnit.json
+++ b/apps/ui/public/locales/fi/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "Kohde ei ole tällä hetkellä varattavissa.",
     "onlyRecurring": "Varattavissa vain kausittain.",
     "futureOpening": "Voit tehdä varauksen tähän kohteeseen {{date}} alkaen."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Ovikoodi",
+    "PHYSICAL_KEY": "Avain",
+    "OPENED_BY_STAFF": "Henkilökunta",
+    "UNRESTRICTED": "Suora pääsy"
   }
 }

--- a/apps/ui/public/locales/fi/searchForm.json
+++ b/apps/ui/public/locales/fi/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Käyttötarkoitus",
   "equipmentsFilter": "Varustelu",
   "durationFilter": "Kesto",
+  "accessTypeFilter": "Pääsy tilaan",
   "beginTimeIsBeforeEndTime": "Alkamisajan on oltava ennen loppumisaikaa",
   "resetForm": "Tyhjennä",
   "filters": {

--- a/apps/ui/public/locales/sv/reservationUnit.json
+++ b/apps/ui/public/locales/sv/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "Objektet går inte att boka just nu.",
     "onlyRecurring": "Kan bokas endast säsongsbokning",
     "futureOpening": "Du kan boka detta objekt från och med {{date}}."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Dörrkod",
+    "PHYSICAL_KEY": "Nyckel",
+    "OPENED_BY_STAFF": "Personal",
+    "UNRESTRICTED": "Direkt tillgång"
   }
 }

--- a/apps/ui/public/locales/sv/reservationUnit.json
+++ b/apps/ui/public/locales/sv/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Kan bokas endast säsongsbokning",
     "futureOpening": "Du kan boka detta objekt från och med {{date}}."
   },
+  "accessType": "Tillträde till utrymmet",
   "accessTypes": {
     "ACCESS_CODE": "Dörrkod",
     "PHYSICAL_KEY": "Nyckel",

--- a/apps/ui/public/locales/sv/searchForm.json
+++ b/apps/ui/public/locales/sv/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Användningsändamål",
   "equipmentsFilter": "Utrustning",
   "durationFilter": "Varaktighet",
+  "accessTypeFilter": "Tillträde till utrymmet",
   "beginTimeIsBeforeEndTime": "Sluttiden måste vara senare än starttiden",
   "resetForm": "Töm",
   "filters": {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds `accessType` to both search pages. Both to the form/filters, and the search result reservation cards

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests
- Both single and seasonal reservation unit searches should have a new filter for `accessType`, and that it works (most/all reservation units use the "Suora pääsy" option for now)
- Check that search results display their respective access types with a new icon + value

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3762](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3762)
- [TILA-3763](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3763)

[TILA-3762]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3763]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ