### PR TITLE
Fix access code active issues

### DIFF
--- a/backend/tests/test_graphql_api/test_recurring_reservation/test_add_reservation.py
+++ b/backend/tests/test_graphql_api/test_recurring_reservation/test_add_reservation.py
@@ -1,17 +1,22 @@
 from __future__ import annotations
 
 import datetime
+from typing import TYPE_CHECKING
 
 import pytest
 from freezegun import freeze_time
 
 from tilavarauspalvelu.enums import AccessType
 from tilavarauspalvelu.integrations.keyless_entry.service import PindoraService
-from utils.date_utils import DEFAULT_TIMEZONE, local_datetime
+from utils.date_utils import DEFAULT_TIMEZONE, local_date, local_datetime
 
+from tests.factories import ReservationUnitAccessTypeFactory
 from tests.helpers import patch_method
 
 from .helpers import ADD_RESERVATION_TO_SERIES_MUTATION, create_reservation_series, get_minimal_add_data
+
+if TYPE_CHECKING:
+    from tilavarauspalvelu.models import Reservation
 
 pytestmark = [
     pytest.mark.django_db,
@@ -81,9 +86,13 @@ def test_recurring_reservations__add_reservation__begin_after_end(graphql):
 def test_recurring_reservations__add_reservation__access_code(graphql):
     recurring_reservation = create_reservation_series(
         reservation_unit__access_types__access_type=AccessType.ACCESS_CODE,
+        reservations__access_type=AccessType.ACCESS_CODE,
+        reservations__access_code_is_active=True,
+        reservations__access_code_generated_at=local_datetime(2024, 1, 1),
     )
 
     assert recurring_reservation.reservations.count() == 9
+    existing = list(recurring_reservation.reservations.values_list("pk", flat=True))
 
     data = get_minimal_add_data(recurring_reservation)
 
@@ -93,5 +102,58 @@ def test_recurring_reservations__add_reservation__access_code(graphql):
     assert response.has_errors is False
 
     assert recurring_reservation.reservations.count() == 10
+    new_reservation: Reservation | None = recurring_reservation.reservations.exclude(pk__in=existing).first()
+
+    assert new_reservation is not None
+
+    assert new_reservation.access_type == AccessType.ACCESS_CODE
+
+    # These are the default, will be updated by rescheduling.
+    assert new_reservation.access_code_is_active is False
+    assert new_reservation.access_code_generated_at is None
 
     assert PindoraService.reschedule_access_code.called is True
+
+
+@freeze_time(local_datetime(2024, 1, 1))
+@patch_method(PindoraService.reschedule_access_code)
+def test_recurring_reservations__add_reservation__new_one_is_not_access_code(graphql):
+    recurring_reservation = create_reservation_series(
+        reservations__access_type=AccessType.ACCESS_CODE,
+        reservations__access_code_is_active=True,
+        reservations__access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    ReservationUnitAccessTypeFactory.create(
+        reservation_unit=recurring_reservation.reservation_unit,
+        access_type=AccessType.ACCESS_CODE,
+        begin_date=local_date(2023, 1, 1),
+    )
+
+    ReservationUnitAccessTypeFactory.create(
+        reservation_unit=recurring_reservation.reservation_unit,
+        access_type=AccessType.PHYSICAL_KEY,
+        begin_date=local_date(2024, 1, 1),
+    )
+
+    assert recurring_reservation.reservations.count() == 9
+    existing = list(recurring_reservation.reservations.values_list("pk", flat=True))
+
+    data = get_minimal_add_data(recurring_reservation)
+
+    graphql.login_with_superuser()
+    response = graphql(ADD_RESERVATION_TO_SERIES_MUTATION, input_data=data)
+
+    assert response.has_errors is False
+
+    assert recurring_reservation.reservations.count() == 10
+    new_reservation: Reservation | None = recurring_reservation.reservations.exclude(pk__in=existing).first()
+
+    assert new_reservation is not None
+
+    assert new_reservation.access_type == AccessType.PHYSICAL_KEY
+    assert new_reservation.access_code_is_active is False
+    assert new_reservation.access_code_generated_at is None
+
+    # No need to call Pindora if this reservation doesn't add an access code.
+    assert PindoraService.reschedule_access_code.called is False

--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_activate_access_code.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_activate_access_code.py
@@ -61,6 +61,17 @@ def test_activate_access_code__reservation__in_series():
         access_code_is_active=False,
         access_code_generated_at=local_datetime(),
     )
+    reservation_3 = ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 16),
+        end=local_datetime(2024, 1, 1, 17),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
 
     with patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_204_NO_CONTENT)):
         PindoraService.activate_access_code(obj=reservation_1)
@@ -70,6 +81,9 @@ def test_activate_access_code__reservation__in_series():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is True
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is False
 
 
 def test_activate_access_code__reservation__in_series__in_seasonal_booking():
@@ -104,6 +118,18 @@ def test_activate_access_code__reservation__in_series__in_seasonal_booking():
         access_code_is_active=False,
         access_code_generated_at=local_datetime(),
     )
+    reservation_3 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 16),
+        end=local_datetime(2024, 1, 1, 17),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
 
     with patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_204_NO_CONTENT)):
         PindoraService.activate_access_code(obj=reservation_1)
@@ -113,6 +139,9 @@ def test_activate_access_code__reservation__in_series__in_seasonal_booking():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is True
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is False
 
 
 def test_activate_access_code__series():
@@ -139,6 +168,17 @@ def test_activate_access_code__series():
         access_code_is_active=False,
         access_code_generated_at=local_datetime(),
     )
+    reservation_3 = ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
 
     with patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_204_NO_CONTENT)):
         PindoraService.activate_access_code(obj=series)
@@ -148,6 +188,9 @@ def test_activate_access_code__series():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is True
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is False
 
 
 def test_activate_access_code__series__in_seasonal_booking():
@@ -182,6 +225,18 @@ def test_activate_access_code__series__in_seasonal_booking():
         access_code_is_active=False,
         access_code_generated_at=local_datetime(),
     )
+    reservation_3 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
 
     with patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_204_NO_CONTENT)):
         PindoraService.activate_access_code(obj=series)
@@ -191,6 +246,9 @@ def test_activate_access_code__series__in_seasonal_booking():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is True
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is False
 
 
 def test_activate_access_code__seasonal_booking():
@@ -225,6 +283,18 @@ def test_activate_access_code__seasonal_booking():
         access_code_is_active=False,
         access_code_generated_at=local_datetime(),
     )
+    reservation_3 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
 
     with patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_204_NO_CONTENT)):
         PindoraService.activate_access_code(obj=section)
@@ -234,3 +304,6 @@ def test_activate_access_code__seasonal_booking():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is True
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is False

--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_deactivate_access_code.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_deactivate_access_code.py
@@ -25,7 +25,7 @@ def test_deactivate_access_code__reservation():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
@@ -46,11 +46,22 @@ def test_deactivate_access_code__reservation__in_series():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
     reservation_2 = ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
+    reservation_3 = ReservationFactory.create(
         reservation_units=[series.reservation_unit],
         recurring_reservation=series,
         begin=local_datetime(2024, 1, 1, 14),
@@ -70,6 +81,9 @@ def test_deactivate_access_code__reservation__in_series():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is False
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is True
 
 
 def test_deactivate_access_code__reservation__in_series__in_seasonal_booking():
@@ -88,11 +102,23 @@ def test_deactivate_access_code__reservation__in_series__in_seasonal_booking():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
     reservation_2 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
+    reservation_3 = ReservationFactory.create(
         user=user,
         reservation_units=[series.reservation_unit],
         recurring_reservation=series,
@@ -114,6 +140,9 @@ def test_deactivate_access_code__reservation__in_series__in_seasonal_booking():
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is False
 
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is True
+
 
 def test_deactivate_access_code__series():
     series = RecurringReservationFactory.create()
@@ -124,11 +153,22 @@ def test_deactivate_access_code__series():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
     reservation_2 = ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
+    reservation_3 = ReservationFactory.create(
         reservation_units=[series.reservation_unit],
         recurring_reservation=series,
         begin=local_datetime(2024, 1, 1, 14),
@@ -148,6 +188,9 @@ def test_deactivate_access_code__series():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is False
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is True
 
 
 def test_deactivate_access_code__series__in_seasonal_booking():
@@ -166,11 +209,23 @@ def test_deactivate_access_code__series__in_seasonal_booking():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
     reservation_2 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
+    reservation_3 = ReservationFactory.create(
         user=user,
         reservation_units=[series.reservation_unit],
         recurring_reservation=series,
@@ -192,6 +247,9 @@ def test_deactivate_access_code__series__in_seasonal_booking():
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is False
 
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is True
+
 
 def test_deactivate_access_code__seasonal_booking():
     user = UserFactory.create()
@@ -209,11 +267,23 @@ def test_deactivate_access_code__seasonal_booking():
         end=local_datetime(2024, 1, 1, 13),
         access_type=AccessType.ACCESS_CODE,
         state=ReservationStateChoice.CONFIRMED,
-        type=ReservationTypeChoice.NORMAL,
+        type=ReservationTypeChoice.BLOCKED,
         access_code_is_active=True,
         access_code_generated_at=local_datetime(),
     )
     reservation_2 = ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 14),
+        end=local_datetime(2024, 1, 1, 15),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(),
+    )
+    reservation_3 = ReservationFactory.create(
         user=user,
         reservation_units=[series.reservation_unit],
         recurring_reservation=series,
@@ -234,3 +304,6 @@ def test_deactivate_access_code__seasonal_booking():
 
     reservation_2.refresh_from_db()
     assert reservation_2.access_code_is_active is False
+
+    reservation_3.refresh_from_db()
+    assert reservation_3.access_code_is_active is True

--- a/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
+++ b/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
@@ -282,12 +282,12 @@ class PindoraService:
         match obj:
             case ApplicationSection():
                 PindoraClient.activate_seasonal_booking_access_code(obj)
-                obj.actions.get_reservations().requires_active_access_code().update(access_code_is_active=True)
+                obj.actions.get_reservations().update_access_code_is_active()
 
             case RecurringReservation():
                 if obj.allocated_time_slot is None:
                     PindoraClient.activate_reservation_series_access_code(obj)
-                    obj.reservations.requires_active_access_code().update(access_code_is_active=True)
+                    obj.reservations.update_access_code_is_active()
                     return
 
                 section = obj.allocated_time_slot.reservation_unit_option.application_section
@@ -313,12 +313,12 @@ class PindoraService:
         match obj:
             case ApplicationSection():
                 PindoraClient.deactivate_seasonal_booking_access_code(obj)
-                obj.actions.get_reservations().requires_active_access_code().update(access_code_is_active=False)
+                obj.actions.get_reservations().update_access_code_is_active()
 
             case RecurringReservation():
                 if obj.allocated_time_slot is None:
                     PindoraClient.deactivate_reservation_series_access_code(obj)
-                    obj.reservations.requires_active_access_code().update(access_code_is_active=False)
+                    obj.reservations.update_access_code_is_active()
                     return
 
                 section = obj.allocated_time_slot.reservation_unit_option.application_section

--- a/backend/tilavarauspalvelu/models/reservation/queryset.py
+++ b/backend/tilavarauspalvelu/models/reservation/queryset.py
@@ -268,6 +268,22 @@ class ReservationQuerySet(models.QuerySet):
             ),
         )
 
+    def update_access_code_is_active(self) -> None:
+        """
+        Sets access code info to reservations in the queryset so that reservation that should have
+        active access codes get the given values, and the rest get empty values.
+        """
+        self.update(
+            access_code_is_active=models.Case(
+                models.When(
+                    L(access_code_should_be_active=True),
+                    then=models.Value(True),  # noqa: FBT003
+                ),
+                default=models.Value(False),  # noqa: FBT003
+                output_field=models.BooleanField(),
+            ),
+        )
+
     def upsert_statistics(self, *, reservation_pks: list[int]) -> None:
         reservations = (
             self.filter(pk__in=reservation_pks)


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

Fixes two issues with the access code active state:

1. Adding new reservations to a series now correctly clears `access_code_is_active` and `access_code_generated_at` if the new reservation doesn't require access codes
2. Activating or deactivating an access code for a series or application section now respectively deactivates or activates the access code for all other reservations.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3917](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3917)
- [TILA-3918](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3918)


[TILA-3917]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3918]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3918?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ