### PR TITLE
Try to prevent reservation statistics update errors

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -258,6 +258,9 @@ task-tags = ["TODO", "FIXME", "XXX", "type"]
 "tilavarauspalvelu/models/*/actions.py" = [
     "B903",     # Don't complain about converting ModelActions to a dataclass
 ]
+"tilavarauspalvelu/signals.py" = [
+    "ARG001",   # Signals can have unused "sender" argument.
+]
 "tilavarauspalvelu/management/commands/data_creation/*.py" = [
     "PLR0913",  # Can take as many arguments as needed.
     "PLR0915",  # Can have as many statements as needed.

--- a/backend/sonar-project.properties
+++ b/backend/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.python.coverage.reportPaths=coverage.xml
 sonar.test.inclusions=**tests**/*
 
 # Set up rule ignores
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14
 
 # Pseudorandom number generators are safe here
 sonar.issue.ignore.multicriteria.e1.ruleKey=python:S2245
@@ -58,3 +58,12 @@ sonar.issue.ignore.multicriteria.e10.resourceKey=**/*.py
 # Don't validate line length, ruff does that already
 sonar.issue.ignore.multicriteria.e11.ruleKey=python:LineLength
 sonar.issue.ignore.multicriteria.e11.resourceKey=**/*.py
+# Don't check names, as SonarCloud can falsely detect them
+sonar.issue.ignore.multicriteria.e12.ruleKey=python:S5953
+sonar.issue.ignore.multicriteria.e12.resourceKey=**/*.py
+# Don't check file length
+sonar.issue.ignore.multicriteria.e13.ruleKey=python:S104
+sonar.issue.ignore.multicriteria.e13.resourceKey=**/*.py
+# Don't check identical implementations
+sonar.issue.ignore.multicriteria.e14.ruleKey=python:S4144
+sonar.issue.ignore.multicriteria.e14.resourceKey=**/*.py

--- a/backend/tests/test_admin/test_django_admin_site.py
+++ b/backend/tests/test_admin/test_django_admin_site.py
@@ -17,7 +17,6 @@ from tilavarauspalvelu.models.bug_report.model import (
     BugReportTargetChoice,
     BugReportUserChoice,
 )
-from tilavarauspalvelu.tasks import create_or_update_reservation_statistics
 from utils.date_utils import local_datetime
 
 from tests import factories
@@ -66,7 +65,7 @@ def create_all_models():
             found_at=local_datetime(),
         )
 
-        create_or_update_reservation_statistics(Reservation.objects.values_list("pk", flat=True))
+        Reservation.objects.all().upsert_statistics()
 
 
 @patch_method(

--- a/backend/tests/test_graphql_api/test_recurring_reservation/test_reschedule_series.py
+++ b/backend/tests/test_graphql_api/test_recurring_reservation/test_reschedule_series.py
@@ -11,7 +11,6 @@ from tilavarauspalvelu.integrations.email.main import EmailService
 from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError
 from tilavarauspalvelu.integrations.keyless_entry.service import PindoraService
 from tilavarauspalvelu.models import AffectingTimeSpan, ReservationStatistic, ReservationUnitHierarchy
-from tilavarauspalvelu.tasks import create_or_update_reservation_statistics
 from utils.date_utils import DEFAULT_TIMEZONE, combine, local_date, local_datetime, local_time
 
 from tests.factories import RecurringReservationFactory, ReservationFactory
@@ -658,7 +657,7 @@ def test_recurring_reservations__reschedule_series__create_statistics(graphql, s
 
     recurring_reservation = create_reservation_series()
 
-    create_or_update_reservation_statistics(recurring_reservation.reservations.values_list("pk", flat=True))
+    recurring_reservation.reservations.upsert_statistics()
 
     # We have 9 reservations, so there should be 9 reservation statistics.
     assert ReservationStatistic.objects.count() == 9
@@ -686,7 +685,7 @@ def test_recurring_reservations__reschedule_series__create_statistics__partial(g
 
     recurring_reservation = create_reservation_series()
 
-    create_or_update_reservation_statistics(recurring_reservation.reservations.values_list("pk", flat=True))
+    recurring_reservation.reservations.upsert_statistics()
 
     # We have 9 reservations, so there should be 9 reservation statistics.
     assert ReservationStatistic.objects.count() == 9

--- a/backend/tilavarauspalvelu/api/rest/views.py
+++ b/backend/tilavarauspalvelu/api/rest/views.py
@@ -82,7 +82,7 @@ def csrf_view(request: WSGIRequest) -> HttpResponseRedirect | JsonResponse:  # N
     # > the CSRF token on a traditional Django website. The browser's same-origin policy
     # > prevents an attacker from getting access to the token with a cross-origin request.
     # Additionally, our backend's CORS policy only allows cross-origin requests from the frontend.
-    redirect_to: str | None = request.GET.get("redirect_to", None)
+    redirect_to: str | None = request.GET.get("redirect_to", None)  # NOSONAR
     # Set these META-flags to force `django.middleware.csrf.CsrfViewMiddleware` to update the CSRF cookie.
     request.META["CSRF_COOKIE_NEEDS_UPDATE"] = True
     request.META["CSRF_COOKIE"] = get_token(request)
@@ -93,7 +93,7 @@ def csrf_view(request: WSGIRequest) -> HttpResponseRedirect | JsonResponse:  # N
     headers = {"NewCSRFToken": request.META["CSRF_COOKIE"]}
     if redirect_to is None:
         return JsonResponse(data={"csrfToken": request.META["CSRF_COOKIE"]}, status=200, headers=headers)
-    return HttpResponseRedirect(redirect_to=redirect_to, headers=headers)
+    return HttpResponseRedirect(redirect_to=redirect_to, headers=headers)  # NOSONAR
 
 
 @require_GET

--- a/backend/tilavarauspalvelu/models/application_round/actions.py
+++ b/backend/tilavarauspalvelu/models/application_round/actions.py
@@ -73,6 +73,7 @@ class ApplicationRoundActions:
                         PindoraService.delete_access_code(obj=section)
 
                 # Remove all recurring reservations, and set application round back to HANDLED
+                # NOTE: This triggers _a lot_ of `post_delete` signals fo reservations.
                 Reservation.objects.for_application_round(self.application_round).delete()
                 RecurringReservation.objects.for_application_round(self.application_round).delete()
 

--- a/backend/tilavarauspalvelu/models/reservation_statistic_unit/model.py
+++ b/backend/tilavarauspalvelu/models/reservation_statistic_unit/model.py
@@ -56,7 +56,7 @@ class ReservationStatisticsReservationUnit(models.Model):
         cls,
         statistic: ReservationStatistic,
         *,
-        save: bool = True,
+        save: bool = False,
     ) -> list[ReservationStatisticsReservationUnit]:
         to_save: list[ReservationStatisticsReservationUnit] = []
         for reservation_unit in statistic.reservation.reservation_units.all():

--- a/backend/tilavarauspalvelu/models/reservation_unit/queryset.py
+++ b/backend/tilavarauspalvelu/models/reservation_unit/queryset.py
@@ -164,7 +164,7 @@ class ReservationUnitQuerySet(models.QuerySet):
     def hidden(self) -> Self:
         return self.published().exclude(self._is_visible)
 
-    def update_search_vectors(self, reservation_unit_pk: int | None = None) -> None:
+    def update_search_vectors(self, pks: list[int] | None = None) -> None:
         qs = self.select_related(
             "unit",
             "reservation_unit_type",
@@ -174,8 +174,8 @@ class ReservationUnitQuerySet(models.QuerySet):
             "purposes",
             "equipments",
         )
-        if reservation_unit_pk is not None:
-            qs = qs.filter(pk=reservation_unit_pk)
+        if pks is not None:
+            qs = qs.filter(pk__in=pks)
 
         reservation_units: list[ReservationUnit] = list(qs)
 

--- a/backend/tilavarauspalvelu/signals.py
+++ b/backend/tilavarauspalvelu/signals.py
@@ -1,7 +1,15 @@
+"""
+Signal receivers.
+
+Note: All signal functions must have names, since Django's signal handlers only store weak references to them.
+This means that a using "_" as the name (meaning we don't care about the name of the function) is not enough,
+as this module must hold strong references to the signal functions.
+"""
+
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Unpack
 
 from django.conf import settings
 from django.contrib.auth import user_logged_in
@@ -25,7 +33,7 @@ from social_core.exceptions import AuthCanceled, AuthFailed, AuthStateForbidden,
 
 from tilavarauspalvelu.integrations.image_cache import purge_previous_image_cache
 from tilavarauspalvelu.integrations.sentry import SentryLogger
-from tilavarauspalvelu.models import Purpose, Reservation, ReservationUnit, ReservationUnitImage, Space
+from tilavarauspalvelu.models import Purpose, Reservation, ReservationUnit, ReservationUnitImage, Space, Unit
 from tilavarauspalvelu.tasks import (
     create_or_update_reservation_statistics,
     create_reservation_unit_thumbnails_and_urls,
@@ -38,132 +46,191 @@ from utils.date_utils import local_datetime
 
 if TYPE_CHECKING:
     from tilavarauspalvelu.models import User
-    from tilavarauspalvelu.tasks import Action
-    from tilavarauspalvelu.typing import M2MAction, WSGIRequest
+    from tilavarauspalvelu.typing import M2MChangedKwargs, PostDeleteKwargs, PostSaveKwargs, PreSaveKwargs, WSGIRequest
 
 
-@receiver([post_save, post_delete], sender=Space, dispatch_uid="space_modify")
-def space_modify(instance: Space, *args: Any, **kwargs: Any) -> None:
+# --- Pre save signals --------------------------------------------------------------------------------------------
+
+
+@receiver(pre_save, sender=Purpose, dispatch_uid="purpose_pre_save")
+def _purpose_pre_save(sender: Any, **kwargs: Unpack[PreSaveKwargs[Purpose]]) -> None:
+    instance = kwargs["instance"]
+
+    if settings.IMAGE_CACHE_ENABLED:
+        purge_previous_image_cache(instance)
+
+
+@receiver(pre_save, sender=ReservationUnitImage, dispatch_uid="reservation_unit_image_pre_save")
+def _reservation_unit_image_pre_save(sender: Any, **kwargs: Unpack[PreSaveKwargs[ReservationUnitImage]]) -> None:
+    instance = kwargs["instance"]
+
+    if settings.UPDATE_RESERVATION_UNIT_THUMBNAILS and settings.IMAGE_CACHE_ENABLED:
+        purge_previous_image_cache(instance)
+
+
+# --- Post save signals -------------------------------------------------------------------------------------------
+
+
+@receiver(post_save, sender=Space, dispatch_uid="space_post_save")
+def _space_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[Space]]) -> None:
+    using = kwargs["using"]
+
     if settings.REBUILD_SPACE_HIERARCHY:
-        tree_id = instance.parent.tree_id if instance.parent else instance.tree_id
-        try:
-            instance.__class__.objects.partial_rebuild(tree_id)
-        except RuntimeError:
-            # If the tree now has more than one root node,
-            # we need to rebuild the whole tree.
-            instance.__class__.objects.rebuild()
+        Space.objects.rebuild()
 
-    # Refresh the reservation unit hierarchy since spaces have changed.
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY:
-        update_reservation_unit_hierarchy_task.delay(using=kwargs.get("using"))
+        update_reservation_unit_hierarchy_task.delay(using=using)
 
 
-@receiver(post_save, sender=Reservation, dispatch_uid="reservation_create")
-def reservation_create(
-    sender: type[Reservation],  # noqa: ARG001
-    instance: Reservation,
-    *,
-    raw: bool = False,
-    **kwargs: Any,
-) -> None:
-    if not raw and settings.SAVE_RESERVATION_STATISTICS:
-        # Note that many-to-many relationships are not yet available at this time so
-        # statistics might be saved with the previous reservation unit value. That is why
-        # we also have m2m_changed signal below.
-        #
-        # It gets triggered when relationships are being changed and happens always after post_save signal.
-        # It will update the reservation unit with the new value.
-        #
-        # Current implementation allows reservation to have multiple reservation units, but in practise, only
-        # one can be defined. If in the future we truly support reservations with multiple reservation units,
-        # we need to change this implementation so that we either have multiple reservation units in the statistics
-        # or we have better way to indicate which one is the primary unit.
+@receiver(post_save, sender=Reservation, dispatch_uid="reservation_post_save")
+def _reservation_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[Reservation]]) -> None:
+    instance = kwargs["instance"]
+    using = kwargs["using"]
+
+    if settings.SAVE_RESERVATION_STATISTICS:
         create_or_update_reservation_statistics.delay([instance.pk])
 
-    if not raw and settings.UPDATE_AFFECTING_TIME_SPANS:
-        update_affecting_time_spans_task.delay(using=kwargs.get("using"))
-
-
-@receiver(post_delete, sender=Reservation, dispatch_uid="reservation_delete")
-def reservation_delete(sender: type[Reservation], **kwargs: Any) -> None:  # noqa: ARG001
     if settings.UPDATE_AFFECTING_TIME_SPANS:
-        update_affecting_time_spans_task.delay(using=kwargs.get("using"))
+        update_affecting_time_spans_task.delay(using=using)
 
 
-@receiver(m2m_changed, sender=Reservation.reservation_units.through, dispatch_uid="reservations_reservation_units_m2m")
-def reservations_reservation_units_m2m(
-    action: M2MAction,
-    instance: Reservation,
-    *,
-    reverse: bool = False,
-    raw: bool = False,
-    **kwargs: Any,
-) -> None:
-    if action == "post_add" and not raw and not reverse and settings.SAVE_RESERVATION_STATISTICS:
-        create_or_update_reservation_statistics.delay([instance.pk])
+@receiver(post_save, sender=ReservationUnit, dispatch_uid="reservation_unit_post_save")
+def _reservation_unit_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[ReservationUnit]]) -> None:
+    instance: ReservationUnit = kwargs["instance"]
+    created: bool = kwargs["created"]
+    using = kwargs["using"]
 
-    if not raw and settings.UPDATE_AFFECTING_TIME_SPANS:
-        update_affecting_time_spans_task.delay(using=kwargs.get("using"))
-
-
-@receiver(post_save, sender=ReservationUnit, dispatch_uid="reservation_unit_saved")
-def reservation_unit_saved(instance: ReservationUnit, *, created: bool, **kwargs: Any) -> None:
     if settings.UPDATE_PRODUCT_MAPPING:
         refresh_reservation_unit_product_mapping.delay(instance.pk)
 
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY and created:
-        update_reservation_unit_hierarchy_task.delay(using=kwargs.get("using"))
+        update_reservation_unit_hierarchy_task.delay(using=using)
 
     if settings.UPDATE_SEARCH_VECTORS:
-        update_reservation_unit_search_vectors_task.delay(reservation_unit_pk=instance.pk)
+        update_reservation_unit_search_vectors_task.delay(pks=[instance.pk])
 
 
-@receiver(post_delete, sender=ReservationUnit, dispatch_uid="reservation_unit_deleted")
-def reservation_unit_deleted(*args: Any, **kwargs: Any) -> None:
+@receiver(post_save, sender=ReservationUnitImage, dispatch_uid="reservation_unit_image_post_save")
+def _reservation_unit_image_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[ReservationUnitImage]]) -> None:
+    instance = kwargs["instance"]
+
+    if settings.UPDATE_RESERVATION_UNIT_THUMBNAILS:
+        create_reservation_unit_thumbnails_and_urls.delay(instance.pk)
+
+
+@receiver(post_save, sender=Unit, dispatch_uid="unit_post_save")
+def _unit_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[Unit]]) -> None:
+    instance = kwargs["instance"]
+
+    if settings.UPDATE_SEARCH_VECTORS:
+        pks = list(instance.reservation_units.values_list("pk", flat=True))
+        update_reservation_unit_search_vectors_task.delay(pks=pks)
+
+
+# --- Post delete signals -----------------------------------------------------------------------------------------
+
+
+@receiver(post_delete, sender=Space, dispatch_uid="space_post_delete")
+def _space_post_delete(sender: Any, **kwargs: Unpack[PostDeleteKwargs[Space]]) -> None:
+    using = kwargs["using"]
+
+    if settings.REBUILD_SPACE_HIERARCHY:
+        Space.objects.rebuild()
+
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY:
-        update_reservation_unit_hierarchy_task.delay(using=kwargs.get("using"))
+        update_reservation_unit_hierarchy_task.delay(using=using)
 
 
-@receiver(m2m_changed, sender=ReservationUnit.spaces.through, dispatch_uid="reservation_unit_spaces_modified")
-def reservation_unit_spaces_modified(action: Action, instance: ReservationUnit, *args: Any, **kwargs: Any) -> None:
+@receiver(post_delete, sender=Reservation, dispatch_uid="reservation_post_delete")
+def _reservation_post_delete(sender: Any, **kwargs: Unpack[PostDeleteKwargs[Reservation]]) -> None:
+    using = kwargs["using"]
+
+    if settings.UPDATE_AFFECTING_TIME_SPANS:
+        update_affecting_time_spans_task.delay(using=using)
+
+
+@receiver(post_delete, sender=ReservationUnit, dispatch_uid="reservation_unit_post_delete")
+def _reservation_unit_post_delete(sender: Any, **kwargs: Unpack[PostDeleteKwargs[ReservationUnit]]) -> None:
+    using = kwargs["using"]
+
+    if settings.UPDATE_RESERVATION_UNIT_HIERARCHY:
+        update_reservation_unit_hierarchy_task.delay(using=using)
+
+
+# --- M2M changed signals -----------------------------------------------------------------------------------------
+
+
+@receiver(m2m_changed, sender=Reservation.reservation_units.through, dispatch_uid="reservation_reservation_units_m2m")
+def _reservation_reservation_units_m2m(sender: Any, **kwargs: Unpack[M2MChangedKwargs[Reservation]]) -> None:
+    action = kwargs["action"]
+    instance = kwargs["instance"]
+    reverse = kwargs["reverse"]
+    using = kwargs["using"]
+
+    if action == "post_add" and not reverse and settings.SAVE_RESERVATION_STATISTICS:
+        create_or_update_reservation_statistics.delay([instance.pk])
+
+    if settings.UPDATE_AFFECTING_TIME_SPANS:
+        update_affecting_time_spans_task.delay(using=using)
+
+
+@receiver(m2m_changed, sender=ReservationUnit.spaces.through, dispatch_uid="reservation_unit_spaces_m2m")
+def _reservation_unit_spaces_m2m(sender: Any, **kwargs: Unpack[M2MChangedKwargs[ReservationUnit]]) -> None:
+    action = kwargs["action"]
+    instance = kwargs["instance"]
+    using = kwargs["using"]
+
     post_modify = action in {"post_add", "post_remove", "post_clear"}
 
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY and post_modify:
-        update_reservation_unit_hierarchy_task.delay(using=kwargs.get("using"))
+        update_reservation_unit_hierarchy_task.delay(using=using)
 
     if settings.UPDATE_SEARCH_VECTORS and post_modify:
-        update_reservation_unit_search_vectors_task.delay(reservation_unit_pk=instance.pk)
+        update_reservation_unit_search_vectors_task.delay(pks=[instance.pk])
 
 
-@receiver(m2m_changed, sender=ReservationUnit.resources.through, dispatch_uid="reservation_unit_resources_modified")
-def reservation_unit_resources_modified(action: Action, instance: ReservationUnit, *args: Any, **kwargs: Any) -> None:
+@receiver(m2m_changed, sender=ReservationUnit.resources.through, dispatch_uid="reservation_unit_resources_m2m")
+def _reservation_unit_resources_m2m(sender: Any, **kwargs: Unpack[M2MChangedKwargs[ReservationUnit]]) -> None:
+    action = kwargs["action"]
+    instance = kwargs["instance"]
+    using = kwargs["using"]
+
     post_modify = action in {"post_add", "post_remove", "post_clear"}
 
     if settings.UPDATE_RESERVATION_UNIT_HIERARCHY and post_modify:
-        update_reservation_unit_hierarchy_task.delay(using=kwargs.get("using"))
+        update_reservation_unit_hierarchy_task.delay(using=using)
 
     if settings.UPDATE_SEARCH_VECTORS and post_modify:
-        update_reservation_unit_search_vectors_task.delay(reservation_unit_pk=instance.pk)
+        update_reservation_unit_search_vectors_task.delay(pks=[instance.pk])
 
 
-@receiver(m2m_changed, sender=ReservationUnit.purposes.through, dispatch_uid="reservation_unit_purposes_modified")
-def reservation_unit_purposes_modified(action: Action, instance: ReservationUnit, *args: Any, **kwargs: Any) -> None:
+@receiver(m2m_changed, sender=ReservationUnit.purposes.through, dispatch_uid="reservation_unit_purposes_m2m")
+def _reservation_unit_purposes_m2m(sender: Any, **kwargs: Unpack[M2MChangedKwargs[ReservationUnit]]) -> None:
+    action = kwargs["action"]
+    instance = kwargs["instance"]
+
     post_modify = action in {"post_add", "post_remove", "post_clear"}
 
     if settings.UPDATE_SEARCH_VECTORS and post_modify:
-        update_reservation_unit_search_vectors_task.delay(reservation_unit_pk=instance.pk)
+        update_reservation_unit_search_vectors_task.delay(pks=[instance.pk])
 
 
-@receiver(m2m_changed, sender=ReservationUnit.equipments.through, dispatch_uid="reservation_unit_equipments_modified")
-def reservation_unit_equipments_modified(action: Action, instance: ReservationUnit, *args: Any, **kwargs: Any) -> None:
+@receiver(m2m_changed, sender=ReservationUnit.equipments.through, dispatch_uid="reservation_unit_equipments_m2m")
+def _reservation_unit_equipments_m2m(sender: Any, **kwargs: Unpack[M2MChangedKwargs[ReservationUnit]]) -> None:
+    action = kwargs["action"]
+    instance = kwargs["instance"]
+
     post_modify = action in {"post_add", "post_remove", "post_clear"}
 
     if settings.UPDATE_SEARCH_VECTORS and post_modify:
-        update_reservation_unit_search_vectors_task.delay(reservation_unit_pk=instance.pk)
+        update_reservation_unit_search_vectors_task.delay(pks=[instance.pk])
+
+
+# --- Misc signals ------------------------------------------------------------------------------------------------
 
 
 @receiver(user_logged_in, dispatch_uid="user_logged_in")
-def update_last_login(user: User, **kwargs: Any) -> None:
+def _user_logged_in(user: User, **kwargs: Any) -> None:
     user.last_login = local_datetime()
     user.sent_email_about_deactivating_permissions = False
     user.sent_email_about_anonymization = False
@@ -176,29 +243,11 @@ def update_last_login(user: User, **kwargs: Any) -> None:
     )
 
 
-@receiver(pre_save, sender=Purpose, dispatch_uid="purpose_to_save")
-def purpose_to_save(instance: Purpose, *args: Any, **kwargs: Any) -> None:
-    if settings.IMAGE_CACHE_ENABLED:
-        purge_previous_image_cache(instance)
-
-
-@receiver(pre_save, sender=ReservationUnitImage, dispatch_uid="reservation_unit_image_to_save")
-def reservation_unit_image_to_save(instance: ReservationUnitImage, *args: Any, **kwargs: Any) -> None:
-    if settings.UPDATE_RESERVATION_UNIT_THUMBNAILS and settings.IMAGE_CACHE_ENABLED:
-        purge_previous_image_cache(instance)
-
-
-@receiver(post_save, sender=ReservationUnitImage, dispatch_uid="reservation_unit_image_saved")
-def reservation_unit_image_saved(instance: ReservationUnitImage, *args: Any, **kwargs: Any) -> None:
-    if settings.UPDATE_RESERVATION_UNIT_THUMBNAILS:
-        create_reservation_unit_thumbnails_and_urls.delay(instance.pk)
-
-
 sentry_disconnected = got_request_exception.disconnect(_got_request_exception)
 if sentry_disconnected:
 
     @receiver(got_request_exception, dispatch_uid="sentry_log_exception")
-    def sentry_log_exception(request: WSGIRequest, **kwargs: Any) -> None:
+    def _sentry_log_exception(request: WSGIRequest, **kwargs: Any) -> None:
         """
         Replace Sentry's default request exception handler with our own.
         This allows us to conditionally log exceptions differently.

--- a/backend/tilavarauspalvelu/signals.py
+++ b/backend/tilavarauspalvelu/signals.py
@@ -88,7 +88,7 @@ def _reservation_post_save(sender: Any, **kwargs: Unpack[PostSaveKwargs[Reservat
     using = kwargs["using"]
 
     if settings.SAVE_RESERVATION_STATISTICS:
-        create_or_update_reservation_statistics.delay([instance.pk])
+        create_or_update_reservation_statistics.delay(reservation_pks=[instance.pk])
 
     if settings.UPDATE_AFFECTING_TIME_SPANS:
         update_affecting_time_spans_task.delay(using=using)
@@ -168,7 +168,7 @@ def _reservation_reservation_units_m2m(sender: Any, **kwargs: Unpack[M2MChangedK
     using = kwargs["using"]
 
     if action == "post_add" and not reverse and settings.SAVE_RESERVATION_STATISTICS:
-        create_or_update_reservation_statistics.delay([instance.pk])
+        create_or_update_reservation_statistics.delay(reservation_pks=[instance.pk])
 
     if settings.UPDATE_AFFECTING_TIME_SPANS:
         update_affecting_time_spans_task.delay(using=using)

--- a/backend/tilavarauspalvelu/tasks.py
+++ b/backend/tilavarauspalvelu/tasks.py
@@ -232,7 +232,7 @@ def update_affecting_time_spans_task(using: str | None = None) -> None:
 
 @app.task(name="create_statistics_for_reservations")
 def create_or_update_reservation_statistics(reservation_pks: list[int]) -> None:
-    Reservation.objects.upsert_statistics(reservation_pks=reservation_pks)
+    Reservation.objects.filter(pk__in=reservation_pks).upsert_statistics()
 
 
 @app.task(name="update_reservation_unit_pricings_tax_percentage")

--- a/backend/tilavarauspalvelu/tasks.py
+++ b/backend/tilavarauspalvelu/tasks.py
@@ -359,8 +359,8 @@ def save_sql_queries_from_request(queries: list[QueryInfo], path: str, body: byt
 
 
 @app.task(name="Update ReservationUnit Search vectors")
-def update_reservation_unit_search_vectors_task(reservation_unit_pk: int | None = None) -> None:
-    ReservationUnit.objects.update_search_vectors(reservation_unit_pk=reservation_unit_pk)
+def update_reservation_unit_search_vectors_task(pks: list[int] | None = None) -> None:
+    ReservationUnit.objects.update_search_vectors(pks=pks)
 
 
 @app.task(name="deactivate_old_permissions")

--- a/backend/tilavarauspalvelu/typing.py
+++ b/backend/tilavarauspalvelu/typing.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, NotRequired, Protoco
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.handlers import wsgi
+from django.db import models
 from graphql import GraphQLResolveInfo
 from rest_framework.exceptions import ValidationError
 
@@ -458,3 +459,39 @@ class ReservationDetails(TypedDict, total=False):
     purpose: int | ReservationPurpose
     home_city: int | City
     age_group: int | AgeGroup
+
+
+class PreSaveKwargs[TModel: models.Model](TypedDict):
+    instance: TModel
+    raw: bool
+    using: str | None
+    update_fields: list[str] | None
+
+
+class PostSaveKwargs[TModel: models.Model](TypedDict):
+    instance: TModel
+    created: bool
+    raw: bool
+    using: str | None
+    update_fields: list[str] | None
+
+
+class PreDeleteKwargs[TModel: models.Model](TypedDict):
+    instance: TModel
+    using: str | None
+    origin: TModel | models.QuerySet[TModel] | None
+
+
+class PostDeleteKwargs[TModel: models.Model](TypedDict):
+    instance: TModel
+    using: str | None
+    origin: TModel | models.QuerySet[TModel] | None
+
+
+class M2MChangedKwargs[TModel: models.Model](TypedDict):
+    action: M2MAction
+    instance: TModel
+    reverse: bool
+    model: type[TModel]
+    pk_set: set[int] | None
+    using: str | None


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

Try to prevent two errors from happening in statistics update:
1. [Statistic already exists for this primary key](https://sentry.hel.fi/organizations/city-of-helsinki/issues/61358/?project=16)
2. [Reservation for this statistic doesn't exist](https://sentry.hel.fi/organizations/city-of-helsinki/issues/61376/?project=16)

Kind of difficult to prevent, but changed the bulk update rules a bit and let's see

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3911](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3911)


[TILA-3911]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ