### PR TITLE
fix: approve dialog doesn't show the price when handling reservation previously accepted as free

### DIFF
--- a/apps/admin-ui/src/spa/reservations/[id]/ApproveDialog.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ApproveDialog.tsx
@@ -38,17 +38,12 @@ const ActionButtons = styled(Dialog.ActionButtons)`
 type ReservationType = NonNullable<ReservationQuery["reservation"]>;
 type Props = {
   reservation: ReservationType;
-  isFree: boolean;
   onClose: () => void;
   onAccept: () => void;
+  isFree?: boolean;
 };
 
-const DialogContent = ({
-  reservation,
-  isFree: isReservationUnitFree,
-  onClose,
-  onAccept,
-}: Props) => {
+const DialogContent = ({ reservation, onClose, onAccept }: Props) => {
   const { t, i18n } = useTranslation();
 
   const [mutation] = useApproveReservationMutation();
@@ -95,11 +90,6 @@ const DialogContent = ({
     });
   };
 
-  // the reservation has a price and the reservation unit is paid
-  // might be extrenous checks (the reservation price is what is important here)
-  // a free reservation should never be allowed to be approved with a price
-  const shouldDisplayPrice = !isReservationUnitFree && hasPrice;
-
   return (
     <>
       <Dialog.Content>
@@ -117,10 +107,6 @@ const DialogContent = ({
               <Notification>
                 {getReservationPriceDetails(reservation, t)}
               </Notification>
-            </>
-          )}
-          {shouldDisplayPrice && (
-            <>
               <Checkbox
                 label={t("RequestedReservation.ApproveDialog.clearPrice")}
                 id="clearPrice"
@@ -217,7 +203,6 @@ const ApproveDialog = ({
           }
         />
         <DialogContent
-          isFree={isFree}
           reservation={reservation}
           onAccept={onAccept}
           onClose={onClose}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- the approve dialog now always shows the price when it should be editable (i.e. when it has been applied to be free of charge)
- removes buggy check for displaying price in approve dialog

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3634](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3634)


[TILA-3634]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ