### PR TITLE
fix: display proper error message when reservation begins in future

### DIFF
--- a/apps/ui/modules/__tests__/reservation.test.ts
+++ b/apps/ui/modules/__tests__/reservation.test.ts
@@ -17,7 +17,6 @@ import {
   getDurationOptions,
   getNormalizedReservationOrderStatus,
   isReservationEditable,
-  isReservationStartInFuture,
 } from "../reservation";
 import {
   type ReservableMap,
@@ -709,41 +708,6 @@ describe("getCheckoutUrl", () => {
         checkoutUrl: "checkout.url?user=1111-2222-3333-4444",
       })
     ).not.toBeDefined();
-  });
-});
-
-describe("isReservationStartInFuture", () => {
-  test("YES for a reservation that starts in the future", () => {
-    const reservationBegins = addMinutes(new Date(), 10).toISOString();
-    expect(isReservationStartInFuture({ reservationBegins })).toBe(true);
-  });
-
-  test("NO for a reservation that starts in the past", () => {
-    const reservationBegins = addMinutes(new Date(), -10).toISOString();
-    expect(isReservationStartInFuture({ reservationBegins })).toBe(false);
-  });
-
-  test("NO for a reservation that now", () => {
-    const reservationBegins = new Date().toISOString();
-    expect(isReservationStartInFuture({ reservationBegins })).toBe(false);
-    expect(isReservationStartInFuture({})).toBe(false);
-  });
-
-  // Why? the name of the function doesn't make sense here
-  test("YES if start < buffer days", () => {
-    const input = {
-      reservationBegins: addDays(new Date(), 10).toISOString(),
-      reservationsMaxDaysBefore: 9,
-    };
-    expect(isReservationStartInFuture(input)).toBe(true);
-  });
-
-  test("NO if start === buffer days", () => {
-    const input = {
-      reservationBegins: addDays(new Date(), 10).toISOString(),
-      reservationsMaxDaysBefore: 10,
-    };
-    expect(isReservationStartInFuture(input)).toBe(false);
   });
 });
 

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -2,7 +2,6 @@ import {
   addMinutes,
   addSeconds,
   isAfter,
-  addDays,
   roundToNearestMinutes,
   differenceInMinutes,
   set,
@@ -340,23 +339,6 @@ export function getCheckoutUrl(
     console.error(e);
   }
   return undefined;
-}
-
-export function isReservationStartInFuture(
-  reservationUnit: Pick<
-    ReservationUnitNode,
-    "reservationBegins" | "reservationsMaxDaysBefore"
-  >,
-  now = new Date()
-): boolean {
-  const { reservationBegins, reservationsMaxDaysBefore } = reservationUnit;
-  const bufferDays = reservationsMaxDaysBefore ?? 0;
-  const negativeBuffer = Math.abs(bufferDays) * -1;
-
-  return (
-    !!reservationBegins &&
-    now < addDays(new Date(reservationBegins), negativeBuffer)
-  );
 }
 
 export function getNewReservation({

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -62,7 +62,6 @@ import {
   convertFormToFocustimeSlot,
   createDateTime,
   getDurationOptions,
-  isReservationStartInFuture,
 } from "@/modules/reservation";
 import {
   clampDuration,
@@ -603,9 +602,6 @@ function ReservationUnit({
     blockingReservations,
   });
 
-  const isUnitReservable =
-    !isReservationStartInFuture(reservationUnit) && reservationUnitIsReservable;
-
   return (
     <ReservationUnitPageWrapper>
       <Head
@@ -621,7 +617,7 @@ function ReservationUnit({
         }
       />
       <div>
-        {isUnitReservable && (
+        {reservationUnitIsReservable && (
           <QuickReservation
             reservationUnit={reservationUnit}
             reservationForm={reservationForm}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: show reservable in the future error message based only on the reservable datetime backend provides.
- Refactor: remove unnecessary utility function.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: check ticket.
- Automation: e2e robot.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3905](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3905)


[TILA-3905]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ