### PR TITLE
Add seasonal booking change access code template

### DIFF
--- a/backend/templates/email/html/partials/access_code_section.jinja
+++ b/backend/templates/email/html/partials/access_code_section.jinja
@@ -1,0 +1,15 @@
+{% if access_code %}
+<mj-spacer />
+<mj-text>{{ access_code_label | safe }}: {{ access_code }}</mj-text>
+{% elif access_code_is_used %}
+<mj-spacer />
+<mj-text>{{ text_access_code_unavailable_instructions_html | sentence }}</mj-text>
+{% endif %}
+{% for allocation in allocations %}
+<mj-spacer />
+<mj-text>{{ weekday_label | safe }}: {{ allocation.weekday_value | safe }}</mj-text>
+<mj-text>{{ time_label | safe }}: {{ allocation.time_value | safe }}</mj-text>
+{% if access_code_is_used %}
+<mj-text>{{ access_code_validity_period_label | safe }}: {{ allocation.access_code_validity_period }}</mj-text>
+{% endif %}
+{% endfor %}

--- a/backend/templates/email/html/seasonal_reservation_modified_series.jinja
+++ b/backend/templates/email/html/seasonal_reservation_modified_series.jinja
@@ -3,10 +3,7 @@
 {% block content_main %}
     <mj-text>{{ text_reservation_modified | sentence | safe }}</mj-text>
     {% include "email/html/partials/application_section_name.jinja" %}
-    <mj-spacer />
-    <mj-text>{{ weekday_label | safe }}: {{ weekday_value | safe }}</mj-text>
-    <mj-text>{{ time_label | safe }}: {{ time_value | safe }}</mj-text>
-    {% include "email/html/partials/access_code.jinja" %}
+    {% include "email/html/partials/access_code_section.jinja" %}
     <mj-spacer />
     <mj-text>{{ check_booking_details_text | safe }}: {{ check_booking_details_url_html | safe }}</mj-text>
 {% endblock %}

--- a/backend/templates/email/html/seasonal_reservation_rejected_series.jinja
+++ b/backend/templates/email/html/seasonal_reservation_rejected_series.jinja
@@ -4,9 +4,7 @@
     <mj-text>{{ text_reservation_rejected | sentence | safe }}</mj-text>
     <mj-text>{{ reason_label | safe }}: {{ rejection_reason | safe }}</mj-text>
     {% include "email/html/partials/application_section_name.jinja" %}
-    <mj-spacer />
-    <mj-text>{{ weekday_label | safe }}: {{ weekday_value | safe }}</mj-text>
-    <mj-text>{{ time_label | safe }}: {{ time_value | safe }}</mj-text>
+    {% include "email/html/partials/access_code_section.jinja" %}
     <mj-spacer />
     <mj-text>{{ check_booking_details_text | safe }}: {{ check_booking_details_url_html | safe }}</mj-text>
 {% endblock %}

--- a/backend/templates/email/text/partials/access_code_section.jinja
+++ b/backend/templates/email/text/partials/access_code_section.jinja
@@ -1,0 +1,9 @@
+{% if access_code %}
+{{ access_code_label | safe }}: {{ access_code }}
+{% elif access_code_is_used %}
+{{ text_access_code_unavailable_instructions_html | sentence }}
+{% endif %}{% for allocation in allocations %}
+{{ weekday_label | safe }}: {{ allocation.weekday_value | safe }}
+{{ time_label | safe }}: {{ allocation.time_value | safe }}
+{% if access_code_is_used %}{{ access_code_validity_period_label | safe }}: {{ allocation.access_code_validity_period }}
+{% endif %}{% endfor %}

--- a/backend/templates/email/text/seasonal_reservation_modified_series.jinja
+++ b/backend/templates/email/text/seasonal_reservation_modified_series.jinja
@@ -3,10 +3,7 @@
 {{ text_reservation_modified | sentence | safe }}
 
 {% include "email/text/partials/application_section_name.jinja" %}
-
-{{ weekday_label | safe }}: {{ weekday_value | safe }}
-{{ time_label | safe }}: {{ time_value | safe }}
-{% include "email/text/partials/access_code.jinja" %}
+{% include "email/text/partials/access_code_section.jinja" %}
 {{ check_booking_details_text | safe }}: {{ check_booking_details_url }}
 
 {% include "email/text/partials/closing.jinja" %}

--- a/backend/templates/email/text/seasonal_reservation_rejected_series.jinja
+++ b/backend/templates/email/text/seasonal_reservation_rejected_series.jinja
@@ -4,9 +4,7 @@
 {{ reason_label | safe }}: {{ rejection_reason }}
 
 {% include "email/text/partials/application_section_name.jinja" %}
-
-{{ weekday_label | safe }}: {{ weekday_value | safe }}
-{{ time_label | safe }}: {{ time_value | safe }}
+{% include "email/text/partials/access_code_section.jinja" %}
 
 {{ check_booking_details_text | safe }}: {{ check_booking_details_url  }}
 

--- a/backend/tests/test_graphql_api/test_reservation/test_confirm.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_confirm.py
@@ -474,6 +474,8 @@ def test_reservation__confirm__without_price_and_with_free_pricing_does_not_requ
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @patch_method(PindoraService.activate_access_code)
@@ -501,6 +503,8 @@ def test_reservation__confirm__pindora_api__call_succeeds(graphql):
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @patch_method(PindoraService.activate_access_code, side_effect=PindoraAPIError("Error"))

--- a/backend/tests/test_integrations/test_email/conftest.py
+++ b/backend/tests/test_integrations/test_email/conftest.py
@@ -76,6 +76,7 @@ def email_reservation() -> Reservation:
     ReservationFactory.create_for_reservation_unit(
         reservation_unit=reservation_unit,
         user=application_section.application.user,
+        state=ReservationStateChoice.CONFIRMED,
         reservee_first_name="[SÄHKÖPOSTIN VASTAANOTTAJAN NIMI]",
         reservee_last_name="",
         cancel_reason__reason_en="[PERUUTUKSEN SYY]",

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
@@ -153,6 +153,8 @@ def test_get_context__reservation_approved__instance(email_reservation):
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @pytest.mark.django_db

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_confirmed.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_confirmed.py
@@ -127,6 +127,8 @@ def test_get_context__reservation_confirmed__instance(email_reservation):
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @pytest.mark.django_db

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified.py
@@ -127,6 +127,8 @@ def test_get_context__reservation_modified_instance(email_reservation):
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @pytest.mark.django_db

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified_access_code.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified_access_code.py
@@ -121,6 +121,8 @@ def test_get_context__reservation_modified_access_code(lang: Lang):
         access_code="123456",
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
     ),
 )
 @pytest.mark.django_db

--- a/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime
+import uuid
 from inspect import cleandoc
 from typing import TYPE_CHECKING
 
@@ -12,15 +13,19 @@ from django.test import override_settings
 from freezegun import freeze_time
 
 from tilavarauspalvelu.admin.email_template.utils import get_mock_data, get_mock_params
-from tilavarauspalvelu.enums import ReservationTypeChoice, Weekday
+from tilavarauspalvelu.enums import AccessType, ReservationTypeChoice, Weekday
 from tilavarauspalvelu.integrations.email.main import EmailService
 from tilavarauspalvelu.integrations.email.rendering import render_html, render_text
 from tilavarauspalvelu.integrations.email.template_context import get_context_for_seasonal_reservation_modified_series
 from tilavarauspalvelu.integrations.email.typing import EmailType
 from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
-from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraNotFoundError
-from tilavarauspalvelu.integrations.keyless_entry.typing import PindoraReservationSeriesResponse
+from tilavarauspalvelu.integrations.keyless_entry.typing import (
+    PindoraSeasonalBookingAccessCodeValidity,
+    PindoraSeasonalBookingResponse,
+)
+from tilavarauspalvelu.integrations.sentry import SentryLogger
 
+from tests.factories import ApplicationFactory, RecurringReservationFactory, UserFactory
 from tests.helpers import TranslationsFromPOFiles, patch_method
 from tests.test_graphql_api.test_recurring_reservation.helpers import create_reservation_series
 from tests.test_integrations.test_email.helpers import (
@@ -51,13 +56,15 @@ COMMON_CONTEXT = {
     "email_recipient_name": "[SÄHKÖPOSTIN VASTAANOTTAJAN NIMI]",
     "application_section_name": "[HAKEMUKSEN OSAN NIMI]",
     "application_round_name": "[KAUSIVARAUSKIERROKSEN NIMI]",
-    "time_value": "13:00-15:00",
 }
 LANGUAGE_CONTEXT = {
     "en": {
         "title": "The time of the space reservation included in your seasonal booking has changed",
         "text_reservation_modified": "The time of the space reservation included in your seasonal booking has changed",
-        "weekday_value": "Monday",
+        "allocations": [
+            {"weekday_value": "Monday", "time_value": "13:00-15:00", "access_code_validity_period": ""},
+            {"weekday_value": "Tuesday", "time_value": "21:00-22:00", "access_code_validity_period": ""},
+        ],
         **BASE_TEMPLATE_CONTEXT_EN,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_EN,
         **KEYLESS_ENTRY_CONTEXT_EN,
@@ -66,7 +73,10 @@ LANGUAGE_CONTEXT = {
     "fi": {
         "title": "Kausivaraukseesi kuuluvan tilavarauksen ajankohta on muuttunut",
         "text_reservation_modified": "Kausivaraukseesi kuuluvan tilavarauksen ajankohta on muuttunut",
-        "weekday_value": "Maanantai",
+        "allocations": [
+            {"weekday_value": "Maanantai", "time_value": "13:00-15:00", "access_code_validity_period": ""},
+            {"weekday_value": "Tiistai", "time_value": "21:00-22:00", "access_code_validity_period": ""},
+        ],
         **BASE_TEMPLATE_CONTEXT_FI,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_FI,
         **KEYLESS_ENTRY_CONTEXT_FI,
@@ -75,7 +85,10 @@ LANGUAGE_CONTEXT = {
     "sv": {
         "title": "Tiden för lokalbokningen som ingår i din säsongsbokning har ändrats",
         "text_reservation_modified": "Tiden för lokalbokningen som ingår i din säsongsbokning har ändrats",
-        "weekday_value": "Måndag",
+        "allocations": [
+            {"weekday_value": "Måndag", "time_value": "13:00-15:00", "access_code_validity_period": ""},
+            {"weekday_value": "Tisdag", "time_value": "21:00-22:00", "access_code_validity_period": ""},
+        ],
         **BASE_TEMPLATE_CONTEXT_SV,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_SV,
         **KEYLESS_ENTRY_CONTEXT_SV,
@@ -103,7 +116,7 @@ def test_get_context_for_seasonal_reservation_modified_series(lang: Lang):
 
 @pytest.mark.django_db
 @freeze_time("2024-01-01 12:00:00+02:00")
-@patch_method(PindoraClient.get_reservation_series, side_effect=PindoraNotFoundError("Error"))
+@patch_method(PindoraClient.get_seasonal_booking)
 def test_get_context_for_seasonal_reservation_modified_series__instance(email_reservation):
     section = email_reservation.actions.get_application_section()
 
@@ -121,9 +134,68 @@ def test_get_context_for_seasonal_reservation_modified_series__instance(email_re
         assert context == expected
 
     with TranslationsFromPOFiles():
-        context = get_context_for_seasonal_reservation_modified_series(
-            reservation_series=email_reservation.recurring_reservation, language="en"
-        )
+        allocation = email_reservation.recurring_reservation.allocated_time_slot
+        section = allocation.reservation_unit_option.application_section
+        context = get_context_for_seasonal_reservation_modified_series(section, language="en")
+        assert context == expected
+
+
+@pytest.mark.django_db
+@freeze_time("2024-01-01 12:00:00+02:00")
+@patch_method(PindoraClient.get_seasonal_booking)
+def test_get_context_for_seasonal_reservation_modified_series__instance__access_code_is_used(email_reservation):
+    section = email_reservation.actions.get_application_section()
+
+    section.actions.get_reservations().update(access_type=AccessType.ACCESS_CODE)
+
+    all_series = section.actions.get_reservation_series()
+    reservation_unit_1 = all_series[0].reservation_unit
+    reservation_unit_2 = all_series[1].reservation_unit
+
+    PindoraClient.get_seasonal_booking.return_value = PindoraSeasonalBookingResponse(
+        access_code="123456",
+        reservation_unit_code_validity=[
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_1.uuid,
+                begin=datetime.datetime(2024, 1, 1, 11),
+                end=datetime.datetime(2024, 1, 1, 15),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_2.uuid,
+                begin=datetime.datetime(2024, 1, 2, 20, 45),
+                end=datetime.datetime(2024, 1, 2, 22, 5),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+        ],
+    )
+
+    expected = {
+        **LANGUAGE_CONTEXT["en"],
+        **get_application_details_urls(section),
+        "access_code": "123456",
+        "access_code_is_used": True,
+        "allocations": [
+            {"weekday_value": "Monday", "time_value": "13:00-15:00", "access_code_validity_period": "11:00-15:00"},
+            {"weekday_value": "Tuesday", "time_value": "21:00-22:00", "access_code_validity_period": "20:45-22:05"},
+        ],
+    }
+
+    params = {
+        "application_id": section.application_id,
+        "application_section_id": section.id,
+        "access_code_is_used": True,
+    }
+    with TranslationsFromPOFiles():
+        context = get_context_for_seasonal_reservation_modified_series(**get_mock_params(**params, language="en"))
+        assert context == expected
+
+    with TranslationsFromPOFiles():
+        allocation = email_reservation.recurring_reservation.allocated_time_slot
+        section = allocation.reservation_unit_option.application_section
+        context = get_context_for_seasonal_reservation_modified_series(section, language="en")
         assert context == expected
 
 
@@ -135,6 +207,7 @@ def test_render_seasonal_reservation_modified_series__text():
     context = get_mock_data(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, language="en")
     text_content = render_text(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, context=context)
     text_content = text_content.replace("&amp;", "&")
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
 
     assert text_content == cleandoc(
         f"""
@@ -147,7 +220,46 @@ def test_render_seasonal_reservation_modified_series__text():
         Day: Monday
         Time: 13:00-15:00
 
-        You can check your booking details at: https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678
+        Day: Tuesday
+        Time: 21:00-22:00
+
+        You can check your booking details at: {url}
+
+        {EMAIL_CLOSING_TEXT_EN}
+        """
+    )
+
+
+@freeze_time("2024-01-01 12:00:00+02:00")
+def test_render_seasonal_reservation_modified_series__text__access_code_is_used():
+    context = get_mock_data(
+        email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES,
+        language="en",
+        access_code_is_used=True,
+    )
+    text_content = render_text(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, context=context)
+    text_content = text_content.replace("&amp;", "&")
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
+
+    assert text_content == cleandoc(
+        f"""
+        Hi [SÄHKÖPOSTIN VASTAANOTTAJAN NIMI],
+
+        The time of the space reservation included in your seasonal booking has changed.
+
+        Seasonal Booking: [HAKEMUKSEN OSAN NIMI], [KAUSIVARAUSKIERROKSEN NIMI]
+
+        Door code: 123456
+
+        Day: Monday
+        Time: 13:00-15:00
+        Validity period of the door code: 11:00-15:00
+
+        Day: Tuesday
+        Time: 21:00-22:00
+        Validity period of the door code: 20:45-22:05
+
+        You can check your booking details at: {url}
 
         {EMAIL_CLOSING_TEXT_EN}
         """
@@ -162,6 +274,7 @@ def test_render_seasonal_reservation_modified_series__html():
     context = get_mock_data(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, language="en")
     html_content = render_html(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, context=context)
     text_content = html_email_to_text(html_content)
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
 
     assert text_content == cleandoc(
         f"""
@@ -174,7 +287,43 @@ def test_render_seasonal_reservation_modified_series__html():
         Seasonal Booking: [HAKEMUKSEN OSAN NIMI], [KAUSIVARAUSKIERROKSEN NIMI]
         Day: Monday
         Time: 13:00-15:00
-        You can check your booking details at: [varaamo.hel.fi](https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678)
+        Day: Tuesday
+        Time: 21:00-22:00
+        You can check your booking details at: [varaamo.hel.fi]({url})
+
+        {EMAIL_CLOSING_HTML_EN}
+        """
+    )
+
+
+@freeze_time("2024-01-01 12:00:00+02:00")
+def test_render_seasonal_reservation_modified_series__html__access_code_is_used():
+    context = get_mock_data(
+        email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES,
+        language="en",
+        access_code_is_used=True,
+    )
+    html_content = render_html(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES, context=context)
+    text_content = html_email_to_text(html_content)
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
+
+    assert text_content == cleandoc(
+        f"""
+        {EMAIL_LOGO_HTML}
+
+        **Hi [SÄHKÖPOSTIN VASTAANOTTAJAN NIMI],**
+
+        The time of the space reservation included in your seasonal booking has changed.
+
+        Seasonal Booking: [HAKEMUKSEN OSAN NIMI], [KAUSIVARAUSKIERROKSEN NIMI]
+        Door code: 123456
+        Day: Monday
+        Time: 13:00-15:00
+        Validity period of the door code: 11:00-15:00
+        Day: Tuesday
+        Time: 21:00-22:00
+        Validity period of the door code: 20:45-22:05
+        You can check your booking details at: [varaamo.hel.fi]({url})
 
         {EMAIL_CLOSING_HTML_EN}
         """
@@ -187,24 +336,25 @@ def test_render_seasonal_reservation_modified_series__html():
 @pytest.mark.django_db
 @override_settings(SEND_EMAILS=True)
 @freeze_time("2024-01-01 12:00:00+02:00")
-@patch_method(
-    PindoraClient.get_reservation_series,
-    return_value=PindoraReservationSeriesResponse(
-        access_code="123456",
-        reservation_unit_code_validity=[
-            {"begin": datetime.datetime(2024, 1, 1, 11), "end": datetime.datetime(2024, 1, 1, 15)}
-        ],
-    ),
-)
 def test_email_service__send_seasonal_reservation_modified_series(outbox):
+    ext_uuid = uuid.uuid4()
+
+    user = UserFactory.create(email="user@email.com")
+    application = ApplicationFactory.create(
+        user=user,
+        contact_person__email="contact@email.com",
+    )
     reservation_series = create_reservation_series(
+        user=user,
+        reservation_unit__uuid=ext_uuid,
         reservations__type=ReservationTypeChoice.SEASONAL,
         allocated_time_slot__day_of_the_week=Weekday.MONDAY,
-        allocated_time_slot__reservation_unit_option__application_section__application__user__email="user@email.com",
-        allocated_time_slot__reservation_unit_option__application_section__application__contact_person__email="contact@email.com",
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
     )
 
-    EmailService.send_seasonal_reservation_modified_series_email(reservation_series=reservation_series)
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_email(section)
 
     assert len(outbox) == 1
 
@@ -215,14 +365,45 @@ def test_email_service__send_seasonal_reservation_modified_series(outbox):
 @pytest.mark.django_db
 @override_settings(SEND_EMAILS=True)
 @freeze_time("2024-01-01 12:00:00+02:00")
-def test_email_service__send_seasonal_reservation_modified_series__email_not_sent__no_allocated_time_slot(outbox):
-    reservation_series = create_reservation_series(
-        user__email="user@email.com",
-        reservations__type=ReservationTypeChoice.SEASONAL,
-        reservations__reservee_email="reservee@email.com",
-        allocated_time_slot=None,
+def test_email_service__send_seasonal_reservation_modified_series__no_reservations(outbox):
+    user = UserFactory.create(email="user@email.com")
+    application = ApplicationFactory.create(
+        user=user,
+        contact_person__email="contact@email.com",
+    )
+    reservation_series = RecurringReservationFactory.create(
+        user=user,
+        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
     )
 
-    EmailService.send_seasonal_reservation_modified_series_email(reservation_series=reservation_series)
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_email(section)
 
     assert len(outbox) == 0
+
+
+@pytest.mark.django_db
+@override_settings(SEND_EMAILS=True)
+@freeze_time("2024-01-01 12:00:00+02:00")
+@patch_method(SentryLogger.log_message)
+def test_email_service__send_seasonal_reservation_modified_series__no_recipients(outbox):
+    application = ApplicationFactory.create(
+        user=None,
+        contact_person=None,
+    )
+    reservation_series = create_reservation_series(
+        user=None,
+        reservations__type=ReservationTypeChoice.SEASONAL,
+        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
+    )
+
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_email(section)
+
+    assert len(outbox) == 0
+
+    assert SentryLogger.log_message.call_count == 1

--- a/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series_access_code.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series_access_code.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import datetime
+import uuid
 from inspect import cleandoc
 from typing import TYPE_CHECKING
 
@@ -12,7 +13,7 @@ from django.test import override_settings
 from freezegun import freeze_time
 
 from tilavarauspalvelu.admin.email_template.utils import get_mock_data, get_mock_params
-from tilavarauspalvelu.enums import ReservationTypeChoice, Weekday
+from tilavarauspalvelu.enums import AccessType, ReservationTypeChoice, Weekday
 from tilavarauspalvelu.integrations.email.main import EmailService
 from tilavarauspalvelu.integrations.email.rendering import render_html, render_text
 from tilavarauspalvelu.integrations.email.template_context.reservation import (
@@ -20,9 +21,14 @@ from tilavarauspalvelu.integrations.email.template_context.reservation import (
 )
 from tilavarauspalvelu.integrations.email.typing import EmailType
 from tilavarauspalvelu.integrations.keyless_entry import PindoraClient
-from tilavarauspalvelu.integrations.keyless_entry.typing import PindoraReservationSeriesResponse
+from tilavarauspalvelu.integrations.keyless_entry.typing import (
+    PindoraSeasonalBookingAccessCodeValidity,
+    PindoraSeasonalBookingResponse,
+)
+from tilavarauspalvelu.integrations.sentry import SentryLogger
 from utils.date_utils import local_datetime
 
+from tests.factories import ApplicationFactory, RecurringReservationFactory, UserFactory
 from tests.helpers import TranslationsFromPOFiles, patch_method
 from tests.test_graphql_api.test_recurring_reservation.helpers import create_reservation_series
 from tests.test_integrations.test_email.helpers import (
@@ -54,38 +60,49 @@ COMMON_CONTEXT = {
     "email_recipient_name": "[SÄHKÖPOSTIN VASTAANOTTAJAN NIMI]",
     "application_section_name": "[HAKEMUKSEN OSAN NIMI]",
     "application_round_name": "[KAUSIVARAUSKIERROKSEN NIMI]",
-    "time_value": "13:00-15:00",
 }
 LANGUAGE_CONTEXT = {
     "en": {
         "title": "The door code has changed",
         "text_reservation_modified": "The door code has changed",
-        "weekday_value": "Monday",
+        "allocations": [
+            {"weekday_value": "Monday", "time_value": "13:00-15:00", "access_code_validity_period": "11:00-15:00"},
+            {"weekday_value": "Tuesday", "time_value": "21:00-22:00", "access_code_validity_period": "20:45-22:05"},
+        ],
         **BASE_TEMPLATE_CONTEXT_EN,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_EN,
         **KEYLESS_ENTRY_CONTEXT_EN,
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         **COMMON_CONTEXT,
+        "access_code_validity_period": "",
     },
     "fi": {
         "title": "Ovikoodi on vaihtunut",
         "text_reservation_modified": "Ovikoodi on vaihtunut",
-        "weekday_value": "Maanantai",
+        "allocations": [
+            {"weekday_value": "Maanantai", "time_value": "13:00-15:00", "access_code_validity_period": "11:00-15:00"},
+            {"weekday_value": "Tiistai", "time_value": "21:00-22:00", "access_code_validity_period": "20:45-22:05"},
+        ],
         **BASE_TEMPLATE_CONTEXT_FI,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_FI,
         **KEYLESS_ENTRY_CONTEXT_FI,
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         **COMMON_CONTEXT,
+        "access_code_validity_period": "",
     },
     "sv": {
         "title": "Dörrkoden har ändrats",
         "text_reservation_modified": "Dörrkoden har ändrats",
-        "weekday_value": "Måndag",
+        "allocations": [
+            {"weekday_value": "Måndag", "time_value": "13:00-15:00", "access_code_validity_period": "11:00-15:00"},
+            {"weekday_value": "Tisdag", "time_value": "21:00-22:00", "access_code_validity_period": "20:45-22:05"},
+        ],
         **BASE_TEMPLATE_CONTEXT_SV,
         **SEASONAL_RESERVATION_CHECK_BOOKING_DETAILS_LINK_SV,
         **KEYLESS_ENTRY_CONTEXT_SV,
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         **COMMON_CONTEXT,
+        "access_code_validity_period": "",
     },
 }
 
@@ -111,17 +128,35 @@ def test_get_context_for_seasonal_reservation_modified_series_access_code(lang: 
 
 @pytest.mark.django_db
 @freeze_time("2024-01-01 12:00:00+02:00")
-@patch_method(
-    PindoraClient.get_reservation_series,
-    return_value=PindoraReservationSeriesResponse(
-        access_code="123456",
-        reservation_unit_code_validity=[
-            {"begin": datetime.datetime(2024, 1, 1, 11), "end": datetime.datetime(2024, 1, 1, 15)}
-        ],
-    ),
-)
+@patch_method(PindoraClient.get_seasonal_booking)
 def test_get_context_for_seasonal_reservation_modified_series_access_codes__instance(email_reservation):
     section = email_reservation.actions.get_application_section()
+
+    section.actions.get_reservations().update(access_type=AccessType.ACCESS_CODE)
+
+    all_series = section.actions.get_reservation_series()
+    reservation_unit_1 = all_series[0].reservation_unit
+    reservation_unit_2 = all_series[1].reservation_unit
+
+    PindoraClient.get_seasonal_booking.return_value = PindoraSeasonalBookingResponse(
+        access_code="123456",
+        reservation_unit_code_validity=[
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_1.uuid,
+                begin=datetime.datetime(2024, 1, 1, 11),
+                end=datetime.datetime(2024, 1, 1, 15),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_2.uuid,
+                begin=datetime.datetime(2024, 1, 2, 20, 45),
+                end=datetime.datetime(2024, 1, 2, 22, 5),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+        ],
+    )
 
     expected = {
         **LANGUAGE_CONTEXT["en"],
@@ -139,10 +174,9 @@ def test_get_context_for_seasonal_reservation_modified_series_access_codes__inst
         assert context == expected
 
     with TranslationsFromPOFiles():
-        context = get_context_for_seasonal_reservation_modified_series_access_code(
-            reservation_series=email_reservation.recurring_reservation,
-            language="en",
-        )
+        allocation = email_reservation.recurring_reservation.allocated_time_slot
+        section = allocation.reservation_unit_option.application_section
+        context = get_context_for_seasonal_reservation_modified_series_access_code(section, language="en")
         assert context == expected
 
 
@@ -154,6 +188,7 @@ def test_render_seasonal_reservation_modified_series_access_code__text():
     context = get_mock_data(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES_ACCESS_CODE, language="en")
     text_content = render_text(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES_ACCESS_CODE, context=context)
     text_content = text_content.replace("&amp;", "&")
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
 
     assert text_content == cleandoc(
         f"""
@@ -163,13 +198,17 @@ def test_render_seasonal_reservation_modified_series_access_code__text():
 
         Seasonal Booking: [HAKEMUKSEN OSAN NIMI], [KAUSIVARAUSKIERROKSEN NIMI]
 
+        Door code: 123456
+
         Day: Monday
         Time: 13:00-15:00
-
-        Door code: 123456
         Validity period of the door code: 11:00-15:00
 
-        You can check your booking details at: https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678
+        Day: Tuesday
+        Time: 21:00-22:00
+        Validity period of the door code: 20:45-22:05
+
+        You can check your booking details at: {url}
 
         {EMAIL_CLOSING_TEXT_EN}
         """
@@ -184,6 +223,7 @@ def test_render_seasonal_reservation_modified_series_access_code__html():
     context = get_mock_data(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES_ACCESS_CODE, language="en")
     html_content = render_html(email_type=EmailType.SEASONAL_RESERVATION_MODIFIED_SERIES_ACCESS_CODE, context=context)
     text_content = html_email_to_text(html_content)
+    url = "https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678"
 
     assert text_content == cleandoc(
         f"""
@@ -194,11 +234,14 @@ def test_render_seasonal_reservation_modified_series_access_code__html():
         The door code has changed.
 
         Seasonal Booking: [HAKEMUKSEN OSAN NIMI], [KAUSIVARAUSKIERROKSEN NIMI]
+        Door code: 123456
         Day: Monday
         Time: 13:00-15:00
-        Door code: 123456
         Validity period of the door code: 11:00-15:00
-        You can check your booking details at: [varaamo.hel.fi](https://fake.varaamo.hel.fi/en/applications/1234/view?tab=reservations&section=5678)
+        Day: Tuesday
+        Time: 21:00-22:00
+        Validity period of the door code: 20:45-22:05
+        You can check your booking details at: [varaamo.hel.fi]({url})
 
         {EMAIL_CLOSING_HTML_EN}
         """
@@ -211,26 +254,41 @@ def test_render_seasonal_reservation_modified_series_access_code__html():
 @pytest.mark.django_db
 @override_settings(SEND_EMAILS=True)
 @freeze_time("2024-01-01 12:00:00+02:00")
-@patch_method(
-    PindoraClient.get_reservation_series,
-    return_value=PindoraReservationSeriesResponse(
+@patch_method(PindoraClient.get_seasonal_booking)
+def test_email_service__send_seasonal_reservation_modified_series_access_code(outbox):
+    ext_uuid = uuid.uuid4()
+
+    PindoraClient.get_seasonal_booking.return_value = PindoraSeasonalBookingResponse(
         access_code="123456",
         reservation_unit_code_validity=[
-            {"begin": datetime.datetime(2024, 1, 1, 11), "end": datetime.datetime(2024, 1, 1, 15)}
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=ext_uuid,
+                begin=datetime.datetime(2024, 1, 1, 11),
+                end=datetime.datetime(2024, 1, 1, 15),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
         ],
-    ),
-)
-def test_email_service__send_seasonal_reservation_modified_series_access_code(outbox):
-    reservation_series = create_reservation_series(
-        reservations__type=ReservationTypeChoice.SEASONAL,
-        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
-        allocated_time_slot__reservation_unit_option__application_section__application__user__email="user@email.com",
-        allocated_time_slot__reservation_unit_option__application_section__application__contact_person__email="contact@email.com",
-        allocated_time_slot__reservation_unit_option__application_section__application__sent_date=local_datetime(),
-        allocated_time_slot__reservation_unit_option__application_section__application__application_round__sent_date=local_datetime(),
     )
 
-    EmailService.send_seasonal_reservation_modified_series_access_code_email(reservation_series=reservation_series)
+    user = UserFactory.create(email="user@email.com")
+    application = ApplicationFactory.create(
+        user=user,
+        contact_person__email="contact@email.com",
+        sent_date=local_datetime(),
+        application_round__sent_date=local_datetime(),
+    )
+    reservation_series = create_reservation_series(
+        user=user,
+        reservation_unit__uuid=ext_uuid,
+        reservations__type=ReservationTypeChoice.SEASONAL,
+        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
+    )
+
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_access_code_email(section)
 
     assert len(outbox) == 1
 
@@ -241,16 +299,49 @@ def test_email_service__send_seasonal_reservation_modified_series_access_code(ou
 @pytest.mark.django_db
 @override_settings(SEND_EMAILS=True)
 @freeze_time("2024-01-01 12:00:00+02:00")
-def test_email_service__send_seasonal_reservation_modified_series_access_code__email_not_sent__no_allocated_time_slot(
-    outbox,
-):
-    reservation_series = create_reservation_series(
-        user__email="user@email.com",
-        reservations__type=ReservationTypeChoice.SEASONAL,
-        reservations__reservee_email="reservee@email.com",
-        allocated_time_slot=None,
+def test_email_service__send_seasonal_reservation_modified_series_access_code__no_reservations(outbox):
+    user = UserFactory.create(email="user@email.com")
+    application = ApplicationFactory.create(
+        user=user,
+        contact_person__email="contact@email.com",
+        sent_date=local_datetime(),
+        application_round__sent_date=local_datetime(),
+    )
+    reservation_series = RecurringReservationFactory.create(
+        user=user,
+        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
     )
 
-    EmailService.send_seasonal_reservation_modified_series_access_code_email(reservation_series=reservation_series)
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_access_code_email(section)
 
     assert len(outbox) == 0
+
+
+@pytest.mark.django_db
+@override_settings(SEND_EMAILS=True)
+@freeze_time("2024-01-01 12:00:00+02:00")
+@patch_method(SentryLogger.log_message)
+def test_email_service__send_seasonal_reservation_modified_series_access_code__no_recipients(outbox):
+    application = ApplicationFactory.create(
+        user=None,
+        contact_person=None,
+        sent_date=local_datetime(),
+        application_round__sent_date=local_datetime(),
+    )
+    reservation_series = create_reservation_series(
+        user=None,
+        reservations__type=ReservationTypeChoice.SEASONAL,
+        allocated_time_slot__day_of_the_week=Weekday.MONDAY,
+        allocated_time_slot__reservation_unit_option__application_section__application=application,
+    )
+
+    section = reservation_series.allocated_time_slot.reservation_unit_option.application_section
+
+    EmailService.send_seasonal_reservation_modified_series_access_code_email(section)
+
+    assert len(outbox) == 0
+
+    assert SentryLogger.log_message.call_count == 1

--- a/backend/tilavarauspalvelu/admin/email_template/forms.py
+++ b/backend/tilavarauspalvelu/admin/email_template/forms.py
@@ -108,4 +108,5 @@ def get_email_tester_form_fields() -> dict[str, Any]:
             initial=initial["access_code_validity_period"], widget=text_widget
         ),
         "language": forms.ChoiceField(initial=Language.FI.value, choices=Language.choices),
+        "allocations": forms.JSONField(initial=initial["allocations"]),
     }

--- a/backend/tilavarauspalvelu/admin/email_template/utils.py
+++ b/backend/tilavarauspalvelu/admin/email_template/utils.py
@@ -80,6 +80,21 @@ def get_mock_params(language: Lang, **kwargs: Any) -> EmailContext | datetime | 
         "access_code_validity_period": (
             kwargs.get("access_code_validity_period", "11:00-15:00") if access_code_is_used else ""
         ),
+        "allocations": kwargs.get(
+            "allocations",
+            [
+                {
+                    "weekday_value": str(WeekdayChoice.MONDAY.label),
+                    "time_value": "13:00-15:00",
+                    "access_code_validity_period": "11:00-15:00" if access_code_is_used else "",
+                },
+                {
+                    "weekday_value": str(WeekdayChoice.TUESDAY.label),
+                    "time_value": "21:00-22:00",
+                    "access_code_validity_period": "20:45-22:05" if access_code_is_used else "",
+                },
+            ],
+        ),
         "language": language,
     }
 

--- a/backend/tilavarauspalvelu/admin/email_template/view.py
+++ b/backend/tilavarauspalvelu/admin/email_template/view.py
@@ -16,6 +16,7 @@ from tilavarauspalvelu.integrations.email.typing import EmailType
 if TYPE_CHECKING:
     from django.utils.safestring import SafeString
 
+    from tilavarauspalvelu.integrations.email.typing import EmailTemplateType
     from tilavarauspalvelu.typing import Lang, WSGIRequest
 
 
@@ -67,7 +68,7 @@ def email_templates_admin_list_view(request: WSGIRequest, **kwargs: Any) -> Tabl
 
 def email_type_admin_view(request: WSGIRequest, email_type: str) -> HttpResponse:
     try:
-        email_type = EmailType.get(email_type)
+        email_template_type = EmailType.get(email_type)
     except ValueError:
         return HttpResponse("Invalid email type")
 
@@ -76,13 +77,13 @@ def email_type_admin_view(request: WSGIRequest, email_type: str) -> HttpResponse
     if language not in {"fi", "en", "sv"}:
         language = "fi"
 
-    content = render_with_mock_data(email_type=email_type, language=language, as_html=as_html)
+    content = render_with_mock_data(email_type=email_template_type, language=language, as_html=as_html)
     if content is None:
-        return HttpResponse(f"Email type '{email_type}' template not implemented.")
+        return HttpResponse(f"Email type '{email_template_type}' template not implemented.")
     return HttpResponse(content)
 
 
-def render_with_mock_data(*, email_type: type[EmailType], language: Lang, as_html: bool) -> str | None:
+def render_with_mock_data(*, email_type: EmailTemplateType, language: Lang, as_html: bool) -> str | None:
     context = get_mock_data(email_type=email_type, language=language)
 
     if as_html:

--- a/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/serializers/deny_serializer.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/serializers/deny_serializer.py
@@ -89,7 +89,9 @@ class ReservationSeriesDenyInputSerializer(NestingModelSerializer):
                 reservation_pks=[reservation.pk for reservation in reservations],
             )
 
-        EmailService.send_seasonal_reservation_rejected_series_email(reservation_series=instance)
+        if instance.allocated_time_slot is not None:
+            section = instance.allocated_time_slot.reservation_unit_option.application_section
+            EmailService.send_seasonal_reservation_rejected_series_email(section)
 
         return instance
 

--- a/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/serializers/reschedule_serializer.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/serializers/reschedule_serializer.py
@@ -156,7 +156,9 @@ class ReservationSeriesRescheduleSerializer(NestingModelSerializer):
                 reservation_pks=[reservation.pk for reservation in reservations],
             )
 
-        EmailService.send_seasonal_reservation_modified_series_email(instance)
+        if instance.allocated_time_slot is not None:
+            section = instance.allocated_time_slot.reservation_unit_option.application_section
+            EmailService.send_seasonal_reservation_modified_series_email(section)
 
         return instance
 

--- a/backend/tilavarauspalvelu/integrations/email/template_context/application.py
+++ b/backend/tilavarauspalvelu/integrations/email/template_context/application.py
@@ -129,7 +129,7 @@ def get_context_for_application_section_cancelled(
             "cancel_reason": get_attr_by_language(reservation.cancel_reason, "reason", language),
             "application_id": getattr(application_section, "application_id", None),
             "application_section_id": getattr(application_section, "id", None),
-            **params_for_application_section_info(application_section=application_section, language=language),
+            **params_for_application_section_info(section=application_section, language=language),
         }
 
     return {
@@ -176,7 +176,7 @@ def get_context_for_staff_notification_application_section_cancelled(
     if application_section is not None:
         reservation_series_data = [
             {
-                **params_for_reservation_series_info(reservation_series=series),
+                **params_for_reservation_series_info(series=series),
                 "reservation_url": get_staff_reservations_ext_link(
                     reservation_id=series.reservations.values_list("pk", flat=True).last()
                 ),
@@ -188,7 +188,7 @@ def get_context_for_staff_notification_application_section_cancelled(
         data: dict[str, Any] = {
             "cancel_reason": get_attr_by_language(reservation.cancel_reason, "reason", language),
             "cancelled_reservation_series": reservation_series_data,
-            **params_for_application_section_info(application_section=application_section, language=language),
+            **params_for_application_section_info(section=application_section, language=language),
         }
 
     return {

--- a/backend/tilavarauspalvelu/integrations/email/typing.py
+++ b/backend/tilavarauspalvelu/integrations/email/typing.py
@@ -36,7 +36,7 @@ from tilavarauspalvelu.integrations.email.template_context.reservation import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
     from tilavarauspalvelu.typing import EmailAttachment, EmailContext
 
@@ -84,7 +84,7 @@ class EmailData:
 class EmailTemplateType:
     label: str
     value: str = dataclasses.field(init=False)
-    get_email_context: callable
+    get_email_context: Callable
     context_variables: list[str]
 
     def __set_name__(self, owner: Any, name: str) -> None:
@@ -317,6 +317,11 @@ class EmailType(_EmailTypeOptions):
             "instructions_confirmed",
         ],
     )
+
+    # Reservation series
+
+    # Seasonal reservation
+
     SEASONAL_RESERVATION_CANCELLED_SINGLE = EmailTemplateType(
         # User cancels one of their seasonal reservations
         label=pgettext_lazy("EmailType", "Seasonal reservation cancelled single"),
@@ -341,15 +346,13 @@ class EmailType(_EmailTypeOptions):
         context_variables=[
             "language",
             "email_recipient_name",
-            "weekday_value",
-            "time_value",
             "application_section_name",
             "application_round_name",
             "application_id",
             "application_section_id",
             "access_code_is_used",
             "access_code",
-            "access_code_validity_period",
+            "allocations",
         ],
     )
     SEASONAL_RESERVATION_MODIFIED_SERIES_ACCESS_CODE = EmailTemplateType(
@@ -359,15 +362,13 @@ class EmailType(_EmailTypeOptions):
         context_variables=[
             "language",
             "email_recipient_name",
-            "weekday_value",
-            "time_value",
             "application_section_name",
             "application_round_name",
             "application_id",
             "application_section_id",
             "access_code_is_used",
             "access_code",
-            "access_code_validity_period",
+            "allocations",
         ],
     )
     SEASONAL_RESERVATION_MODIFIED_SINGLE = EmailTemplateType(
@@ -394,12 +395,11 @@ class EmailType(_EmailTypeOptions):
             "language",
             "rejection_reason",
             "email_recipient_name",
-            "weekday_value",
-            "time_value",
             "application_section_name",
             "application_round_name",
             "application_id",
             "application_section_id",
+            "allocations",
         ],
     )
     SEASONAL_RESERVATION_REJECTED_SINGLE = EmailTemplateType(

--- a/backend/tilavarauspalvelu/models/application_section/actions.py
+++ b/backend/tilavarauspalvelu/models/application_section/actions.py
@@ -30,9 +30,7 @@ class ApplicationSectionActions:
         )
 
     def get_reservations(self) -> ReservationQuerySet:
-        return Reservation.objects.for_application_section(self.application_section).filter(
-            user=self.application_section.application.user,
-        )
+        return Reservation.objects.for_application_section(self.application_section)
 
     def get_last_reservation(self) -> Reservation | None:
         return self.get_reservations().last()


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Changes the seasonal booking emails to take in an application section instead of a series
- Changes how Pindora information is retrieved for these emails
- Changes rules for when series modify emails are sent
- Fixes some minor typing issues
- Fixes a bug where access code validity didn't account for valid before and after minutes

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3900](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3900)


[TILA-3900]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ