### PR TITLE
Display unrestricted access in reservation unit page infos

### DIFF
--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -15,13 +15,9 @@ import {
   formatDuration,
   getTranslationSafe,
 } from "common/src/common/util";
+import { ReservationKind, type ReservationUnitPageQuery } from "@gql/gql-types";
 import { H1, H3 } from "common/src/common/typography";
 import { formatDateTime } from "@/modules/util";
-import {
-  AccessType,
-  ReservationKind,
-  type ReservationUnitPageQuery,
-} from "@gql/gql-types";
 import { IconWithText } from "../common/IconWithText";
 import { Images } from "./Images";
 import {
@@ -281,9 +277,7 @@ function IconList({
           ),
         }
       : null,
-    reservationUnit.currentAccessType &&
-    (reservationUnit.currentAccessType !== AccessType.Unrestricted ||
-      reservationUnit.accessTypes.length > 1)
+    reservationUnit.currentAccessType
       ? {
           key: "accessType",
           icon: (


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Show unrestricted access type in the info section on reservation unit pages

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Search for reservation units with unrestricted access, and visit one of their pages: the access type should be displayed there
- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3904](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3904)


[TILA-3904]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ