### PR TITLE
Fix HTML formatting for "access code unavailable instructions" in emails

### DIFF
--- a/backend/templates/email/html/partials/access_code.jinja
+++ b/backend/templates/email/html/partials/access_code.jinja
@@ -4,6 +4,6 @@
 <mj-text>{{ access_code_label | safe }}: {{ access_code }}</mj-text>
 <mj-text>{{ access_code_validity_period_label | safe }}: {{ access_code_validity_period }}</mj-text>
 {% else %}
-<mj-text>{{ text_access_code_unavailable_instructions_html | sentence }}</mj-text>
+<mj-text>{{ text_access_code_unavailable_instructions_html | sentence | safe }}</mj-text>
 {% endif %}
 {% endif %}

--- a/backend/templates/email/html/partials/access_code_with_instructions.jinja
+++ b/backend/templates/email/html/partials/access_code_with_instructions.jinja
@@ -1,10 +1,10 @@
 {% if access_code_is_used %}
 <mj-spacer />
 {% if access_code %}
-<mj-text>{{ text_access_code_to_access | sentence }}</mj-text>
+<mj-text>{{ text_access_code_to_access | sentence | safe }}</mj-text>
 <mj-text>{{ access_code_label | safe }}: {{ access_code }}</mj-text>
 <mj-text>{{ access_code_validity_period_label | safe }}: {{ access_code_validity_period }}</mj-text>
 {% else %}
-<mj-text>{{ text_access_code_unavailable_instructions_html | sentence }}</mj-text>
+<mj-text>{{ text_access_code_unavailable_instructions_html | sentence | safe }}</mj-text>
 {% endif %}
 {% endif %}

--- a/backend/templates/email/text/application_in_allocation.jinja
+++ b/backend/templates/email/text/application_in_allocation.jinja
@@ -1,6 +1,6 @@
 {{ salutation | safe }}
 
-{{ text_application_in_allocation | safe | sentence }} {{ text_view_application | sentence | safe }}
+{{ text_application_in_allocation | sentence | safe }} {{ text_view_application | sentence | safe }}
 
 {% include "email/text/partials/closing_polite.jinja" %}
 

--- a/backend/templates/email/text/partials/access_code.jinja
+++ b/backend/templates/email/text/partials/access_code.jinja
@@ -2,5 +2,5 @@
 {{ access_code_label | safe }}: {{ access_code }}
 {{ access_code_validity_period_label | safe }}: {{ access_code_validity_period }}
 {% else %}
-{{ text_access_code_unavailable_instructions | safe | sentence }}
+{{ text_access_code_unavailable_instructions | sentence | safe }}
 {% endif %}{% endif %}

--- a/backend/templates/email/text/partials/access_code_with_instructions.jinja
+++ b/backend/templates/email/text/partials/access_code_with_instructions.jinja
@@ -1,7 +1,7 @@
 {% if access_code_is_used %}{% if access_code %}
-{{ text_access_code_to_access | sentence }}
+{{ text_access_code_to_access | sentence | safe }}
 {{ access_code_label | safe }}: {{ access_code }}
 {{ access_code_validity_period_label | safe }}: {{ access_code_validity_period }}
 {% else %}
-{{ text_access_code_unavailable_instructions | safe | sentence }}
+{{ text_access_code_unavailable_instructions | sentence | safe }}
 {% endif %}{% endif %}

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
@@ -470,10 +470,9 @@ def test_render_reservation_approved__access_code_error__html():
     text_content = html_email_to_text(html_content)
 
     access_code_text = (
-        "You can see the door code on the "
-        "<a href=\"https://fake.varaamo.hel.fi/en/reservations\">'My bookings' page</a> at Varaamo. "
-        "If the code is not visible in your booking details, please contact "
-        '<a href="https://fake.varaamo.hel.fi/feedback?lang=en">Varaamo customer service</a>.'
+        "You can see the door code on the ['My bookings' page](https://fake.varaamo.hel.fi/en/reservations) at "
+        "Varaamo. If the code is not visible in your booking details, "
+        "please contact [Varaamo customer service](https://fake.varaamo.hel.fi/feedback?lang=en)."
     )
 
     assert text_content == cleandoc(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix HTML formatting for "access code unavailable instructions" in emails

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3890](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3890)


[TILA-3890]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3890?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ