### PR TITLE
fix: missing reservation number in info card

### DIFF
--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -222,7 +222,7 @@ export function EditStep0({
     <>
       <StyledReservationInfoCard
         reservation={reservation}
-        type="pending"
+        bgColor="gold"
         disableImage
       />
       {/* TODO on mobile in the design this is after the calendar but before action buttons */}

--- a/apps/ui/components/reservation/EditStep1.tsx
+++ b/apps/ui/components/reservation/EditStep1.tsx
@@ -144,7 +144,7 @@ export function EditStep1({
     <>
       <StyledReservationInfoCard
         reservation={modifiedReservation}
-        type="pending"
+        bgColor="gold"
       />
       <StyledForm
         onSubmit={(e) => {

--- a/apps/ui/components/reservation/ReservationCancellation.tsx
+++ b/apps/ui/components/reservation/ReservationCancellation.tsx
@@ -105,7 +105,7 @@ export function ReservationCancellation(props: CancellationProps): JSX.Element {
       {reservation.recurringReservation ? (
         <ApplicationInfoCard reservation={reservation} />
       ) : (
-        <StyledReservationInfoCard reservation={reservation} type="complete" />
+        <StyledReservationInfoCard reservation={reservation} />
       )}
       <CancellationForm
         onNext={onSubmit}

--- a/apps/ui/components/reservation/ReservationInfoCard.tsx
+++ b/apps/ui/components/reservation/ReservationInfoCard.tsx
@@ -28,13 +28,12 @@ import {
   getTranslationSafe,
 } from "common/src/common/util";
 
-const Wrapper = styled.div<{ $type: Type }>`
-  --bg-color-complete: var(--color-silver-light);
-  --bg-color-pending: var(--color-gold-light);
-  background-color: var(
-    ${({ $type }) =>
-      $type === "complete" ? "--bg-color-complete" : "--bg-color-pending"}
+const Wrapper = styled.div<{ $color: "gold" | "silver" }>`
+  --bg-color: var(
+    ${({ $color }) =>
+      $color === "gold" ? "--color-gold-light" : "--color-silver-light"}
   );
+  background-color: var(--bg-color);
 `;
 
 const MainImage = styled.img`
@@ -61,12 +60,12 @@ const Subheading = styled.p`
   margin: 0;
 `;
 
-type Type = "pending" | "complete";
-
 type Props = {
   reservation: ReservationInfoCardFragment;
-  type: Type;
   shouldDisplayReservationUnitPrice?: boolean;
+  // Background color of the card
+  bgColor?: "gold" | "silver";
+  // Hide the reservation unit image
   disableImage?: boolean;
   className?: string;
   style?: React.CSSProperties;
@@ -74,7 +73,7 @@ type Props = {
 
 export function ReservationInfoCard({
   reservation,
-  type,
+  bgColor = "silver",
   shouldDisplayReservationUnitPrice = false,
   disableImage = false,
   className,
@@ -116,8 +115,14 @@ export function ReservationInfoCard({
     lang,
     shouldDisplayReservationUnitPrice
   );
+
+  const { taxPercentageValue, state } = reservation;
+
+  const showReservationNumber =
+    state != null && state !== ReservationStateChoice.Created;
+
   const shouldDisplayTaxPercentage: boolean =
-    reservation.state === ReservationStateChoice.RequiresHandling
+    state === ReservationStateChoice.RequiresHandling
       ? isReservationUnitPaid(reservationUnit.pricings, new Date(begin))
       : Number(reservation?.price) > 0;
 
@@ -130,10 +135,9 @@ export function ReservationInfoCard({
       ? getTranslationSafe(reservationUnit.unit, "name", lang)
       : "-";
 
-  const { taxPercentageValue } = reservation;
   // TODO why does this not use the Card component?
   return (
-    <Wrapper $type={type} className={className} style={style}>
+    <Wrapper $color={bgColor} className={className} style={style}>
       {!disableImage && <MainImage src={imgSrc} alt={name} />}
       <Content data-testid="reservation__reservation-info-card__content">
         <H4 as="h2" $marginBottom="none">
@@ -144,7 +148,7 @@ export function ReservationInfoCard({
             {name}
           </StyledLink>
         </H4>
-        {type === "complete" && (
+        {showReservationNumber && (
           <Subheading>
             {t("reservations:reservationNumber")}:{" "}
             <span data-testid="reservation__reservation-info-card__reservationNumber">

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -357,7 +357,7 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
       <ReservationPageWrapper>
         <StyledReservationInfoCard
           reservation={reservation}
-          type="pending"
+          bgColor="gold"
           shouldDisplayReservationUnitPrice={shouldDisplayReservationUnitPrice}
         />
         {termsOfUse && (

--- a/apps/ui/pages/reservations/[id]/confirmation.tsx
+++ b/apps/ui/pages/reservations/[id]/confirmation.tsx
@@ -57,7 +57,7 @@ function Confirmation({ apiBaseUrl, reservation }: PropsNarrowed) {
     <>
       <Breadcrumb routes={routes} />
       <ReservationPageWrapper $nRows={4}>
-        <ReservationInfoCard reservation={reservation} type="pending" />
+        <ReservationInfoCard reservation={reservation} bgColor="gold" />
         <ReservationConfirmation
           apiBaseUrl={apiBaseUrl}
           reservation={reservation}

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -437,7 +437,7 @@ function Reservation({
           </SubHeading>
         </Flex>
         <div style={{ gridRowEnd: "span 3" }}>
-          <ReservationInfoCard reservation={reservation} type="complete" />
+          <ReservationInfoCard reservation={reservation} />
           <SecondaryActions>
             {reservation.state === ReservationStateChoice.Confirmed && (
               <ButtonLikeExternalLink


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix: missing reservation number in info card
- refactor: reservation number (pk) is shown as long as reservation has been made without control props.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests: e2e robot

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
