### PR TITLE
Remove time from reservation period in application round cards

### DIFF
--- a/apps/ui/components/recurring/ApplicationRoundCard.tsx
+++ b/apps/ui/components/recurring/ApplicationRoundCard.tsx
@@ -13,6 +13,7 @@ import { getApplicationRoundPath } from "@/modules/urls";
 import {
   convertLanguageCode,
   getTranslationSafe,
+  toUIDate,
 } from "common/src/common/util";
 import { gql } from "@apollo/client";
 
@@ -49,7 +50,7 @@ function translateRoundDate(
 
 export function ApplicationRoundCard({
   applicationRound,
-}: CardProps): JSX.Element {
+}: Readonly<CardProps>): JSX.Element {
   const { t, i18n } = useTranslation();
   const lang = convertLanguageCode(i18n.language);
 
@@ -57,8 +58,8 @@ export function ApplicationRoundCard({
   const timeString = translateRoundDate(t, applicationRound);
   const begin = new Date(applicationRound.reservationPeriodBegin);
   const end = new Date(applicationRound.reservationPeriodEnd);
-  const reservationPeriodBegin = formatDateTime(t, begin);
-  const reservationPeriodEnd = formatDateTime(t, end);
+  const reservationPeriodBegin = toUIDate(begin);
+  const reservationPeriodEnd = toUIDate(end);
 
   const reservationPeriod = t(`applicationRound:card.reservationPeriod`, {
     reservationPeriodBegin,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Removes the time from where the application round cards show the reservation period

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests
- Go to recurrable reservations index page - note that the reservation period shows only date with no time specified

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3789](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3789)


[TILA-3789]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ