### PR TITLE
Allow empty series and sections in Pindora

### DIFF
--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_client/test_reservation_series.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_client/test_reservation_series.py
@@ -4,7 +4,6 @@ import pytest
 import requests
 from graphene_django_extensions.testing import parametrize_helper
 from rest_framework.status import (
-    HTTP_200_OK,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
@@ -19,7 +18,6 @@ from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
 from tilavarauspalvelu.integrations.keyless_entry.exceptions import (
     PindoraAPIError,
     PindoraBadRequestError,
-    PindoraClientError,
     PindoraConflictError,
     PindoraNotFoundError,
     PindoraPermissionError,
@@ -216,11 +214,14 @@ def test_pindora_client__create_reservation_series__errors(status_code, exceptio
 def test_pindora_client__create_reservation_series__no_reservations():
     series = RecurringReservationFactory.create()
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_reservation_series_response(reservation_unit_code_validity=[])
 
-    msg = f"No reservations require an access code in reservation series '{series.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
+
+    with patch as mock:
         PindoraClient.create_reservation_series(series)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -233,11 +234,14 @@ def test_pindora_client__create_reservation_series__no_confirmed_reservations():
         access_type=AccessType.ACCESS_CODE,
     )
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_reservation_series_response(reservation_unit_code_validity=[])
 
-    msg = f"No reservations require an access code in reservation series '{series.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
+
+    with patch as mock:
         PindoraClient.create_reservation_series(series)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -298,11 +302,14 @@ def test_pindora_client__reschedule_reservation_series__errors(status_code, exce
 def test_pindora_client__reschedule_reservation_series__no_reservations():
     series = RecurringReservationFactory.create()
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_access_code_modify_response()
 
-    msg = f"No confirmed reservations in reservation series '{series.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
+
+    with patch as mock:
         PindoraClient.reschedule_reservation_series(series)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -315,11 +322,14 @@ def test_pindora_client__reschedule_reservation_series__no_confirmed_reservation
         access_type=AccessType.ACCESS_CODE,
     )
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_access_code_modify_response()
 
-    msg = f"No confirmed reservations in reservation series '{series.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
+
+    with patch as mock:
         PindoraClient.reschedule_reservation_series(series)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 def test_pindora_client__delete_reservation_series():

--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_client/test_seasonal_booking.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_client/test_seasonal_booking.py
@@ -4,7 +4,6 @@ import pytest
 import requests
 from graphene_django_extensions.testing import parametrize_helper
 from rest_framework.status import (
-    HTTP_200_OK,
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_403_FORBIDDEN,
@@ -18,7 +17,6 @@ from tilavarauspalvelu.enums import AccessType, ReservationStateChoice, Reservat
 from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
 from tilavarauspalvelu.integrations.keyless_entry.exceptions import (
     PindoraBadRequestError,
-    PindoraClientError,
     PindoraConflictError,
     PindoraNotFoundError,
     PindoraPermissionError,
@@ -204,11 +202,13 @@ def test_pindora_client__create_seasonal_booking__errors(status_code, exception,
 def test_pindora_client__create_seasonal_booking__no_reservations():
     application_section = ApplicationSectionFactory.create()
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_seasonal_booking_response()
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
 
-    msg = f"No reservations require an access code in seasonal booking '{application_section.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    with patch as mock:
         PindoraClient.create_seasonal_booking(application_section)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -225,11 +225,13 @@ def test_pindora_client__create_seasonal_booking__no_confirmed_reservations():
         state=ReservationStateChoice.DENIED,
     )
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_seasonal_booking_response()
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
 
-    msg = f"No reservations require an access code in seasonal booking '{application_section.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    with patch as mock:
         PindoraClient.create_seasonal_booking(application_section)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -302,11 +304,13 @@ def test_pindora_client__reschedule_seasonal_booking__errors(status_code, except
 def test_pindora_client__reschedule_seasonal_booking__no_reservations():
     application_section = ApplicationSectionFactory.create()
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_access_code_modify_response()
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
 
-    msg = f"No confirmed reservations in seasonal booking '{application_section.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    with patch as mock:
         PindoraClient.reschedule_seasonal_booking(application_section)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 @pytest.mark.django_db
@@ -323,11 +327,13 @@ def test_pindora_client__reschedule_seasonal_booking__no_confirmed_reservations(
         state=ReservationStateChoice.DENIED,
     )
 
-    patch = patch_method(PindoraClient.request, return_value=ResponseMock(status_code=HTTP_200_OK))
+    data = default_access_code_modify_response()
+    patch = patch_method(PindoraClient.request, return_value=ResponseMock(json_data=data))
 
-    msg = f"No confirmed reservations in seasonal booking '{application_section.ext_uuid}'."
-    with patch, pytest.raises(PindoraClientError, match=exact(msg)):
+    with patch as mock:
         PindoraClient.reschedule_seasonal_booking(application_section)
+
+    assert mock.call_args.kwargs["json"]["series"] == []
 
 
 def test_pindora_client__delete_seasonal_booking():

--- a/backend/tilavarauspalvelu/integrations/keyless_entry/client.py
+++ b/backend/tilavarauspalvelu/integrations/keyless_entry/client.py
@@ -22,7 +22,6 @@ from utils.external_service.base_external_service_client import BaseExternalServ
 from .exceptions import (
     PindoraBadRequestError,
     PindoraClientConfigurationError,
-    PindoraClientError,
     PindoraConflictError,
     PindoraInvalidValueError,
     PindoraMissingKeyError,
@@ -482,10 +481,6 @@ class PindoraSeasonalBookingClient(BasePindoraClient):
             .select_related("recurring_reservation__reservation_unit")
         )
 
-        if not reservations:
-            msg = f"No reservations require an access code in seasonal booking '{section.ext_uuid}'."
-            raise PindoraClientError(msg)
-
         data = PindoraSeasonalBookingCreateData(
             seasonal_booking_id=str(section.ext_uuid),
             series=[
@@ -522,10 +517,6 @@ class PindoraSeasonalBookingClient(BasePindoraClient):
             .requires_active_access_code()
             .select_related("recurring_reservation__reservation_unit")
         )
-
-        if not reservations:
-            msg = f"No confirmed reservations in seasonal booking '{section.ext_uuid}'."
-            raise PindoraClientError(msg)
 
         data = PindoraSeasonalBookingRescheduleData(
             series=[
@@ -747,10 +738,6 @@ class PindoraReservationSeriesClient(BasePindoraClient):
 
         reservations: list[Reservation] = list(series.reservations.requires_active_access_code())
 
-        if not reservations:
-            msg = f"No reservations require an access code in reservation series '{series.ext_uuid}'."
-            raise PindoraClientError(msg)
-
         data = PindoraReservationSeriesCreateData(
             reservation_series_id=str(series.ext_uuid),
             reservation_unit_id=str(series.reservation_unit.uuid),
@@ -783,10 +770,6 @@ class PindoraReservationSeriesClient(BasePindoraClient):
 
         # This only selects confirmed non-blocking reservations.
         reservations: list[Reservation] = list(series.reservations.requires_active_access_code())
-
-        if not reservations:
-            msg = f"No confirmed reservations in reservation series '{series.ext_uuid}'."
-            raise PindoraClientError(msg)
 
         data = PindoraReservationSeriesRescheduleData(
             series=[

--- a/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
+++ b/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
@@ -18,7 +18,7 @@ from utils.date_utils import DEFAULT_TIMEZONE
 from utils.external_service.errors import ExternalServiceError
 
 from .client import PindoraClient
-from .exceptions import PindoraClientError, PindoraConflictError, PindoraInvalidValueError, PindoraNotFoundError
+from .exceptions import PindoraAPIError, PindoraClientError, PindoraConflictError, PindoraNotFoundError
 from .typing import PindoraAccessCodeModifyResponse, PindoraAccessCodePeriod
 
 if TYPE_CHECKING:
@@ -133,7 +133,8 @@ class PindoraService:
                 validity = next(next_valid, None)
 
                 if validity is None:
-                    raise PindoraInvalidValueError(entity="reservation", error="Access code not found")
+                    msg = "Access code is not valid for this reservation"
+                    raise PindoraAPIError(msg)
 
                 return PindoraReservationInfoData(
                     access_code=series_data.access_code,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Our current series cancellation operation wants to leave an empty series in Pindora. Allow this in `PindoraClient` as well.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3919](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3919)


[TILA-3919]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ