### PR TITLE
Add filtering to Report APIs

### DIFF
--- a/backend/tests/test_rest_api/test_reservation_statistics_export.py
+++ b/backend/tests/test_rest_api/test_reservation_statistics_export.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import datetime
+
 import pytest
 from django.urls import reverse
+
+from utils.date_utils import local_datetime
 
 from tests.factories import ReservationFactory
 
@@ -27,68 +31,68 @@ def test_reservation_statistics_export(api_client, settings):
     # Assume that the data per reservation statistic is correct from the exporter
     # -> Simply check the keys are what we expect
     assert list(data[0]) == [
-        "id",
-        "num_persons",
-        "state",
-        "reservation_type",
-        "begin",
-        "end",
-        "buffer_time_before",
-        "buffer_time_after",
-        "reservation_handled_at",
-        "reservation_confirmed_at",
-        "reservation_created_at",
-        "price",
-        "price_net",
-        "non_subsidised_price",
-        "non_subsidised_price_net",
-        "tax_percentage_value",
-        "applying_for_free_of_charge",
-        "reservee_id",
-        "reservee_organisation_name",
-        "reservee_address_zip",
-        "reservee_is_unregistered_association",
-        "reservee_language",
-        "reservee_type",
-        "access_type",
-        "access_code_generated_at",
-        "primary_reservation_unit",
-        "primary_reservation_unit_name",
-        "primary_unit_tprek_id",
-        "primary_unit_name",
-        "deny_reason",
-        "deny_reason_text",
-        "cancel_reason",
-        "cancel_reason_text",
-        "purpose",
-        "purpose_name",
-        "home_city",
-        "home_city_name",
-        "home_city_municipality_code",
-        "age_group",
-        "age_group_name",
         "ability_group",
         "ability_group_name",
-        "reservation",
-        "updated_at",
+        "access_code_generated_at",
+        "access_type",
+        "age_group",
+        "age_group_name",
+        "applying_for_free_of_charge",
+        "begin",
+        "buffer_time_after",
+        "buffer_time_before",
+        "cancel_reason",
+        "cancel_reason_text",
+        "deny_reason",
+        "deny_reason_text",
+        "duration_minutes",
+        "end",
+        "home_city",
+        "home_city_municipality_code",
+        "home_city_name",
+        "id",
+        "is_applied",
+        "is_recurring",
+        "is_subsidised",
+        "non_subsidised_price",
+        "non_subsidised_price_net",
+        "num_persons",
+        "price",
+        "price_net",
+        "primary_reservation_unit",
+        "primary_reservation_unit_name",
+        "primary_unit_name",
+        "primary_unit_tprek_id",
         "priority",
         "priority_name",
-        "duration_minutes",
-        "is_subsidised",
-        "is_recurring",
+        "purpose",
+        "purpose_name",
         "recurrence_begin_date",
         "recurrence_end_date",
         "recurrence_uuid",
+        "reservation",
+        "reservation_confirmed_at",
+        "reservation_created_at",
+        "reservation_handled_at",
+        "reservation_type",
         "reservation_uuid",
-        "reservee_uuid",
+        "reservee_address_zip",
+        "reservee_id",
+        "reservee_is_unregistered_association",
+        "reservee_language",
+        "reservee_organisation_name",
+        "reservee_type",
         "reservee_used_ad_login",
-        "is_applied",
+        "reservee_uuid",
+        "state",
+        "tax_percentage_value",
+        "updated_at",
     ]
     assert data[0]["reservation"] == reservation_1.pk
     assert data[1]["reservation"] == reservation_2.pk
 
 
-def test_reservation_unit_export__missing_auth(api_client, settings):
+def test_reservation_statistics_export__missing_auth(api_client, settings):
     settings.SAVE_RESERVATION_STATISTICS = True
 
     ReservationFactory.create()
@@ -101,7 +105,7 @@ def test_reservation_unit_export__missing_auth(api_client, settings):
     assert response.content.decode() == "Not authorized to export reservation statistics."
 
 
-def test_reservation_unit_export__incorrect_auth(api_client, settings):
+def test_reservation_statistics_export__incorrect_auth(api_client, settings):
     settings.SAVE_RESERVATION_STATISTICS = True
 
     ReservationFactory.create()
@@ -114,3 +118,122 @@ def test_reservation_unit_export__incorrect_auth(api_client, settings):
 
     assert response.status_code == 403
     assert response.content.decode() == "Not authorized to export reservation statistics."
+
+
+def test_reservation_statistics_export__only_one(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    reservation = ReservationFactory.create()
+    ReservationFactory.create()
+
+    url = reverse("reservation_statistics_export") + f"?only={reservation.pk}"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk
+
+
+def test_reservation_statistics_export__only_two(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    reservation_1 = ReservationFactory.create()
+    reservation_2 = ReservationFactory.create()
+
+    url = reverse("reservation_statistics_export") + f"?only={reservation_1.pk},{reservation_2.pk}"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["reservation"] == reservation_1.pk
+    assert data[1]["reservation"] == reservation_2.pk
+
+
+def test_reservation_statistics_export__tprek_id(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    reservation = ReservationFactory.create(reservation_units__unit__tprek_id="1")
+    ReservationFactory.create(reservation_units__unit__tprek_id="2")
+
+    url = reverse("reservation_statistics_export") + "?tprek_id=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk
+
+
+def test_reservation_statistics_export__begins_after(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    begin_1 = local_datetime(2022, 1, 2, 12)
+    begin_2 = begin_1 - datetime.timedelta(days=1)
+
+    reservation = ReservationFactory.create(begin=begin_1)
+    ReservationFactory.create(begin=begin_2)
+
+    url = reverse("reservation_statistics_export") + f"?begins_after={begin_1.isoformat()}"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk
+
+
+def test_reservation_statistics_export__begins_before(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    begin_1 = local_datetime(2022, 1, 2, 12)
+    begin_2 = begin_1 - datetime.timedelta(days=1)
+
+    ReservationFactory.create(begin=begin_1)
+    reservation = ReservationFactory.create(begin=begin_2)
+
+    url = reverse("reservation_statistics_export") + f"?begins_before={begin_1.isoformat()}"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk
+
+
+def test_reservation_statistics_export__start(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    ReservationFactory.create()
+    reservation = ReservationFactory.create()
+
+    url = reverse("reservation_statistics_export") + "?start=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk
+
+
+def test_reservation_statistics_export__stop(api_client, settings):
+    settings.SAVE_RESERVATION_STATISTICS = True
+
+    reservation = ReservationFactory.create()
+    ReservationFactory.create()
+
+    url = reverse("reservation_statistics_export") + "?stop=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200, response.json()
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation"] == reservation.pk

--- a/backend/tests/test_rest_api/test_reservation_unit_export.py
+++ b/backend/tests/test_rest_api/test_reservation_unit_export.py
@@ -25,73 +25,73 @@ def test_reservation_unit_export(api_client, settings):
     # Assume that the data per reservation unit is correct from the exporter
     # -> Simply check the keys are what we expect
     assert list(data[0]) == [
-        "reservation_unit_id",
-        "name",
-        "name_fi",
-        "name_en",
-        "name_sv",
-        "description",
-        "description_fi",
-        "description_en",
-        "description_sv",
-        "type",
-        "terms_of_use",
-        "terms_of_use_fi",
-        "terms_of_use_en",
-        "terms_of_use_sv",
-        "service_specific_terms",
-        "tprek_id",
-        "unit",
-        "contact_information",
-        "is_this_in_draft_state",
-        "publish_begins",
-        "publish_ends",
-        "spaces",
-        "resources",
-        "qualifiers",
-        "payment_terms",
-        "cancellation_terms",
-        "pricing_terms",
-        "cancellation_rule",
-        "price_unit",
-        "lowest_price",
-        "highest_price",
-        "tax_percentage",
-        "reservation_begins",
-        "reservation_ends",
-        "reservation_metadata_set",
-        "require_a_handling",
-        "authentication",
-        "reservation_kind",
-        "payment_type",
-        "can_apply_free_of_charge",
-        "additional_instructions_for_pending_reservation_fi",
-        "additional_instructions_for_pending_reservation_sv",
-        "additional_instructions_for_pending_reservation_en",
-        "additional_instructions_for_confirmed_reservation_fi",
-        "additional_instructions_for_confirmed_reservation_sv",
-        "additional_instructions_for_confirmed_reservation_en",
+        "additional_instructions_for_cancelled_reservations_en",
         "additional_instructions_for_cancelled_reservations_fi",
         "additional_instructions_for_cancelled_reservations_sv",
-        "additional_instructions_for_cancelled_reservations_en",
-        "maximum_reservation_duration",
-        "minimum_reservation_duration",
-        "maximum_number_of_persons",
-        "minimum_number_of_persons",
-        "surface_area",
-        "buffer_time_before_reservation",
-        "buffer_time_after_reservation",
-        "hauki_resource_id",
-        "reservation_start_interval",
-        "maximum_number_of_days_before_reservations_can_be_made",
-        "minimum_days_before_reservations_can_be_made",
-        "maximum_number_of_active_reservations_per_user",
+        "additional_instructions_for_confirmed_reservation_en",
+        "additional_instructions_for_confirmed_reservation_fi",
+        "additional_instructions_for_confirmed_reservation_sv",
+        "additional_instructions_for_pending_reservation_en",
+        "additional_instructions_for_pending_reservation_fi",
+        "additional_instructions_for_pending_reservation_sv",
         "allow_reservations_without_opening_hours",
-        "is_reservation_unit_archived",
-        "purposes",
+        "authentication",
+        "buffer_time_after_reservation",
+        "buffer_time_before_reservation",
+        "can_apply_free_of_charge",
+        "cancellation_rule",
+        "cancellation_terms",
+        "contact_information",
+        "description",
+        "description_en",
+        "description_fi",
+        "description_sv",
         "equipments",
-        "state",
+        "hauki_resource_id",
+        "highest_price",
+        "is_reservation_unit_archived",
+        "is_this_in_draft_state",
+        "lowest_price",
+        "maximum_number_of_active_reservations_per_user",
+        "maximum_number_of_days_before_reservations_can_be_made",
+        "maximum_number_of_persons",
+        "maximum_reservation_duration",
+        "minimum_days_before_reservations_can_be_made",
+        "minimum_number_of_persons",
+        "minimum_reservation_duration",
+        "name",
+        "name_en",
+        "name_fi",
+        "name_sv",
+        "payment_terms",
+        "payment_type",
+        "price_unit",
+        "pricing_terms",
+        "publish_begins",
+        "publish_ends",
+        "purposes",
+        "qualifiers",
+        "require_a_handling",
+        "reservation_begins",
+        "reservation_ends",
+        "reservation_kind",
+        "reservation_metadata_set",
+        "reservation_start_interval",
         "reservation_state",
+        "reservation_unit_id",
+        "resources",
+        "service_specific_terms",
+        "spaces",
+        "state",
+        "surface_area",
+        "tax_percentage",
+        "terms_of_use",
+        "terms_of_use_en",
+        "terms_of_use_fi",
+        "terms_of_use_sv",
+        "tprek_id",
+        "type",
+        "unit",
     ]
     assert data[0]["reservation_unit_id"] == reservation_unit_1.pk
     assert data[1]["reservation_unit_id"] == reservation_unit_2.pk
@@ -158,4 +158,49 @@ def test_reservation_unit_export__only_incorrect(api_client, settings):
     response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
 
     assert response.status_code == 400
-    assert response.content.decode() == "'only' should be a comma separated list of reservation unit ids."
+    assert response.json() == {
+        "detail": "'only' should be a comma separated list of reservation unit ids.",
+        "code": "",
+    }
+
+
+def test_reservation_unit_export__tprek_id(api_client, settings):
+    reservation_unit = ReservationUnitFactory.create(unit__tprek_id="1")
+    ReservationUnitFactory.create(unit__tprek_id="2")
+
+    url = reverse("reservation_unit_export") + "?tprek_id=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation_unit_id"] == reservation_unit.pk
+
+
+def test_reservation_unit_export__start(api_client, settings):
+    ReservationUnitFactory.create()
+    reservation_unit = ReservationUnitFactory.create()
+
+    url = reverse("reservation_unit_export") + "?start=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation_unit_id"] == reservation_unit.pk
+
+
+def test_reservation_unit_export__stop(api_client, settings):
+    reservation_unit = ReservationUnitFactory.create()
+    ReservationUnitFactory.create()
+
+    url = reverse("reservation_unit_export") + "?stop=1"
+    response = api_client.get(url, headers={"Authorization": settings.EXPORT_AUTHORIZATION_TOKEN})
+
+    assert response.status_code == 200
+
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["reservation_unit_id"] == reservation_unit.pk

--- a/backend/tilavarauspalvelu/api/rest/utils.py
+++ b/backend/tilavarauspalvelu/api/rest/utils.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import dataclasses
+import datetime
+from functools import wraps
+from typing import TYPE_CHECKING
+
+from django.core.exceptions import ValidationError
+from django.http import JsonResponse
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from tilavarauspalvelu.typing import WSGIRequest
+
+
+__all__ = [
+    "ReservationUnitParams",
+    "StatisticsParams",
+    "validate_pagination",
+    "validation_error_as_response",
+]
+
+
+def validation_error_as_response[R, **P](func: Callable[P, R]) -> Callable[P, R]:
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
+        try:
+            return func(*args, **kwargs)
+        except ValidationError as error:
+            return JsonResponse({"detail": str(error.message), "code": error.code or ""}, status=400)
+
+    return wrapper
+
+
+@dataclasses.dataclass
+class ReservationUnitParams:
+    reservation_units: list[int]
+    tprek_id: str
+
+    @classmethod
+    def from_request(cls, request: WSGIRequest) -> ReservationUnitParams:
+        try:
+            reservation_units = [int(pk) for pk in request.GET.get("only", "").split(",") if pk]
+        except (ValueError, TypeError) as error:
+            msg = "'only' should be a comma separated list of reservation unit ids."
+            raise ValidationError(msg) from error
+
+        tprek_id: str = str(request.GET.get("tprek_id", ""))
+
+        return cls(
+            reservation_units=reservation_units,
+            tprek_id=tprek_id,
+        )
+
+
+@dataclasses.dataclass
+class StatisticsParams:
+    begins_after: datetime.datetime | None
+    begins_before: datetime.datetime | None
+    reservations: list[int]
+    tprek_id: str
+
+    @classmethod
+    def from_request(cls, request: WSGIRequest) -> StatisticsParams:
+        try:
+            reservations: list[int] = [int(pk) for pk in request.GET.get("only", "").split(",") if pk]
+        except (ValueError, TypeError) as error:
+            msg = "'only' should be a comma separated list of reservation ids."
+            raise ValidationError(msg) from error
+
+        # "+" is an escape char in URL params for a space, so replace it with "+" for the timezone info
+        begins_after_str: str = request.GET.get("begins_after", "").replace(" ", "+")
+        begins_before_str: str = request.GET.get("begins_before", "").replace(" ", "+")
+        begins_after: datetime.datetime | None = None
+        begins_before: datetime.datetime | None = None
+
+        if begins_after_str:
+            try:
+                begins_after = datetime.datetime.fromisoformat(begins_after_str)
+            except (ValueError, TypeError) as error:
+                msg = "'begins_after' should be a ISO datetime string."
+                raise ValidationError(msg) from error
+
+        if begins_before_str:
+            try:
+                begins_before = datetime.datetime.fromisoformat(begins_before_str)
+            except (ValueError, TypeError) as error:
+                msg = "'begins_before' should be a ISO datetime string."
+                raise ValidationError(msg) from error
+
+        tprek_id: str = str(request.GET.get("tprek_id", ""))
+
+        return cls(
+            begins_after=begins_after,
+            begins_before=begins_before,
+            reservations=reservations,
+            tprek_id=tprek_id,
+        )
+
+
+def validate_pagination(request: WSGIRequest) -> tuple[int, int]:
+    # Set max page size to avoid timeouts
+    max_page_size = 100
+
+    try:
+        start = int(request.GET.get("start", 0))
+    except (ValueError, TypeError) as error:
+        msg = "'start' should be a number."
+        raise ValidationError(msg) from error
+
+    try:
+        stop = int(request.GET.get("stop", start + max_page_size))
+    except (ValueError, TypeError) as error:
+        msg = "'stop' should be a number."
+        raise ValidationError(msg) from error
+
+    if start >= stop:
+        msg = "'start' should be less than 'stop'."
+        raise ValidationError(msg)
+
+    if stop - start > max_page_size:
+        msg = f"The difference between 'start' and 'stop' should be no more than {max_page_size}."
+        raise ValidationError(msg)
+
+    return start, stop


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add new filtering to the reservation unit and reservation statistics JSON report API
- Added filtering:
  - Reservation Units: `tprek_id`, `only` (reservation unit ids), `start`, `stop`
  - Reservation Statistics: `begins_after`, `begins_before`, `tprek_id`, `only` (reservation ids), `start`, `stop`
- Better validation logic for the APIs
- Format datetimes and times with timezone info
- Added pagination data to response headers
- Sort JSON keys alphabetically

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3871](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3871)


[TILA-3871]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ