### PR TITLE
Reschedule and then set active in Pindora series sync operation

### DIFF
--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_sync_access_code.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_sync_access_code.py
@@ -208,10 +208,10 @@ def test_sync_access_code__reservation__state_indicates_no_access_code(state):
     assert PindoraClient.reschedule_reservation.call_count == 0
 
 
+@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.create_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
-@patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__reservation__in_series(is_active):
     series = RecurringReservationFactory.create()
@@ -229,16 +229,16 @@ def test_sync_access_code__reservation__in_series(is_active):
 
     PindoraService.sync_access_code(obj=reservation)
 
+    assert PindoraService.reschedule_access_code.call_count == 1
+    assert PindoraService.create_access_code.call_count == 0
     assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
     assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
-    assert PindoraService.create_access_code.call_count == 0
-    assert PindoraService.reschedule_access_code.call_count == 1
 
 
-@patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("Not found"))
-@patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("Not found"))
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("Not found"))
 @patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__reservation__in_series__not_found(is_active):
     series = RecurringReservationFactory.create()
@@ -256,17 +256,17 @@ def test_sync_access_code__reservation__in_series__not_found(is_active):
 
     PindoraService.sync_access_code(obj=reservation)
 
-    assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
-    assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
+    assert PindoraService.reschedule_access_code.call_count == 1
     assert PindoraService.create_access_code.call_count == 1
     assert PindoraService.create_access_code.call_args.kwargs["is_active"] is is_active
-    assert PindoraService.reschedule_access_code.call_count == 0
+    assert PindoraService.activate_access_code.call_count == 0
+    assert PindoraService.deactivate_access_code.call_count == 0
 
 
+@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.create_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
-@patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__reservation__in_series__in_seasonal_booking(is_active):
     user = UserFactory.create()
@@ -291,16 +291,16 @@ def test_sync_access_code__reservation__in_series__in_seasonal_booking(is_active
 
     PindoraService.sync_access_code(obj=reservation)
 
+    assert PindoraService.reschedule_access_code.call_count == 1
+    assert PindoraService.create_access_code.call_count == 0
     assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
     assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
-    assert PindoraService.create_access_code.call_count == 0
-    assert PindoraService.reschedule_access_code.call_count == 1
 
 
-@patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("Not found"))
-@patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("Not found"))
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("Not found"))
 @patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__reservation__in_series__in_seasonal_booking__not_found(is_active):
     user = UserFactory.create()
@@ -325,17 +325,17 @@ def test_sync_access_code__reservation__in_series__in_seasonal_booking__not_foun
 
     PindoraService.sync_access_code(obj=reservation)
 
-    assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
-    assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
+    assert PindoraService.reschedule_access_code.call_count == 1
     assert PindoraService.create_access_code.call_count == 1
     assert PindoraService.create_access_code.call_args.kwargs["is_active"] is is_active
-    assert PindoraService.reschedule_access_code.call_count == 0
+    assert PindoraService.activate_access_code.call_count == 0
+    assert PindoraService.deactivate_access_code.call_count == 0
 
 
+@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.create_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
-@patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__series(is_active):
     series = RecurringReservationFactory.create()
@@ -353,16 +353,16 @@ def test_sync_access_code__series(is_active):
 
     PindoraService.sync_access_code(obj=series)
 
+    assert PindoraService.reschedule_access_code.call_count == 1
+    assert PindoraService.create_access_code.call_count == 0
     assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
     assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
-    assert PindoraService.create_access_code.call_count == 0
-    assert PindoraService.reschedule_access_code.call_count == 1
 
 
-@patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("Not found"))
-@patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("Not found"))
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("Not found"))
 @patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__series__not_found(is_active):
     series = RecurringReservationFactory.create()
@@ -380,17 +380,17 @@ def test_sync_access_code__series__not_found(is_active):
 
     PindoraService.sync_access_code(obj=series)
 
-    assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
-    assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
+    assert PindoraService.reschedule_access_code.call_count == 1
     assert PindoraService.create_access_code.call_count == 1
     assert PindoraService.create_access_code.call_args.kwargs["is_active"] is is_active
-    assert PindoraService.reschedule_access_code.call_count == 0
+    assert PindoraService.activate_access_code.call_count == 0
+    assert PindoraService.deactivate_access_code.call_count == 0
 
 
+@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.create_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
-@patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__series__in_seasonal_booking(is_active):
     user = UserFactory.create()
@@ -415,16 +415,16 @@ def test_sync_access_code__series__in_seasonal_booking(is_active):
 
     PindoraService.sync_access_code(obj=series)
 
+    assert PindoraService.reschedule_access_code.call_count == 1
+    assert PindoraService.create_access_code.call_count == 0
     assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
     assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
-    assert PindoraService.create_access_code.call_count == 0
-    assert PindoraService.reschedule_access_code.call_count == 1
 
 
-@patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("Not found"))
-@patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("Not found"))
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("Not found"))
 @patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__series__in_seasonal_booking__not_found(is_active):
     user = UserFactory.create()
@@ -449,17 +449,17 @@ def test_sync_access_code__series__in_seasonal_booking__not_found(is_active):
 
     PindoraService.sync_access_code(obj=series)
 
-    assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
-    assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
+    assert PindoraService.reschedule_access_code.call_count == 1
     assert PindoraService.create_access_code.call_count == 1
     assert PindoraService.create_access_code.call_args.kwargs["is_active"] is is_active
-    assert PindoraService.reschedule_access_code.call_count == 0
+    assert PindoraService.activate_access_code.call_count == 0
+    assert PindoraService.deactivate_access_code.call_count == 0
 
 
+@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.create_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
-@patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__seasonal_booking(is_active):
     user = UserFactory.create()
@@ -484,16 +484,16 @@ def test_sync_access_code__seasonal_booking(is_active):
 
     PindoraService.sync_access_code(obj=section)
 
+    assert PindoraService.reschedule_access_code.call_count == 1
+    assert PindoraService.create_access_code.call_count == 0
     assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
     assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
-    assert PindoraService.create_access_code.call_count == 0
-    assert PindoraService.reschedule_access_code.call_count == 1
 
 
-@patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("Not found"))
-@patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("Not found"))
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("Not found"))
 @patch_method(PindoraService.create_access_code)
-@patch_method(PindoraService.reschedule_access_code)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
 @pytest.mark.parametrize("is_active", [True, False])
 def test_sync_access_code__seasonal_booking__not_found(is_active):
     user = UserFactory.create()
@@ -518,8 +518,8 @@ def test_sync_access_code__seasonal_booking__not_found(is_active):
 
     PindoraService.sync_access_code(obj=section)
 
-    assert PindoraService.activate_access_code.call_count == (1 if is_active else 0)
-    assert PindoraService.deactivate_access_code.call_count == (0 if is_active else 1)
+    assert PindoraService.reschedule_access_code.call_count == 1
     assert PindoraService.create_access_code.call_count == 1
     assert PindoraService.create_access_code.call_args.kwargs["is_active"] is is_active
-    assert PindoraService.reschedule_access_code.call_count == 0
+    assert PindoraService.activate_access_code.call_count == 0
+    assert PindoraService.deactivate_access_code.call_count == 0

--- a/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
+++ b/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
@@ -612,17 +612,17 @@ class PindoraService:
         should_be_active: bool = obj.should_have_active_access_code  # type: ignore[attr-defined]
 
         try:
+            # Reschedule first, so that if there are any reservations that didn't have an access code before,
+            # but have one after a reschedule, they will know that the access code has been generated.
+            cls.reschedule_access_code(obj=obj)
+        except PindoraNotFoundError:
+            # Reservation series and application sections always have an access code, even if it's not active.
+            cls.create_access_code(obj=obj, is_active=should_be_active)
+        else:
             if should_be_active:
                 cls.activate_access_code(obj=obj)
             else:
                 cls.deactivate_access_code(obj=obj)
-
-        except PindoraNotFoundError:
-            # Reservation series and application sections always have an access code, even if it's not active.
-            cls.create_access_code(obj=obj, is_active=should_be_active)
-
-        else:
-            cls.reschedule_access_code(obj=obj)
 
     @classmethod
     def _parse_series_validity_info(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes Pindora series and seasonal booking sync operations to reschedule first and then set active state, so that any reservations moved to access codes get the access code generated info before trying to set active state

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
