### PR TITLE
fix: access code section display in reservation view

### DIFF
--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -83,6 +83,7 @@ import { Instructions } from "@/components/Instructions";
 import { gql } from "@apollo/client";
 import StatusLabel from "common/src/components/StatusLabel";
 import IconButton from "common/src/components/IconButton";
+import { isBefore, sub } from "date-fns";
 
 type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
 
@@ -321,10 +322,12 @@ function Reservation({
   feedbackUrl,
 }: Readonly<PropsNarrowed>): JSX.Element | null {
   const { t, i18n } = useTranslation();
-  const isAccessCodeReservation =
+  const shouldShowAccessCode =
+    isBefore(sub(new Date(), { days: 1 }), new Date(reservation.end)) &&
+    reservation.state === ReservationStateChoice.Confirmed &&
     reservation.accessType === AccessType.AccessCode;
   const { data: accessCodeData } = useAccessCodeQuery({
-    skip: !reservation || !isAccessCodeReservation,
+    skip: !reservation || !shouldShowAccessCode,
     variables: {
       id: base64encode(`ReservationNode:${reservation.pk}`),
     },
@@ -410,7 +413,7 @@ function Reservation({
                   testId="reservation__payment-status"
                 />
               )}
-              {isAccessCodeReservation && (
+              {shouldShowAccessCode && (
                 <StatusLabel
                   type="info"
                   icon={
@@ -513,7 +516,7 @@ function Reservation({
             reservation={reservation}
             supportedFields={supportedFields}
           />
-          {isAccessCodeReservation && (
+          {shouldShowAccessCode && (
             <AccessCodeInfo
               pindoraInfo={pindoraInfo}
               feedbackUrl={feedbackUrl}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- access code section is only shown for confirmed reservations which have not ended before yesterday, only show it if:
  - `reservation.state` is `Confirmed`
  - `reservation.end` is less than 24h before now
  - `reservation.accessType` is `AccessCode`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3894](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3894)


[TILA-3894]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ