### PR TITLE
Add access type and access code to client UI

### DIFF
--- a/apps/ui/components/application/ReservationUnitList.tsx
+++ b/apps/ui/components/application/ReservationUnitList.tsx
@@ -49,7 +49,7 @@ export function ReservationUnitList({
   applicationRound,
   options,
   minSize,
-}: Props): JSX.Element {
+}: Readonly<Props>): JSX.Element {
   const { t } = useTranslation();
   const [showModal, setShowModal] = useState(false);
 
@@ -233,6 +233,10 @@ export const APPLICATION_RESERVATION_UNIT_LIST_FRAGMENT = gql`
         nameFi
         nameSv
         nameEn
+      }
+      accessTypes {
+        id
+        accessType
       }
     }
   }

--- a/apps/ui/components/common/Footer.tsx
+++ b/apps/ui/components/common/Footer.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import { Footer as HDSFooter, IconLinkExternal, IconSize } from "hds-react";
 import Logo from "common/src/components/Logo";
 import styled from "styled-components";
+import { getFeedbackUrl } from "@/modules/urls";
 
 const Wrapper = styled(HDSFooter)`
   margin-top: var(--spacing-xl);
@@ -18,20 +19,10 @@ const Wrapper = styled(HDSFooter)`
   }
 `;
 
-function constructFeedbackUrl(feedbackUrl: string, i18n: { language: string }) {
-  try {
-    const url = new URL(feedbackUrl);
-    url.searchParams.set("lang", i18n.language);
-    return url.toString();
-  } catch (e) {
-    return null;
-  }
-}
-
 function Footer({ feedbackUrl }: { feedbackUrl: string }) {
   const { t, i18n } = useTranslation();
   const locale = i18n.language === "fi" ? "" : `/${i18n.language}`;
-  const languageUrl = constructFeedbackUrl(feedbackUrl, i18n);
+  const languageUrl = getFeedbackUrl(feedbackUrl, i18n);
   return (
     <Wrapper korosType="basic" theme="light" title="Varaamo">
       <HDSFooter.Navigation>

--- a/apps/ui/components/reservation-unit/utils.test.ts
+++ b/apps/ui/components/reservation-unit/utils.test.ts
@@ -209,7 +209,13 @@ describe("getNextAvailableTime", () => {
       applicationRounds: [],
       equipments: [],
       pricings: [],
-      accessType: AccessType.Unrestricted,
+      accessTypes: [
+        {
+          id: "123",
+          accessType: AccessType.Unrestricted,
+          beginDate: new Date().toISOString(),
+        },
+      ],
     };
     return {
       start,

--- a/apps/ui/components/reservation-unit/utils.test.ts
+++ b/apps/ui/components/reservation-unit/utils.test.ts
@@ -11,8 +11,8 @@ import {
   ReservationKind,
   ReservationStartInterval,
 } from "common/gql/gql-types";
-import { ReservationUnitPageQuery } from "@/gql/gql-types";
-import { ReservableMap, RoundPeriod, dateToKey } from "@/modules/reservable";
+import { AccessType, ReservationUnitPageQuery } from "@/gql/gql-types";
+import { dateToKey, ReservableMap, RoundPeriod } from "@/modules/reservable";
 
 describe("getLastPossibleReservationDate", () => {
   beforeAll(() => {
@@ -209,6 +209,7 @@ describe("getNextAvailableTime", () => {
       applicationRounds: [],
       equipments: [],
       pricings: [],
+      accessType: AccessType.Unrestricted,
     };
     return {
       start,

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { IconEuroSign, IconCross, IconArrowRight } from "hds-react";
+import { IconEuroSign, IconCross, IconArrowRight, IconLock } from "hds-react";
 import { useTranslation } from "next-i18next";
 import { trim } from "lodash";
 import {
+  AccessType,
   type ListReservationsQuery,
   ReservationStateChoice,
 } from "@gql/gql-types";
@@ -84,6 +85,18 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
       value: price ?? "",
     },
   ];
+
+  if (reservationUnit.accessType !== AccessType.Unrestricted) {
+    infos.push({
+      icon: (
+        <IconLock
+          aria-label={t("reservationUnit:accessType")}
+          aria-hidden="false"
+        />
+      ),
+      value: t(`reservationUnit:accessTypes.${reservationUnit?.accessType}`),
+    });
+  }
 
   const buttons = [];
   if (type === "upcoming" && isReservationCancellable(reservation)) {

--- a/apps/ui/components/reservation/ReservationCard.tsx
+++ b/apps/ui/components/reservation/ReservationCard.tsx
@@ -35,7 +35,7 @@ interface PropsT {
   type?: CardType;
 }
 
-function ReservationCard({ reservation, type }: PropsT): JSX.Element {
+function ReservationCard({ reservation, type }: Readonly<PropsT>): JSX.Element {
   const { t, i18n } = useTranslation();
 
   const reservationUnit = reservation.reservationUnits?.[0] ?? undefined;
@@ -86,7 +86,8 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
     },
   ];
 
-  if (reservationUnit.accessType !== AccessType.Unrestricted) {
+  // TODO: Remove this check when all reservations have an accessType
+  if (reservation.accessType !== AccessType.Unrestricted) {
     infos.push({
       icon: (
         <IconLock
@@ -94,7 +95,7 @@ function ReservationCard({ reservation, type }: PropsT): JSX.Element {
           aria-hidden="false"
         />
       ),
-      value: t(`reservationUnit:accessTypes.${reservationUnit?.accessType}`),
+      value: t(`reservationUnit:accessTypes.${reservation.accessType}`),
     });
   }
 

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -42,6 +42,7 @@ export const RESERVATION_INFO_CARD_FRAGMENT = gql`
       nameFi
       nameEn
       nameSv
+      accessType
       ...PriceReservationUnit
       images {
         ...Image
@@ -103,7 +104,7 @@ export function ReservationInfoCard({
   disableImage = false,
   className,
   style,
-}: Props): JSX.Element | null {
+}: Readonly<Props>): JSX.Element | null {
   const { t, i18n } = useTranslation();
   const reservationUnit = reservation.reservationUnits?.[0];
 

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -80,13 +80,16 @@ export function ReservationInfoCard({
 }: Readonly<Props>): JSX.Element | null {
   const { t, i18n } = useTranslation();
   const reservationUnit = reservation.reservationUnits?.[0];
-  const { data, loading, error } = useAccessCodeQuery({
+  const { data: accessCodeData } = useAccessCodeQuery({
     skip: !reservation || reservation.accessType !== AccessType.AccessCode,
     variables: {
       id: base64encode(`ReservationNode:${reservation.pk}`),
     },
   });
-  console.log(reservation, data);
+  const { accessCode } = accessCodeData?.reservation?.pindoraInfo ?? {};
+  const shouldDisplayAccessCode =
+    accessCodeData?.reservation?.pindoraInfo?.accessCodeIsActive;
+
   const { begin, end } = reservation || {};
   // NOTE can be removed after this has been refactored not to be used for PendingReservation
 
@@ -163,10 +166,11 @@ export function ReservationInfoCard({
               ),
             })})`}
         </div>
-        {reservationUnit.accessType === AccessType.Unrestricted && (
+        {reservation.accessType !== AccessType.Unrestricted && (
           <div>
-            {t("reservationUnit:accessType")}:{" "}
-            {t(`reservationUnit:accessTypes.${reservationUnit.accessType}`)}
+            {!shouldDisplayAccessCode && `${t("reservationUnit:accessType")}: `}
+            {t(`reservationUnit:accessTypes.${reservation.accessType}`)}
+            {shouldDisplayAccessCode && accessCode && `: ${accessCode}`}
           </div>
         )}
       </Content>

--- a/apps/ui/components/search/ReservationUnitCard.tsx
+++ b/apps/ui/components/search/ReservationUnitCard.tsx
@@ -8,6 +8,7 @@ import {
   ButtonSize,
   ButtonVariant,
   IconHome,
+  IconLock,
 } from "hds-react";
 import React from "react";
 import { useTranslation } from "next-i18next";
@@ -36,7 +37,7 @@ export function ReservationUnitCard({
   selectReservationUnit,
   containsReservationUnit,
   removeReservationUnit,
-}: CardProps): JSX.Element {
+}: Readonly<CardProps>): JSX.Element {
   const { t, i18n } = useTranslation();
   const lang = convertLanguageCode(i18n.language);
 
@@ -67,6 +68,20 @@ export function ReservationUnitCard({
       value: t("reservationUnitCard:maxPersons", {
         count: reservationUnit.maxPersons,
       }),
+    });
+  }
+  if (reservationUnit.currentAccessType) {
+    infos.push({
+      icon: (
+        <IconLock
+          aria-hidden="false"
+          aria-label={t("reservationUnit:accessType")}
+          size={IconSize.Small}
+        />
+      ),
+      value: t(
+        `reservationUnit:accessTypes.${reservationUnit.currentAccessType}`
+      ),
     });
   }
 

--- a/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
+++ b/apps/ui/components/search/SingleSearchReservationUnitCard.tsx
@@ -3,6 +3,7 @@ import {
   IconEuroSign,
   IconGroup,
   IconHome,
+  IconLock,
   IconSize,
 } from "hds-react";
 import React from "react";
@@ -142,10 +143,32 @@ function ReservationUnitCard({ reservationUnit }: PropsT): JSX.Element {
   }
   if (reservationUnit.maxPersons) {
     infos.push({
-      icon: <IconGroup size={IconSize.Small} />,
+      icon: (
+        <IconGroup
+          aria-hidden="false"
+          aria-label={t("reservationUnitCard:maxPersons", {
+            maxPersons: reservationUnit.maxPersons,
+          })}
+          size={IconSize.Small}
+        />
+      ),
       value: t("reservationUnitCard:maxPersons", {
         count: reservationUnit.maxPersons,
       }),
+    });
+  }
+  if (reservationUnit.currentAccessType) {
+    infos.push({
+      icon: (
+        <IconLock
+          aria-hidden="false"
+          aria-label={t("reservationUnit:accessType")}
+          size={IconSize.Small}
+        />
+      ),
+      value: t(
+        `reservationUnit:accessTypes.${reservationUnit.currentAccessType}`
+      ),
     });
   }
 

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -239,10 +239,12 @@ export type ApplicationCreateMutationInput = {
     Array<InputMaybe<ApplicationSectionForApplicationSerializerInput>>
   >;
   billingAddress?: InputMaybe<AddressSerializerInput>;
+  cancelledDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   contactPerson?: InputMaybe<PersonSerializerInput>;
   homeCity?: InputMaybe<Scalars["Int"]["input"]>;
   organisation?: InputMaybe<OrganisationSerializerInput>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
+  sentDate?: InputMaybe<Scalars["DateTime"]["input"]>;
 };
 
 export type ApplicationCreateMutationPayload = {
@@ -716,20 +718,24 @@ export enum ApplicationStatusChoice {
 export type ApplicationUpdateMutationInput = {
   additionalInformation?: InputMaybe<Scalars["String"]["input"]>;
   applicantType?: InputMaybe<ApplicantTypeChoice>;
+  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
   applicationSections?: InputMaybe<
     Array<InputMaybe<UpdateApplicationSectionForApplicationSerializerInput>>
   >;
   billingAddress?: InputMaybe<UpdateAddressSerializerInput>;
+  cancelledDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   contactPerson?: InputMaybe<UpdatePersonSerializerInput>;
   homeCity?: InputMaybe<Scalars["Int"]["input"]>;
   organisation?: InputMaybe<UpdateOrganisationSerializerInput>;
   pk: Scalars["Int"]["input"];
+  sentDate?: InputMaybe<Scalars["DateTime"]["input"]>;
+  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ApplicationUpdateMutationPayload = {
   additionalInformation?: Maybe<Scalars["String"]["output"]>;
   applicantType?: Maybe<ApplicantTypeChoice>;
-  applicationRound?: Maybe<Scalars["ID"]["output"]>;
+  applicationRound?: Maybe<Scalars["Int"]["output"]>;
   applicationSections?: Maybe<Array<Maybe<ApplicationSectionNode>>>;
   billingAddress?: Maybe<AddressNode>;
   cancelledDate?: Maybe<Scalars["DateTime"]["output"]>;
@@ -741,16 +747,6 @@ export type ApplicationUpdateMutationPayload = {
   pk?: Maybe<Scalars["Int"]["output"]>;
   sentDate?: Maybe<Scalars["DateTime"]["output"]>;
   status?: Maybe<Status>;
-  user?: Maybe<Scalars["ID"]["output"]>;
-};
-
-export type ApplicationWorkingMemoMutationInput = {
-  pk: Scalars["Int"]["input"];
-  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
-};
-
-export type ApplicationWorkingMemoMutationPayload = {
-  pk?: Maybe<Scalars["Int"]["output"]>;
   workingMemo?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -1240,7 +1236,6 @@ export type Mutation = {
   staffReservationModify?: Maybe<ReservationStaffModifyMutationPayload>;
   updateApplication?: Maybe<ApplicationUpdateMutationPayload>;
   updateApplicationSection?: Maybe<ApplicationSectionUpdateMutationPayload>;
-  updateApplicationWorkingMemo?: Maybe<ApplicationWorkingMemoMutationPayload>;
   updateBannerNotification?: Maybe<BannerNotificationUpdateMutationPayload>;
   updateCurrentUser?: Maybe<CurrentUserUpdateMutationPayload>;
   updateEquipment?: Maybe<EquipmentUpdateMutationPayload>;
@@ -1456,10 +1451,6 @@ export type MutationUpdateApplicationArgs = {
 
 export type MutationUpdateApplicationSectionArgs = {
   input: ApplicationSectionUpdateMutationInput;
-};
-
-export type MutationUpdateApplicationWorkingMemoArgs = {
-  input: ApplicationWorkingMemoMutationInput;
 };
 
 export type MutationUpdateBannerNotificationArgs = {
@@ -8297,6 +8288,8 @@ export type ApplicationRoundQuery = {
     nameFi?: string | null;
     nameEn?: string | null;
     nameSv?: string | null;
+    reservationPeriodBegin: string;
+    reservationPeriodEnd: string;
     reservationUnits: Array<{ id: string; pk?: number | null }>;
   } | null;
 };
@@ -12773,6 +12766,8 @@ export const ApplicationRoundDocument = gql`
       nameFi
       nameEn
       nameSv
+      reservationPeriodBegin
+      reservationPeriodEnd
       reservationUnits {
         id
         pk

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6556,6 +6556,7 @@ export type ReservationUnitPageFieldsFragment = {
   reservationState?: ReservationUnitReservationState | null;
   numActiveUserReservations?: number | null;
   requireReservationHandling: boolean;
+  currentAccessType?: AccessType | null;
   termsOfUseFi?: string | null;
   termsOfUseEn?: string | null;
   termsOfUseSv?: string | null;
@@ -6729,6 +6730,7 @@ export type ReservationUnitPageQuery = {
     reservationState?: ReservationUnitReservationState | null;
     numActiveUserReservations?: number | null;
     requireReservationHandling: boolean;
+    currentAccessType?: AccessType | null;
     maxReservationDuration?: number | null;
     minReservationDuration?: number | null;
     reservationsMaxDaysBefore?: number | null;
@@ -6860,6 +6862,7 @@ export type ReservationUnitPageQuery = {
 
 export type ReservationUnitCardFieldsFragment = {
   maxPersons?: number | null;
+  currentAccessType?: AccessType | null;
   id: string;
   pk?: number | null;
   nameFi?: string | null;
@@ -6897,6 +6900,7 @@ export type ReservationUnitCardFieldsFragment = {
     smallUrl?: string | null;
     imageType: ImageType;
   }>;
+  accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
 };
 
 export type SearchReservationUnitsQueryVariables = Exact<{
@@ -6927,6 +6931,11 @@ export type SearchReservationUnitsQueryVariables = Exact<{
     | Array<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
   >;
+  accessType?: InputMaybe<
+    Array<InputMaybe<AccessType>> | InputMaybe<AccessType>
+  >;
+  accessTypeBeginDate?: InputMaybe<Scalars["Date"]["input"]>;
+  accessTypeEndDate?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
@@ -6954,6 +6963,7 @@ export type SearchReservationUnitsQuery = {
         reservationEnds?: string | null;
         isClosed?: boolean | null;
         firstReservableDatetime?: string | null;
+        currentAccessType?: AccessType | null;
         maxPersons?: number | null;
         id: string;
         pk?: number | null;
@@ -7000,6 +7010,7 @@ export type SearchReservationUnitsQuery = {
           smallUrl?: string | null;
           imageType: ImageType;
         }>;
+        accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
       } | null;
     } | null>;
     pageInfo: { endCursor?: string | null; hasNextPage: boolean };
@@ -9537,6 +9548,7 @@ export const ReservationUnitPageFieldsFragmentDoc = gql`
       id
       ...EquipmentFields
     }
+    currentAccessType
   }
   ${AddressFieldsFragmentDoc}
   ${TermsOfUseFragmentDoc}
@@ -9601,6 +9613,11 @@ export const ReservationUnitCardFieldsFragmentDoc = gql`
       ...Image
     }
     maxPersons
+    currentAccessType
+    accessTypes(isActiveOrFuture: true) {
+      accessType
+      beginDate
+    }
   }
   ${ReservationUnitNameFieldsFragmentDoc}
   ${UnitNameFieldsI18NFragmentDoc}
@@ -11408,6 +11425,9 @@ export const SearchReservationUnitsDocument = gql`
     $reservationUnitType: [Int]
     $purposes: [Int]
     $equipments: [Int]
+    $accessType: [AccessType]
+    $accessTypeBeginDate: Date
+    $accessTypeEndDate: Date
     $reservableDateStart: Date
     $reservableDateEnd: Date
     $reservableTimeStart: Time
@@ -11434,6 +11454,9 @@ export const SearchReservationUnitsDocument = gql`
       reservationUnitType: $reservationUnitType
       purposes: $purposes
       equipments: $equipments
+      accessType: $accessType
+      accessTypeBeginDate: $accessTypeBeginDate
+      accessTypeEndDate: $accessTypeEndDate
       reservableDateStart: $reservableDateStart
       reservableDateEnd: $reservableDateEnd
       reservableTimeStart: $reservableTimeStart
@@ -11456,6 +11479,7 @@ export const SearchReservationUnitsDocument = gql`
           reservationEnds
           isClosed
           firstReservableDatetime
+          currentAccessType
           pricings {
             ...PricingFields
           }
@@ -11493,6 +11517,9 @@ export const SearchReservationUnitsDocument = gql`
  *      reservationUnitType: // value for 'reservationUnitType'
  *      purposes: // value for 'purposes'
  *      equipments: // value for 'equipments'
+ *      accessType: // value for 'accessType'
+ *      accessTypeBeginDate: // value for 'accessTypeBeginDate'
+ *      accessTypeEndDate: // value for 'accessTypeEndDate'
  *      reservableDateStart: // value for 'reservableDateStart'
  *      reservableDateEnd: // value for 'reservableDateEnd'
  *      reservableTimeStart: // value for 'reservableTimeStart'

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5454,6 +5454,7 @@ export type ReservationInfoCardFragment = {
     nameFi?: string | null;
     nameEn?: string | null;
     nameSv?: string | null;
+    accessType: AccessType;
     reservationBegins?: string | null;
     reservationEnds?: string | null;
     images: Array<{
@@ -6402,6 +6403,7 @@ export type ListReservationsQuery = {
           nameFi?: string | null;
           nameEn?: string | null;
           nameSv?: string | null;
+          accessType: AccessType;
           reservationBegins?: string | null;
           reservationEnds?: string | null;
           images: Array<{
@@ -8360,6 +8362,7 @@ export type ReservationQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
+      accessType: AccessType;
       minPersons?: number | null;
       maxPersons?: number | null;
       termsOfUseFi?: string | null;
@@ -8469,6 +8472,7 @@ export type ReservationCancelPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
+      accessType: AccessType;
       reservationBegins?: string | null;
       reservationEnds?: string | null;
       cancellationTerms?: {
@@ -8595,6 +8599,7 @@ export type ReservationConfirmationPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
+      accessType: AccessType;
       reservationPendingInstructionsFi?: string | null;
       reservationPendingInstructionsEn?: string | null;
       reservationPendingInstructionsSv?: string | null;
@@ -8692,6 +8697,7 @@ export type ReservationEditPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
+      accessType: AccessType;
       minPersons?: number | null;
       maxPersons?: number | null;
       reservationBegins?: string | null;
@@ -8822,6 +8828,7 @@ export type ReservationPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
+      accessType: AccessType;
       reservationPendingInstructionsFi?: string | null;
       reservationPendingInstructionsEn?: string | null;
       reservationPendingInstructionsSv?: string | null;
@@ -9009,6 +9016,7 @@ export const ReservationInfoCardFragmentDoc = gql`
       nameFi
       nameEn
       nameSv
+      accessType
       ...PriceReservationUnit
       images {
         ...Image

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5377,6 +5377,7 @@ export type ApplicationRoundForApplicationFragment = {
       nameSv?: string | null;
       nameEn?: string | null;
     } | null;
+    accessTypes: Array<{ id: string; accessType: AccessType }>;
   }>;
 };
 
@@ -5409,6 +5410,7 @@ export type ApplicationReservationUnitListFragment = {
       nameSv?: string | null;
       nameEn?: string | null;
     } | null;
+    accessTypes: Array<{ id: string; accessType: AccessType }>;
   }>;
 };
 
@@ -5803,6 +5805,7 @@ export type ApplicationFormFragment = {
         nameSv?: string | null;
         nameEn?: string | null;
       } | null;
+      accessTypes: Array<{ id: string; accessType: AccessType }>;
     }>;
   };
   applicationSections?: Array<{
@@ -5963,6 +5966,7 @@ export type ApplicationCommonFragment = {
         nameSv?: string | null;
         nameEn?: string | null;
       } | null;
+      accessTypes: Array<{ id: string; accessType: AccessType }>;
     }>;
   };
   applicationSections?: Array<{
@@ -6385,7 +6389,6 @@ export type ListReservationsQuery = {
         name?: string | null;
         bufferTimeBefore: number;
         bufferTimeAfter: number;
-        accessType: AccessType;
         isBlocked?: boolean | null;
         pk?: number | null;
         taxPercentageValue?: string | null;
@@ -6393,6 +6396,7 @@ export type ListReservationsQuery = {
         end: string;
         state?: ReservationStateChoice | null;
         price?: string | null;
+        accessType: AccessType;
         paymentOrder: Array<{
           id: string;
           checkoutUrl?: string | null;
@@ -6520,6 +6524,7 @@ export type AccessCodeQuery = {
       accessCode: string;
       accessCodeBeginsAt: string;
       accessCodeEndsAt: string;
+      accessCodeIsActive: boolean;
     } | null;
   } | null;
 };
@@ -6652,7 +6657,7 @@ export type ReservationUnitPageFieldsFragment = {
       nameSv?: string | null;
     };
   }>;
-  accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
+  accessTypes: Array<{ id: string; accessType: AccessType; beginDate: string }>;
   serviceSpecificTerms?: {
     id: string;
     textFi?: string | null;
@@ -6827,7 +6832,11 @@ export type ReservationUnitPageQuery = {
         nameSv?: string | null;
       };
     }>;
-    accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
+    accessTypes: Array<{
+      id: string;
+      accessType: AccessType;
+      beginDate: string;
+    }>;
     reservableTimeSpans?: Array<{
       startDatetime?: string | null;
       endDatetime?: string | null;
@@ -6920,7 +6929,7 @@ export type ReservationUnitCardFieldsFragment = {
     smallUrl?: string | null;
     imageType: ImageType;
   }>;
-  accessTypes: Array<{ accessType: AccessType }>;
+  accessTypes: Array<{ id: string; accessType: AccessType }>;
 };
 
 export type SearchReservationUnitsQueryVariables = Exact<{
@@ -7030,7 +7039,7 @@ export type SearchReservationUnitsQuery = {
           smallUrl?: string | null;
           imageType: ImageType;
         }>;
-        accessTypes: Array<{ accessType: AccessType }>;
+        accessTypes: Array<{ id: string; accessType: AccessType }>;
       } | null;
     } | null>;
     pageInfo: { endCursor?: string | null; hasNextPage: boolean };
@@ -7550,6 +7559,7 @@ export type ApplicationPage1Query = {
           nameSv?: string | null;
           nameEn?: string | null;
         } | null;
+        accessTypes: Array<{ id: string; accessType: AccessType }>;
       }>;
     };
     applicationSections?: Array<{
@@ -7701,6 +7711,7 @@ export type ApplicationPage2Query = {
           nameSv?: string | null;
           nameEn?: string | null;
         } | null;
+        accessTypes: Array<{ id: string; accessType: AccessType }>;
       }>;
     };
     applicationSections?: Array<{
@@ -7852,6 +7863,7 @@ export type ApplicationPage3Query = {
           nameSv?: string | null;
           nameEn?: string | null;
         } | null;
+        accessTypes: Array<{ id: string; accessType: AccessType }>;
       }>;
     };
     applicationSections?: Array<{
@@ -8181,6 +8193,7 @@ export type ApplicationViewQuery = {
           nameSv?: string | null;
           nameEn?: string | null;
         } | null;
+        accessTypes: Array<{ id: string; accessType: AccessType }>;
       }>;
     };
     applicationSections?: Array<{
@@ -9199,6 +9212,10 @@ export const ApplicationReservationUnitListFragmentDoc = gql`
         nameSv
         nameEn
       }
+      accessTypes {
+        id
+        accessType
+      }
     }
   }
   ${ImageFragmentDoc}
@@ -9585,7 +9602,8 @@ export const ReservationUnitPageFieldsFragmentDoc = gql`
       ...EquipmentFields
     }
     currentAccessType
-    accessTypes(isActiveOrFuture: true) {
+    accessTypes(isActiveOrFuture: true, orderBy: [beginDateAsc]) {
+      id
       accessType
       beginDate
     }
@@ -9654,7 +9672,8 @@ export const ReservationUnitCardFieldsFragmentDoc = gql`
     }
     maxPersons
     currentAccessType
-    accessTypes(isActiveOrFuture: true) {
+    accessTypes(isActiveOrFuture: true, orderBy: [beginDateAsc]) {
+      id
       accessType
     }
   }
@@ -10995,7 +11014,6 @@ export const ListReservationsDocument = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
-          accessType
           ...ReservationOrderStatus
           paymentOrder {
             id
@@ -11357,6 +11375,7 @@ export const AccessCodeDocument = gql`
         accessCode
         accessCodeBeginsAt
         accessCodeEndsAt
+        accessCodeIsActive
       }
     }
   }

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -239,12 +239,10 @@ export type ApplicationCreateMutationInput = {
     Array<InputMaybe<ApplicationSectionForApplicationSerializerInput>>
   >;
   billingAddress?: InputMaybe<AddressSerializerInput>;
-  cancelledDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   contactPerson?: InputMaybe<PersonSerializerInput>;
   homeCity?: InputMaybe<Scalars["Int"]["input"]>;
   organisation?: InputMaybe<OrganisationSerializerInput>;
   pk?: InputMaybe<Scalars["Int"]["input"]>;
-  sentDate?: InputMaybe<Scalars["DateTime"]["input"]>;
 };
 
 export type ApplicationCreateMutationPayload = {
@@ -718,24 +716,20 @@ export enum ApplicationStatusChoice {
 export type ApplicationUpdateMutationInput = {
   additionalInformation?: InputMaybe<Scalars["String"]["input"]>;
   applicantType?: InputMaybe<ApplicantTypeChoice>;
-  applicationRound?: InputMaybe<Scalars["Int"]["input"]>;
   applicationSections?: InputMaybe<
     Array<InputMaybe<UpdateApplicationSectionForApplicationSerializerInput>>
   >;
   billingAddress?: InputMaybe<UpdateAddressSerializerInput>;
-  cancelledDate?: InputMaybe<Scalars["DateTime"]["input"]>;
   contactPerson?: InputMaybe<UpdatePersonSerializerInput>;
   homeCity?: InputMaybe<Scalars["Int"]["input"]>;
   organisation?: InputMaybe<UpdateOrganisationSerializerInput>;
   pk: Scalars["Int"]["input"];
-  sentDate?: InputMaybe<Scalars["DateTime"]["input"]>;
-  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type ApplicationUpdateMutationPayload = {
   additionalInformation?: Maybe<Scalars["String"]["output"]>;
   applicantType?: Maybe<ApplicantTypeChoice>;
-  applicationRound?: Maybe<Scalars["Int"]["output"]>;
+  applicationRound?: Maybe<Scalars["ID"]["output"]>;
   applicationSections?: Maybe<Array<Maybe<ApplicationSectionNode>>>;
   billingAddress?: Maybe<AddressNode>;
   cancelledDate?: Maybe<Scalars["DateTime"]["output"]>;
@@ -747,6 +741,16 @@ export type ApplicationUpdateMutationPayload = {
   pk?: Maybe<Scalars["Int"]["output"]>;
   sentDate?: Maybe<Scalars["DateTime"]["output"]>;
   status?: Maybe<Status>;
+  user?: Maybe<Scalars["ID"]["output"]>;
+};
+
+export type ApplicationWorkingMemoMutationInput = {
+  pk: Scalars["Int"]["input"];
+  workingMemo?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+export type ApplicationWorkingMemoMutationPayload = {
+  pk?: Maybe<Scalars["Int"]["output"]>;
   workingMemo?: Maybe<Scalars["String"]["output"]>;
 };
 
@@ -1236,6 +1240,7 @@ export type Mutation = {
   staffReservationModify?: Maybe<ReservationStaffModifyMutationPayload>;
   updateApplication?: Maybe<ApplicationUpdateMutationPayload>;
   updateApplicationSection?: Maybe<ApplicationSectionUpdateMutationPayload>;
+  updateApplicationWorkingMemo?: Maybe<ApplicationWorkingMemoMutationPayload>;
   updateBannerNotification?: Maybe<BannerNotificationUpdateMutationPayload>;
   updateCurrentUser?: Maybe<CurrentUserUpdateMutationPayload>;
   updateEquipment?: Maybe<EquipmentUpdateMutationPayload>;
@@ -1451,6 +1456,10 @@ export type MutationUpdateApplicationArgs = {
 
 export type MutationUpdateApplicationSectionArgs = {
   input: ApplicationSectionUpdateMutationInput;
+};
+
+export type MutationUpdateApplicationWorkingMemoArgs = {
+  input: ApplicationWorkingMemoMutationInput;
 };
 
 export type MutationUpdateBannerNotificationArgs = {
@@ -6625,6 +6634,7 @@ export type ReservationUnitPageFieldsFragment = {
       nameSv?: string | null;
     };
   }>;
+  accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
   serviceSpecificTerms?: {
     id: string;
     textFi?: string | null;
@@ -6799,6 +6809,7 @@ export type ReservationUnitPageQuery = {
         nameSv?: string | null;
       };
     }>;
+    accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
     reservableTimeSpans?: Array<{
       startDatetime?: string | null;
       endDatetime?: string | null;
@@ -9542,6 +9553,10 @@ export const ReservationUnitPageFieldsFragmentDoc = gql`
       ...EquipmentFields
     }
     currentAccessType
+    accessTypes(isActiveOrFuture: true) {
+      accessType
+      beginDate
+    }
   }
   ${AddressFieldsFragmentDoc}
   ${TermsOfUseFragmentDoc}

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6900,7 +6900,7 @@ export type ReservationUnitCardFieldsFragment = {
     smallUrl?: string | null;
     imageType: ImageType;
   }>;
-  accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
+  accessTypes: Array<{ accessType: AccessType }>;
 };
 
 export type SearchReservationUnitsQueryVariables = Exact<{
@@ -7010,7 +7010,7 @@ export type SearchReservationUnitsQuery = {
           smallUrl?: string | null;
           imageType: ImageType;
         }>;
-        accessTypes: Array<{ accessType: AccessType; beginDate: string }>;
+        accessTypes: Array<{ accessType: AccessType }>;
       } | null;
     } | null>;
     pageInfo: { endCursor?: string | null; hasNextPage: boolean };
@@ -9616,7 +9616,6 @@ export const ReservationUnitCardFieldsFragmentDoc = gql`
     currentAccessType
     accessTypes(isActiveOrFuture: true) {
       accessType
-      beginDate
     }
   }
   ${ReservationUnitNameFieldsFragmentDoc}

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -50,7 +50,6 @@ export type AbilityGroupNode = Node & {
 /** How is the reservee able to enter the space in their reservation unit? */
 export enum AccessType {
   AccessCode = "ACCESS_CODE",
-  Multivalued = "MULTIVALUED",
   OpenedByStaff = "OPENED_BY_STAFF",
   PhysicalKey = "PHYSICAL_KEY",
   Unrestricted = "UNRESTRICTED",
@@ -6520,6 +6519,7 @@ export type AccessCodeQueryVariables = Exact<{
 
 export type AccessCodeQuery = {
   reservation?: {
+    id: string;
     pindoraInfo?: {
       accessCode: string;
       accessCodeBeginsAt: string;
@@ -11371,6 +11371,7 @@ export type RefreshOrderMutationOptions = Apollo.BaseMutationOptions<
 export const AccessCodeDocument = gql`
   query AccessCode($id: ID!) {
     reservation(id: $id) {
+      id
       pindoraInfo {
         accessCode
         accessCodeBeginsAt

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -5448,13 +5448,14 @@ export type ReservationInfoCardFragment = {
   end: string;
   state?: ReservationStateChoice | null;
   price?: string | null;
+  accessType: AccessType;
+  pindoraInfo?: { accessCode: string } | null;
   reservationUnits: Array<{
     id: string;
     pk?: number | null;
     nameFi?: string | null;
     nameEn?: string | null;
     nameSv?: string | null;
-    accessType: AccessType;
     reservationBegins?: string | null;
     reservationEnds?: string | null;
     images: Array<{
@@ -6384,6 +6385,7 @@ export type ListReservationsQuery = {
         name?: string | null;
         bufferTimeBefore: number;
         bufferTimeAfter: number;
+        accessType: AccessType;
         isBlocked?: boolean | null;
         pk?: number | null;
         taxPercentageValue?: string | null;
@@ -6403,7 +6405,6 @@ export type ListReservationsQuery = {
           nameFi?: string | null;
           nameEn?: string | null;
           nameSv?: string | null;
-          accessType: AccessType;
           reservationBegins?: string | null;
           reservationEnds?: string | null;
           images: Array<{
@@ -6433,6 +6434,7 @@ export type ListReservationsQuery = {
             taxPercentage: { id: string; pk?: number | null; value: string };
           }>;
         }>;
+        pindoraInfo?: { accessCode: string } | null;
       } | null;
     } | null>;
   } | null;
@@ -6506,6 +6508,20 @@ export type RefreshOrderMutationVariables = Exact<{
 
 export type RefreshOrderMutation = {
   refreshOrder?: { orderUuid?: string | null; status?: string | null } | null;
+};
+
+export type AccessCodeQueryVariables = Exact<{
+  id: Scalars["ID"]["input"];
+}>;
+
+export type AccessCodeQuery = {
+  reservation?: {
+    pindoraInfo?: {
+      accessCode: string;
+      accessCodeBeginsAt: string;
+      accessCodeEndsAt: string;
+    } | null;
+  } | null;
 };
 
 export type ReservationUnitTypeFieldsFragment = {
@@ -8328,6 +8344,7 @@ export type ReservationQuery = {
     end: string;
     state?: ReservationStateChoice | null;
     price?: string | null;
+    accessType: AccessType;
     reserveeFirstName?: string | null;
     reserveeLastName?: string | null;
     reserveeEmail?: string | null;
@@ -8362,7 +8379,6 @@ export type ReservationQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
-      accessType: AccessType;
       minPersons?: number | null;
       maxPersons?: number | null;
       termsOfUseFi?: string | null;
@@ -8449,6 +8465,7 @@ export type ReservationQuery = {
       nameSv?: string | null;
       nameEn?: string | null;
     } | null;
+    pindoraInfo?: { accessCode: string } | null;
   } | null;
 };
 
@@ -8466,13 +8483,13 @@ export type ReservationCancelPageQuery = {
     end: string;
     state?: ReservationStateChoice | null;
     price?: string | null;
+    accessType: AccessType;
     reservationUnits: Array<{
       id: string;
       pk?: number | null;
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
-      accessType: AccessType;
       reservationBegins?: string | null;
       reservationEnds?: string | null;
       cancellationTerms?: {
@@ -8535,6 +8552,7 @@ export type ReservationCancelPageQuery = {
         };
       } | null;
     } | null;
+    pindoraInfo?: { accessCode: string } | null;
   } | null;
   reservationCancelReasons?: {
     edges: Array<{
@@ -8584,6 +8602,7 @@ export type ReservationConfirmationPageQuery = {
     end: string;
     state?: ReservationStateChoice | null;
     price?: string | null;
+    accessType: AccessType;
     paymentOrder: Array<{
       id: string;
       reservationPk?: string | null;
@@ -8599,7 +8618,6 @@ export type ReservationConfirmationPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
-      accessType: AccessType;
       reservationPendingInstructionsFi?: string | null;
       reservationPendingInstructionsEn?: string | null;
       reservationPendingInstructionsSv?: string | null;
@@ -8651,6 +8669,7 @@ export type ReservationConfirmationPageQuery = {
       minimum: number;
       maximum?: number | null;
     } | null;
+    pindoraInfo?: { accessCode: string } | null;
   } | null;
 };
 
@@ -8673,6 +8692,7 @@ export type ReservationEditPageQuery = {
     end: string;
     state?: ReservationStateChoice | null;
     price?: string | null;
+    accessType: AccessType;
     reserveeFirstName?: string | null;
     reserveeLastName?: string | null;
     reserveeEmail?: string | null;
@@ -8697,7 +8717,6 @@ export type ReservationEditPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
-      accessType: AccessType;
       minPersons?: number | null;
       maxPersons?: number | null;
       reservationBegins?: string | null;
@@ -8754,6 +8773,7 @@ export type ReservationEditPageQuery = {
       nameSv?: string | null;
       nameEn?: string | null;
     } | null;
+    pindoraInfo?: { accessCode: string } | null;
   } | null;
 };
 
@@ -8812,6 +8832,7 @@ export type ReservationPageQuery = {
     end: string;
     state?: ReservationStateChoice | null;
     price?: string | null;
+    accessType: AccessType;
     paymentOrder: Array<{
       id: string;
       reservationPk?: string | null;
@@ -8828,7 +8849,6 @@ export type ReservationPageQuery = {
       nameFi?: string | null;
       nameEn?: string | null;
       nameSv?: string | null;
-      accessType: AccessType;
       reservationPendingInstructionsFi?: string | null;
       reservationPendingInstructionsEn?: string | null;
       reservationPendingInstructionsSv?: string | null;
@@ -8929,6 +8949,7 @@ export type ReservationPageQuery = {
       minimum: number;
       maximum?: number | null;
     } | null;
+    pindoraInfo?: { accessCode: string } | null;
   } | null;
 };
 
@@ -9010,13 +9031,16 @@ export const ReservationInfoCardFragmentDoc = gql`
     end
     state
     price
+    accessType
+    pindoraInfo {
+      accessCode
+    }
     reservationUnits {
       id
       pk
       nameFi
       nameEn
       nameSv
-      accessType
       ...PriceReservationUnit
       images {
         ...Image
@@ -10971,6 +10995,7 @@ export const ListReservationsDocument = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
+          accessType
           ...ReservationOrderStatus
           paymentOrder {
             id
@@ -11324,6 +11349,87 @@ export type RefreshOrderMutationResult =
 export type RefreshOrderMutationOptions = Apollo.BaseMutationOptions<
   RefreshOrderMutation,
   RefreshOrderMutationVariables
+>;
+export const AccessCodeDocument = gql`
+  query AccessCode($id: ID!) {
+    reservation(id: $id) {
+      pindoraInfo {
+        accessCode
+        accessCodeBeginsAt
+        accessCodeEndsAt
+      }
+    }
+  }
+`;
+
+/**
+ * __useAccessCodeQuery__
+ *
+ * To run a query within a React component, call `useAccessCodeQuery` and pass it any options that fit your needs.
+ * When your component renders, `useAccessCodeQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useAccessCodeQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useAccessCodeQuery(
+  baseOptions: Apollo.QueryHookOptions<
+    AccessCodeQuery,
+    AccessCodeQueryVariables
+  > &
+    (
+      | { variables: AccessCodeQueryVariables; skip?: boolean }
+      | { skip: boolean }
+    )
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useQuery<AccessCodeQuery, AccessCodeQueryVariables>(
+    AccessCodeDocument,
+    options
+  );
+}
+export function useAccessCodeLazyQuery(
+  baseOptions?: Apollo.LazyQueryHookOptions<
+    AccessCodeQuery,
+    AccessCodeQueryVariables
+  >
+) {
+  const options = { ...defaultOptions, ...baseOptions };
+  return Apollo.useLazyQuery<AccessCodeQuery, AccessCodeQueryVariables>(
+    AccessCodeDocument,
+    options
+  );
+}
+export function useAccessCodeSuspenseQuery(
+  baseOptions?:
+    | Apollo.SkipToken
+    | Apollo.SuspenseQueryHookOptions<AccessCodeQuery, AccessCodeQueryVariables>
+) {
+  const options =
+    baseOptions === Apollo.skipToken
+      ? baseOptions
+      : { ...defaultOptions, ...baseOptions };
+  return Apollo.useSuspenseQuery<AccessCodeQuery, AccessCodeQueryVariables>(
+    AccessCodeDocument,
+    options
+  );
+}
+export type AccessCodeQueryHookResult = ReturnType<typeof useAccessCodeQuery>;
+export type AccessCodeLazyQueryHookResult = ReturnType<
+  typeof useAccessCodeLazyQuery
+>;
+export type AccessCodeSuspenseQueryHookResult = ReturnType<
+  typeof useAccessCodeSuspenseQuery
+>;
+export type AccessCodeQueryResult = Apollo.QueryResult<
+  AccessCodeQuery,
+  AccessCodeQueryVariables
 >;
 export const ReservationUnitPageDocument = gql`
   query ReservationUnitPage(

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -103,7 +103,6 @@ export const LIST_RESERVATIONS = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
-          accessType
           ...ReservationOrderStatus
           paymentOrder {
             id
@@ -181,7 +180,7 @@ export const REFRESH_ORDER = gql`
   }
 `;
 
-export const RESERVATION_ACCESS_CODE = gql`
+export const ACCESS_CODE = gql`
   query AccessCode($id: ID!) {
     reservation(id: $id) {
       id
@@ -189,6 +188,7 @@ export const RESERVATION_ACCESS_CODE = gql`
         accessCode
         accessCodeBeginsAt
         accessCodeEndsAt
+        accessCodeIsActive
       }
     }
   }

--- a/apps/ui/modules/queries/reservation.tsx
+++ b/apps/ui/modules/queries/reservation.tsx
@@ -103,6 +103,7 @@ export const LIST_RESERVATIONS = gql`
           name
           bufferTimeBefore
           bufferTimeAfter
+          accessType
           ...ReservationOrderStatus
           paymentOrder {
             id
@@ -176,6 +177,19 @@ export const REFRESH_ORDER = gql`
     refreshOrder(input: $input) {
       orderUuid
       status
+    }
+  }
+`;
+
+export const RESERVATION_ACCESS_CODE = gql`
+  query AccessCode($id: ID!) {
+    reservation(id: $id) {
+      id
+      pindoraInfo {
+        accessCode
+        accessCodeBeginsAt
+        accessCodeEndsAt
+      }
     }
   }
 `;

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -95,6 +95,10 @@ export const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
       ...EquipmentFields
     }
     currentAccessType
+    accessTypes(isActiveOrFuture: true) {
+      accessType
+      beginDate
+    }
   }
 `;
 

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -94,6 +94,7 @@ export const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
       id
       ...EquipmentFields
     }
+    currentAccessType
   }
 `;
 
@@ -172,6 +173,11 @@ export const RESERVATION_UNIT_CARD_FRAGMENT = gql`
       ...Image
     }
     maxPersons
+    currentAccessType
+    accessTypes(isActiveOrFuture: true) {
+      accessType
+      beginDate
+    }
   }
 `;
 
@@ -190,6 +196,9 @@ export const SEARCH_RESERVATION_UNITS = gql`
     $reservationUnitType: [Int]
     $purposes: [Int]
     $equipments: [Int]
+    $accessType: [AccessType]
+    $accessTypeBeginDate: Date
+    $accessTypeEndDate: Date
     $reservableDateStart: Date
     $reservableDateEnd: Date
     $reservableTimeStart: Time
@@ -216,6 +225,9 @@ export const SEARCH_RESERVATION_UNITS = gql`
       reservationUnitType: $reservationUnitType
       purposes: $purposes
       equipments: $equipments
+      accessType: $accessType
+      accessTypeBeginDate: $accessTypeBeginDate
+      accessTypeEndDate: $accessTypeEndDate
       reservableDateStart: $reservableDateStart
       reservableDateEnd: $reservableDateEnd
       reservableTimeStart: $reservableTimeStart
@@ -238,6 +250,7 @@ export const SEARCH_RESERVATION_UNITS = gql`
           reservationEnds
           isClosed
           firstReservableDatetime
+          currentAccessType
           pricings {
             ...PricingFields
           }

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -176,7 +176,6 @@ export const RESERVATION_UNIT_CARD_FRAGMENT = gql`
     currentAccessType
     accessTypes(isActiveOrFuture: true) {
       accessType
-      beginDate
     }
   }
 `;

--- a/apps/ui/modules/queries/reservationUnit.tsx
+++ b/apps/ui/modules/queries/reservationUnit.tsx
@@ -95,7 +95,8 @@ export const RESERVATION_UNIT_PAGE_FRAGMENT = gql`
       ...EquipmentFields
     }
     currentAccessType
-    accessTypes(isActiveOrFuture: true) {
+    accessTypes(isActiveOrFuture: true, orderBy: [beginDateAsc]) {
+      id
       accessType
       beginDate
     }
@@ -178,7 +179,8 @@ export const RESERVATION_UNIT_CARD_FRAGMENT = gql`
     }
     maxPersons
     currentAccessType
-    accessTypes(isActiveOrFuture: true) {
+    accessTypes(isActiveOrFuture: true, orderBy: [beginDateAsc]) {
+      id
       accessType
     }
   }

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -273,15 +273,6 @@ export function processVariables({
   };
 }
 
-export function mapSingleParamToFormValue(
-  param: string | string[] | undefined
-): string | null {
-  if (param == null) return null;
-  if (param === "") return null;
-  if (Array.isArray(param)) return param.join(",");
-  return param;
-}
-
 // default to false if the param is present but not true, null if not present
 export function mapSingleBooleanParamToFormValue(
   param: string | string[] | undefined
@@ -297,39 +288,6 @@ export function mapSingleBooleanParamToFormValue(
   return param === "true";
 }
 
-export function mapQueryParamToStringArray(
-  param: string | string[] | undefined
-): string[] {
-  if (param == null) return [];
-  if (param === "") return [];
-  if (Array.isArray(param)) return param;
-  return [param];
-}
-
-export function mapQueryParamToNumber(
-  param: string | string[] | undefined
-): number | null {
-  if (param == null) return null;
-  if (param === "") return null;
-  if (Array.isArray(param)) {
-    return toNumber(param[0]);
-  }
-  return toNumber(param);
-}
-
-export function mapQueryParamToNumberArray(
-  param: string | string[] | undefined
-): number[] {
-  if (param == null) return [];
-  if (param === "") return [];
-  if (Array.isArray(param)) {
-    return param.map(Number).filter(Number.isInteger);
-  }
-  const v = Number(param);
-  if (Number.isNaN(v)) {
-    return [];
-  }
-  return [v];
 export function mapParamToNumber(param: string[], min?: number): number[] {
   const numbers = param.map(Number).filter(Number.isInteger);
   return min != null ? numbers.filter((n) => n >= min) : numbers;

--- a/apps/ui/modules/urls.ts
+++ b/apps/ui/modules/urls.ts
@@ -98,3 +98,16 @@ export function getReservationUnitPath(pk: Maybe<number> | undefined): string {
   }
   return `${reservationUnitPrefix}/${pk}`;
 }
+
+export function getFeedbackUrl(
+  feedbackUrl: string,
+  i18n: { language: string }
+) {
+  try {
+    const url = new URL(feedbackUrl);
+    url.searchParams.set("lang", i18n.language);
+    return url.toString();
+  } catch (e) {
+    return null;
+  }
+}

--- a/apps/ui/pages/recurring/[id]/index.tsx
+++ b/apps/ui/pages/recurring/[id]/index.tsx
@@ -37,7 +37,7 @@ function SeasonalSearch({
   unitOptions,
   reservationUnitTypeOptions,
   purposeOptions,
-}: NarrowedProps): JSX.Element {
+}: Readonly<NarrowedProps>): JSX.Element {
   const { t, i18n } = useTranslation();
   const searchValues = useSearchParams();
 
@@ -53,6 +53,8 @@ function SeasonalSearch({
     language: i18n.language,
     kind: ReservationKind.Season,
     applicationRound: applicationRound.pk ?? 0,
+    reservationPeriodBegin: applicationRound?.reservationPeriodBegin ?? "",
+    reservationPeriodEnd: applicationRound?.reservationPeriodEnd ?? "",
   });
   const query = useSearchQuery(variables);
   const { data, isLoading, error, fetchMore, previousData } = query;
@@ -129,7 +131,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       notFound: true,
     },
   };
-  if (pk == null || !(pk > 0)) {
+  if (pk == null || pk <= 0) {
     return notFound;
   }
   const { data } = await apolloClient.query<
@@ -167,6 +169,8 @@ export const APPLICATION_ROUND_QUERY = gql`
       nameFi
       nameEn
       nameSv
+      reservationPeriodBegin
+      reservationPeriodEnd
       reservationUnits {
         id
         pk

--- a/apps/ui/pages/reservation/cancel.tsx
+++ b/apps/ui/pages/reservation/cancel.tsx
@@ -8,7 +8,6 @@ import {
   getReservationByOrderUuid,
 } from "@/modules/serverUtils";
 import { useTranslation } from "next-i18next";
-import { mapSingleParamToFormValue } from "@/modules/search";
 import { createApolloClient } from "@/modules/apolloClient";
 import {
   DeleteReservationDocument,
@@ -17,6 +16,7 @@ import {
 } from "@/gql/gql-types";
 import { Breadcrumb } from "@/components/common/Breadcrumb";
 import { reservationsPrefix } from "@/modules/urls";
+import { ignoreMaybeArray } from "common/src/helpers";
 
 // This is the callback page from webstore if user cancels the order
 // TODO this would be nicer if we could use a reservation/[id]/cancelled page (or reservation/[id])
@@ -49,7 +49,7 @@ function Cancel({ apiBaseUrl }: NarrowedProps): JSX.Element {
 export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
-  const orderId = mapSingleParamToFormValue(query.orderId);
+  const orderId = ignoreMaybeArray(query.orderId);
 
   const notFoundValue = {
     notFound: true,

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -25,6 +25,8 @@ import {
   type ApplicationRecurringReservationQueryVariables,
   ApplicationRecurringReservationDocument,
   OrderStatus,
+  useAccessCodeQuery,
+  AccessType,
 } from "@gql/gql-types";
 import Link from "next/link";
 import { createApolloClient } from "@/modules/apolloClient";
@@ -141,7 +143,7 @@ function formatReserveeName(
 function ReserveeBusinessInfo({
   reservation,
   supportedFields,
-}: {
+}: Readonly<{
   reservation: Pick<
     NodeT,
     | "reserveeOrganisationName"
@@ -152,7 +154,7 @@ function ReserveeBusinessInfo({
     | "reserveeEmail"
   >;
   supportedFields: Pick<ReservationMetadataFieldNode, "fieldName">[];
-}): JSX.Element {
+}>): JSX.Element {
   const { t } = useTranslation();
   const arr = [];
   if (containsField(supportedFields, "reserveeOrganisationName")) {
@@ -207,13 +209,13 @@ function ReserveeBusinessInfo({
 function ReserveePersonInfo({
   reservation,
   supportedFields,
-}: {
+}: Readonly<{
   reservation: Pick<
     NodeT,
     "reserveeEmail" | "reserveeFirstName" | "reserveeLastName" | "reserveePhone"
   >;
   supportedFields: Pick<ReservationMetadataFieldNode, "fieldName">[];
-}) {
+}>) {
   const { t } = useTranslation();
   const arr = [];
   if (containsNameField(supportedFields)) {
@@ -253,7 +255,7 @@ function ReserveePersonInfo({
 function ReserveeInfo({
   reservation,
   supportedFields,
-}: {
+}: Readonly<{
   reservation: Pick<
     NodeT,
     | "reserveeType"
@@ -265,7 +267,7 @@ function ReserveeInfo({
     | "reserveeEmail"
   >;
   supportedFields: Pick<ReservationMetadataFieldNode, "fieldName">[];
-}) {
+}>) {
   const { t } = useTranslation();
   const showBusinessFields =
     CustomerTypeChoice.Business === reservation.reserveeType ||
@@ -299,7 +301,7 @@ function LabelValuePair({
   label,
   value,
   testId,
-}: LabelValuePairProps): JSX.Element {
+}: Readonly<LabelValuePairProps>): JSX.Element {
   return (
     <p>
       {label}: <span data-testid={testId}>{value}</span>
@@ -312,7 +314,7 @@ function LabelValuePair({
 function Reservation({
   termsOfUse,
   reservation,
-}: PropsNarrowed): JSX.Element | null {
+}: Readonly<PropsNarrowed>): JSX.Element | null {
   const { t, i18n } = useTranslation();
 
   // NOTE typescript can't type array off index
@@ -497,15 +499,19 @@ function Reservation({
 function TermsInfo({
   reservation,
   termsOfUse,
-}: {
+}: Readonly<{
   reservation: Pick<
     NodeT,
     "reservationUnits" | "begin" | "applyingForFreeOfCharge"
   >;
   termsOfUse: PropsNarrowed["termsOfUse"];
-}) {
+}>) {
   const { t, i18n } = useTranslation();
   const reservationUnit = reservation.reservationUnits.find(() => true);
+  const reservationAccessCode = useAccessCodeQuery({
+    variables: { id: reservation.id },
+    skip: reservation.accessType !== AccessType.AccessCode,
+  });
   const shouldDisplayPricingTerms: boolean = useMemo(() => {
     if (!reservationUnit) {
       return false;
@@ -743,10 +749,10 @@ function getReservationValue(
 function ReservationInfo({
   reservation,
   supportedFields,
-}: {
+}: Readonly<{
   reservation: ReservationInfoFragment;
   supportedFields: Pick<ReservationMetadataFieldNode, "fieldName">[];
-}) {
+}>) {
   const { t, i18n } = useTranslation();
   const POSSIBLE_FIELDS = [
     "purpose",

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -42,7 +42,7 @@ function SearchSingle({
   reservationUnitTypeOptions,
   purposeOptions,
   equipmentsOptions,
-}: Props): JSX.Element {
+}: Readonly<Props>): JSX.Element {
   const { t, i18n } = useTranslation();
 
   const searchValues = useSearchParams();

--- a/apps/ui/pages/success.tsx
+++ b/apps/ui/pages/success.tsx
@@ -11,10 +11,10 @@ import {
 } from "@/modules/serverUtils";
 import { getReservationPath } from "@/modules/urls";
 import { createApolloClient } from "@/modules/apolloClient";
-import { mapSingleParamToFormValue } from "@/modules/search";
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { CenterSpinner } from "common/styles/util";
+import { ignoreMaybeArray } from "common/src/helpers";
 
 // TODO should be moved to /reservations/success
 // but because this is webstore callback page we need to leave the url (use an url rewrite)
@@ -23,7 +23,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
   const { locale, query } = ctx;
   const commonProps = getCommonServerSideProps();
 
-  const orderId = mapSingleParamToFormValue(query.orderId);
+  const orderId = ignoreMaybeArray(query.orderId);
   const notFoundValue = {
     notFound: true,
     props: {

--- a/apps/ui/public/locales/en/common.json
+++ b/apps/ui/public/locales/en/common.json
@@ -4,6 +4,8 @@
   "timeLabel": "Time",
   "dateWithWeekday": "{{date, datetime}}",
   "dayTimeSeparator": ",",
+  "dateGte": "from {{value}}",
+  "dateLte": "until {{value}}",
   "today": "Today",
   "tomorrow": "Tomorrow",
   "day": "Day",

--- a/apps/ui/public/locales/en/reservationUnit.json
+++ b/apps/ui/public/locales/en/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Can only be booked seasonally",
     "futureOpening": "You can make bookings for this item starting on {{date}}."
   },
+  "accessType": "Access to the space",
   "accessTypes": {
     "ACCESS_CODE": "Door code",
     "PHYSICAL_KEY": "Key",

--- a/apps/ui/public/locales/en/reservationUnit.json
+++ b/apps/ui/public/locales/en/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "This item is not available for booking at the moment.",
     "onlyRecurring": "Can only be booked seasonally",
     "futureOpening": "You can make bookings for this item starting on {{date}}."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Door code",
+    "PHYSICAL_KEY": "Key",
+    "OPENED_BY_STAFF": "Staff",
+    "UNRESTRICTED": "Direct access"
   }
 }

--- a/apps/ui/public/locales/en/reservations.json
+++ b/apps/ui/public/locales/en/reservations.json
@@ -120,5 +120,7 @@
     "heading": "Awaiting for payment",
     "body": "Your payment could not be confirmed. Please check the status of your booking in a moment from Your bookings -page. If the booking was unsuccessful, please repeat the booking process. Our customer service will provide assistance if necessary."
   },
-  "confirmNavigation": "If you wish to leave this page, your booking will be cancelled automatically."
+  "confirmNavigation": "If you wish to leave this page, your booking will be cancelled automatically.",
+  "accessCodeDuration": "Door code valid",
+  "contactSupport": "Please contact support."
 }

--- a/apps/ui/public/locales/en/searchForm.json
+++ b/apps/ui/public/locales/en/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Purpose of use",
   "equipmentsFilter": "Equipment",
   "durationFilter": "Duration",
+  "accessTypeFilter": "Access to the space",
   "beginTimeIsBeforeEndTime": "The start time must be before the end time",
   "resetForm": "Clear",
   "filters": {

--- a/apps/ui/public/locales/fi/common.json
+++ b/apps/ui/public/locales/fi/common.json
@@ -4,6 +4,8 @@
   "timeLabel": "Kellonaika",
   "dateWithWeekday": "{{date, datetime}}",
   "dayTimeSeparator": " klo",
+  "dateGte": "{{value}} lähtien",
+  "dateLte": "{{value}} asti",
   "today": "Tänään",
   "tomorrow": "Huomenna",
   "day": "Päivä",

--- a/apps/ui/public/locales/fi/reservationUnit.json
+++ b/apps/ui/public/locales/fi/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Varattavissa vain kausittain.",
     "futureOpening": "Voit tehdä varauksen tähän kohteeseen {{date}} alkaen."
   },
+  "accessType": "Pääsy tilaan",
   "accessTypes": {
     "ACCESS_CODE": "Ovikoodi",
     "PHYSICAL_KEY": "Avain",

--- a/apps/ui/public/locales/fi/reservationUnit.json
+++ b/apps/ui/public/locales/fi/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "Kohde ei ole tällä hetkellä varattavissa.",
     "onlyRecurring": "Varattavissa vain kausittain.",
     "futureOpening": "Voit tehdä varauksen tähän kohteeseen {{date}} alkaen."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Ovikoodi",
+    "PHYSICAL_KEY": "Avain",
+    "OPENED_BY_STAFF": "Henkilökunta",
+    "UNRESTRICTED": "Suora pääsy"
   }
 }

--- a/apps/ui/public/locales/fi/reservations.json
+++ b/apps/ui/public/locales/fi/reservations.json
@@ -116,5 +116,7 @@
     "heading": "Maksu odottaa vahvistusta",
     "body": "Maksuasi ei voitu vielä vahvistaa. Tarkista varauksen tila hetken kuluttua Omat varaukset -sivulta. Jos varaus ei onnistunut, ole hyvä ja tee uusi varaus. Asiakaspalvelumme auttaa tarvittaessa."
   },
-  "confirmNavigation": "Jos haluat poistua tältä sivulta, niin varauksesi peruuntuu automaattisesti"
+  "confirmNavigation": "Jos haluat poistua tältä sivulta, niin varauksesi peruuntuu automaattisesti",
+  "accessCodeDuration": "Ovikoodi voimassa",
+  "contactSupport": "Ota yhteyttä asiakaspalveluun"
 }

--- a/apps/ui/public/locales/fi/searchForm.json
+++ b/apps/ui/public/locales/fi/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Käyttötarkoitus",
   "equipmentsFilter": "Varustelu",
   "durationFilter": "Kesto",
+  "accessTypeFilter": "Pääsy tilaan",
   "beginTimeIsBeforeEndTime": "Alkamisajan on oltava ennen loppumisaikaa",
   "resetForm": "Tyhjennä",
   "filters": {

--- a/apps/ui/public/locales/sv/common.json
+++ b/apps/ui/public/locales/sv/common.json
@@ -4,6 +4,8 @@
   "timeLabel": "Tid",
   "dateWithWeekday": "{{date, datetime}}",
   "dayTimeSeparator": " kl.",
+  "dateGte": "från {{value}}",
+  "dateLte": "till {{value}}",
   "today": "I dag",
   "tomorrow": "I morgon",
   "day": "Dag",

--- a/apps/ui/public/locales/sv/reservationUnit.json
+++ b/apps/ui/public/locales/sv/reservationUnit.json
@@ -54,5 +54,11 @@
     "notReservable": "Objektet går inte att boka just nu.",
     "onlyRecurring": "Kan bokas endast säsongsbokning",
     "futureOpening": "Du kan boka detta objekt från och med {{date}}."
+  },
+  "accessTypes": {
+    "ACCESS_CODE": "Dörrkod",
+    "PHYSICAL_KEY": "Nyckel",
+    "OPENED_BY_STAFF": "Personal",
+    "UNRESTRICTED": "Direkt tillgång"
   }
 }

--- a/apps/ui/public/locales/sv/reservationUnit.json
+++ b/apps/ui/public/locales/sv/reservationUnit.json
@@ -55,6 +55,7 @@
     "onlyRecurring": "Kan bokas endast säsongsbokning",
     "futureOpening": "Du kan boka detta objekt från och med {{date}}."
   },
+  "accessType": "Tillträde till utrymmet",
   "accessTypes": {
     "ACCESS_CODE": "Dörrkod",
     "PHYSICAL_KEY": "Nyckel",

--- a/apps/ui/public/locales/sv/reservations.json
+++ b/apps/ui/public/locales/sv/reservations.json
@@ -120,5 +120,7 @@
     "heading": "Väntar på betalning",
     "body": "Din betalning kunde inte bekräftas. Vänligen kontrollera efter en stund statusen för bokningen från Dina bokningar sidan. Om bokningen misslyckades, vänligen upprepa bokningsprocessen. Vår kundtjänst hjälper dig vid behov."
   },
-  "confirmNavigation": "Om du vill lämna sidan, kommer din bokning att avbokas automatiskt."
+  "confirmNavigation": "Om du vill lämna sidan, kommer din bokning att avbokas automatiskt.",
+  "accessCodeDuration": "Dörrkoden är giltig",
+  "contactSupport": "Vänligen kontakta kundtjänsten."
 }

--- a/apps/ui/public/locales/sv/searchForm.json
+++ b/apps/ui/public/locales/sv/searchForm.json
@@ -13,6 +13,7 @@
   "purposesFilter": "Användningsändamål",
   "equipmentsFilter": "Utrustning",
   "durationFilter": "Varaktighet",
+  "accessTypeFilter": "Tillträde till utrymmet",
   "beginTimeIsBeforeEndTime": "Sluttiden måste vara senare än starttiden",
   "resetForm": "Töm",
   "filters": {

--- a/backend/tests/test_models/test_recurring_reservation.py
+++ b/backend/tests/test_models/test_recurring_reservation.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pytest
 from lookup_property import L
 
-from tilavarauspalvelu.enums import AccessType
+from tilavarauspalvelu.enums import AccessType, AccessTypeWithMultivalued
 from tilavarauspalvelu.models import RecurringReservation
 
 from tests.factories import RecurringReservationFactory, ReservationFactory
@@ -73,7 +73,7 @@ def test__recurring_reservation__access_type__multiple_different():
     ReservationFactory.create(recurring_reservation=series, access_type=AccessType.ACCESS_CODE)
 
     # Test non-ORM code
-    assert series.access_type == AccessType.MULTIVALUED
+    assert series.access_type == AccessTypeWithMultivalued.MULTIVALUED
     assert series.used_access_types == [AccessType.ACCESS_CODE, AccessType.PHYSICAL_KEY]
 
     series = RecurringReservation.objects.annotate(
@@ -82,5 +82,5 @@ def test__recurring_reservation__access_type__multiple_different():
     ).first()
 
     # Test ORM code
-    assert series.access_type == AccessType.MULTIVALUED
+    assert series.access_type == AccessTypeWithMultivalued.MULTIVALUED
     assert series.used_access_types == [AccessType.ACCESS_CODE, AccessType.PHYSICAL_KEY]

--- a/backend/tilavarauspalvelu/admin/reservation/form.py
+++ b/backend/tilavarauspalvelu/admin/reservation/form.py
@@ -15,7 +15,7 @@ from utils.external_service.errors import ExternalServiceError
 class ReservationAdminForm(forms.ModelForm):
     instance: Reservation
 
-    access_type = forms.ChoiceField(choices=AccessType.model_choices, required=False)
+    access_type = forms.ChoiceField(choices=AccessType.choices, required=False)
 
     pindora_response = forms.CharField(
         widget=forms.Textarea(attrs={"disabled": True, "cols": "40", "rows": "1"}),

--- a/backend/tilavarauspalvelu/admin/reservation_unit/form.py
+++ b/backend/tilavarauspalvelu/admin/reservation_unit/form.py
@@ -106,7 +106,7 @@ class ReservationUnitAccessTypeFormSet(BaseInlineFormSet):
 class ReservationUnitAdminForm(forms.ModelForm):
     instance: ReservationUnit
 
-    access_type = forms.ChoiceField(choices=AccessType.model_choices, required=False)
+    access_type = forms.ChoiceField(choices=AccessType.choices, required=False)
 
     pindora_response = forms.CharField(
         widget=forms.Textarea(attrs={"disabled": True, "cols": "40", "rows": "1"}),

--- a/backend/tilavarauspalvelu/enums.py
+++ b/backend/tilavarauspalvelu/enums.py
@@ -1095,6 +1095,18 @@ class AccessType(models.TextChoices):
     PHYSICAL_KEY = "PHYSICAL_KEY", pgettext_lazy("AccessType", "physical key")
     UNRESTRICTED = "UNRESTRICTED", pgettext_lazy("AccessType", "unrestricted")
 
+
+class AccessTypeWithMultivalued(models.TextChoices):
+    """
+    Same as AccessType, but includes the 'MULTIVALUED' option
+    for series and seasonal bookings where access type between reservations varies.
+    """
+
+    ACCESS_CODE = "ACCESS_CODE", pgettext_lazy("AccessType", "access code")
+    OPENED_BY_STAFF = "OPENED_BY_STAFF", pgettext_lazy("AccessType", "opened by staff")
+    PHYSICAL_KEY = "PHYSICAL_KEY", pgettext_lazy("AccessType", "physical key")
+    UNRESTRICTED = "UNRESTRICTED", pgettext_lazy("AccessType", "unrestricted")
+
     # Should not be settable to models, only available in API responses.
     MULTIVALUED = "MULTIVALUED", pgettext_lazy("AccessType", "multi-valued")
 

--- a/backend/tilavarauspalvelu/models/reservation/model.py
+++ b/backend/tilavarauspalvelu/models/reservation/model.py
@@ -77,7 +77,7 @@ class Reservation(SerializableMixin, models.Model):
     # Access information
     access_type: str = models.CharField(
         max_length=20,
-        choices=AccessType.model_choices,
+        choices=AccessType.choices,
         default=AccessType.UNRESTRICTED.value,
     )
     access_code_generated_at: datetime.datetime | None = models.DateTimeField(null=True, blank=True)

--- a/backend/tilavarauspalvelu/models/reservation_unit_access_type/model.py
+++ b/backend/tilavarauspalvelu/models/reservation_unit_access_type/model.py
@@ -34,7 +34,7 @@ class ReservationUnitAccessType(models.Model):
     )
     access_type: AccessType = models.CharField(
         max_length=255,
-        choices=AccessType.model_choices,
+        choices=AccessType.choices,
         default=AccessType.UNRESTRICTED.value,
     )
     begin_date: datetime.date = models.DateField()

--- a/packages/common/src/components/IconButton.tsx
+++ b/packages/common/src/components/IconButton.tsx
@@ -15,7 +15,7 @@ interface IconButtonProps {
   // a HDS-icon element (use `null` if no icon is desired)
   icon: React.ReactNode;
   // the link URI (defaults to "javascript:void(0);" to not interfere with onClick if not in use)
-  href?: string;
+  href?: string | null;
   // should the link open in a new tab (true if href begins "http...", otherwise false by default)
   openInNewTab?: boolean;
   // an optional function to call when clicking the button


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds `accessType` filter to single and recurring search forms
- Displays `accessType` for search results
- Adds `accessType` info to reservation unit page
- Displays reservation `accessType` in my reservations listing results
- Displays `accessType` (and `accessCode` where relevant) in `ReservationInfoCard`
- Adds `accessType` (and `accessCode`) to the reservation page

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing vs the ticket specs

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3762](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3762)
- [TILA-3763](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3763)
- [TILA-3764](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3764)
- [TILA-3790](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3790)
- [TILA-3791](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3791)


[TILA-3762]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3763]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ