### PR TITLE
Fix graphql non-null fields

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -221,14 +221,14 @@ export type ApplicantNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -300,7 +300,7 @@ export type ApplicationNode = Node & {
   readonly organisation: Maybe<OrganisationNode>;
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationStatusChoice>;
+  readonly status: ApplicationStatusChoice;
   readonly user: Maybe<ApplicantNode>;
   readonly workingMemo: Scalars["String"]["output"];
 };
@@ -377,7 +377,7 @@ export enum ApplicationOrderingChoices {
 export type ApplicationRoundNode = Node & {
   readonly applicationPeriodBegin: Scalars["DateTime"]["output"];
   readonly applicationPeriodEnd: Scalars["DateTime"]["output"];
-  readonly applicationsCount: Maybe<Scalars["Int"]["output"]>;
+  readonly applicationsCount: Scalars["Int"]["output"];
   readonly criteria: Scalars["String"]["output"];
   readonly criteriaEn: Maybe<Scalars["String"]["output"]>;
   readonly criteriaFi: Maybe<Scalars["String"]["output"]>;
@@ -385,7 +385,7 @@ export type ApplicationRoundNode = Node & {
   readonly handledDate: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isSettingHandledAllowed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isSettingHandledAllowed: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -398,13 +398,13 @@ export type ApplicationRoundNode = Node & {
   readonly publicDisplayBegin: Scalars["DateTime"]["output"];
   readonly publicDisplayEnd: Scalars["DateTime"]["output"];
   readonly purposes: ReadonlyArray<ReservationPurposeNode>;
-  readonly reservationCreationStatus: Maybe<ApplicationRoundReservationCreationStatusChoice>;
+  readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice;
   readonly reservationPeriodBegin: Scalars["Date"]["output"];
   readonly reservationPeriodEnd: Scalars["Date"]["output"];
-  readonly reservationUnitCount: Maybe<Scalars["Int"]["output"]>;
+  readonly reservationUnitCount: Scalars["Int"]["output"];
   readonly reservationUnits: ReadonlyArray<ReservationUnitNode>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationRoundStatusChoice>;
+  readonly status: ApplicationRoundStatusChoice;
   readonly statusTimestamp: Maybe<Scalars["DateTime"]["output"]>;
   readonly termsOfUse: Maybe<TermsOfUseNode>;
 };
@@ -436,10 +436,10 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -453,18 +453,18 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -475,13 +475,13 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -529,7 +529,7 @@ export type ApplicationRoundTimeSlotNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservableTimes: Maybe<ReadonlyArray<Maybe<TimeSlotType>>>;
+  readonly reservableTimes: ReadonlyArray<Maybe<TimeSlotType>>;
   readonly weekday: Scalars["Int"]["output"];
 };
 
@@ -610,7 +610,7 @@ export type ApplicationSectionForApplicationSerializerInput = {
 
 export type ApplicationSectionNode = Node & {
   readonly ageGroup: Maybe<AgeGroupNode>;
-  readonly allocations: Maybe<Scalars["Int"]["output"]>;
+  readonly allocations: Scalars["Int"]["output"];
   readonly application: ApplicationNode;
   readonly appliedReservationsPerWeek: Scalars["Int"]["output"];
   readonly extUuid: Scalars["UUID"]["output"];
@@ -628,8 +628,8 @@ export type ApplicationSectionNode = Node & {
   readonly reservationUnitOptions: ReadonlyArray<ReservationUnitOptionNode>;
   readonly reservationsBeginDate: Scalars["Date"]["output"];
   readonly reservationsEndDate: Scalars["Date"]["output"];
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly status: Maybe<ApplicationSectionStatusChoice>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly status: ApplicationSectionStatusChoice;
   readonly suitableTimeRanges: ReadonlyArray<SuitableTimeRangeNode>;
 };
 
@@ -889,7 +889,7 @@ export type BannerNotificationNode = Node & {
   readonly messageSv: Maybe<Scalars["String"]["output"]>;
   readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly state: Maybe<BannerNotificationState>;
+  readonly state: BannerNotificationState;
   readonly target: BannerNotificationTarget;
 };
 
@@ -1189,7 +1189,7 @@ export type GeneralRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly user: UserNode;
 };
@@ -1201,7 +1201,7 @@ export type HelsinkiProfileDataNode = {
   readonly firstName: Maybe<Scalars["String"]["output"]>;
   readonly isStrongLogin: Scalars["Boolean"]["output"];
   readonly lastName: Maybe<Scalars["String"]["output"]>;
-  readonly loginMethod: Maybe<LoginMethod>;
+  readonly loginMethod: LoginMethod;
   readonly municipalityCode: Maybe<Scalars["String"]["output"]>;
   readonly municipalityName: Maybe<Scalars["String"]["output"]>;
   readonly phone: Maybe<Scalars["String"]["output"]>;
@@ -1693,7 +1693,7 @@ export type PaymentMerchantNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly name: Scalars["String"]["output"];
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 export type PaymentOrderNode = Node & {
@@ -1707,14 +1707,14 @@ export type PaymentOrderNode = Node & {
   readonly receiptUrl: Maybe<Scalars["String"]["output"]>;
   readonly refundUuid: Maybe<Scalars["UUID"]["output"]>;
   readonly reservationPk: Maybe<Scalars["String"]["output"]>;
-  readonly status: Maybe<OrderStatus>;
+  readonly status: OrderStatus;
 };
 
 export type PaymentProductNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly merchant: Maybe<PaymentMerchantNode>;
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 /** An enumeration. */
@@ -1766,9 +1766,7 @@ export type PindoraSectionInfoType = {
   readonly accessCodePhoneNumber: Scalars["String"]["output"];
   readonly accessCodeSmsMessage: Scalars["String"]["output"];
   readonly accessCodeSmsNumber: Scalars["String"]["output"];
-  readonly accessCodeValidity: ReadonlyArray<
-    Maybe<PindoraSectionValidityInfoType>
-  >;
+  readonly accessCodeValidity: ReadonlyArray<PindoraSectionValidityInfoType>;
 };
 
 export type PindoraSectionValidityInfoType = {
@@ -2229,8 +2227,8 @@ export type QueryEquipmentsArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryEquipmentsAllArgs = {
@@ -2440,10 +2438,10 @@ export type QueryReservationUnitsArgs = {
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
   last?: InputMaybe<Scalars["Int"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -2458,18 +2456,18 @@ export type QueryReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -2480,13 +2478,13 @@ export type QueryReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -2681,7 +2679,7 @@ export type QueryUserArgs = {
 
 export type RecurringReservationNode = Node & {
   readonly abilityGroup: Maybe<AbilityGroupNode>;
-  readonly accessType: Maybe<AccessTypeWithMultivalued>;
+  readonly accessType: AccessTypeWithMultivalued;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly allocatedTimeSlot: Maybe<AllocatedTimeSlotNode>;
   readonly beginDate: Maybe<Scalars["Date"]["output"]>;
@@ -2693,7 +2691,7 @@ export type RecurringReservationNode = Node & {
   readonly extUuid: Scalars["UUID"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple series, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraSeriesInfoType>;
@@ -2702,10 +2700,10 @@ export type RecurringReservationNode = Node & {
   readonly rejectedOccurrences: ReadonlyArray<RejectedOccurrenceNode>;
   readonly reservationUnit: ReservationUnitNode;
   readonly reservations: ReadonlyArray<ReservationNode>;
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly usedAccessTypes: Maybe<ReadonlyArray<Maybe<AccessType>>>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly usedAccessTypes: ReadonlyArray<Maybe<AccessType>>;
   readonly user: Maybe<UserNode>;
-  readonly weekdays: Maybe<ReadonlyArray<Maybe<Scalars["Int"]["output"]>>>;
+  readonly weekdays: ReadonlyArray<Scalars["Int"]["output"]>;
 };
 
 export type RecurringReservationNodeRejectedOccurrencesArgs = {
@@ -3105,8 +3103,8 @@ export type ReservationNode = Node & {
   readonly accessCodeShouldBeActive: Maybe<Scalars["Boolean"]["output"]>;
   readonly accessType: AccessType;
   /** Which reservation units' reserveability is affected by this reservation? */
-  readonly affectedReservationUnits: Maybe<
-    ReadonlyArray<Maybe<Scalars["Int"]["output"]>>
+  readonly affectedReservationUnits: ReadonlyArray<
+    Maybe<Scalars["Int"]["output"]>
   >;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly applyingForFreeOfCharge: Maybe<Scalars["Boolean"]["output"]>;
@@ -3120,7 +3118,7 @@ export type ReservationNode = Node & {
   readonly billingPhone: Maybe<Scalars["String"]["output"]>;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calendarUrl: Maybe<Scalars["String"]["output"]>;
+  readonly calendarUrl: Scalars["String"]["output"];
   readonly cancelDetails: Maybe<Scalars["String"]["output"]>;
   readonly cancelReason: Maybe<ReservationCancelReasonNode>;
   readonly createdAt: Maybe<Scalars["DateTime"]["output"]>;
@@ -3134,13 +3132,11 @@ export type ReservationNode = Node & {
   readonly homeCity: Maybe<CityNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isBlocked: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
+  readonly isBlocked: Scalars["Boolean"]["output"];
   readonly isHandled: Maybe<Scalars["Boolean"]["output"]>;
   readonly name: Maybe<Scalars["String"]["output"]>;
   readonly numPersons: Maybe<Scalars["Int"]["output"]>;
-  /** @deprecated Please use to 'paymentOrder' instead. */
-  readonly order: Maybe<PaymentOrderNode>;
   readonly paymentOrder: ReadonlyArray<PaymentOrderNode>;
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple reservations, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraReservationInfoType>;
@@ -3164,8 +3160,6 @@ export type ReservationNode = Node & {
   readonly reserveeOrganisationName: Maybe<Scalars["String"]["output"]>;
   readonly reserveePhone: Maybe<Scalars["String"]["output"]>;
   readonly reserveeType: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please use to 'type' instead. */
-  readonly staffEvent: Maybe<Scalars["Boolean"]["output"]>;
   readonly state: Maybe<ReservationStateChoice>;
   readonly taxPercentageValue: Maybe<Scalars["Decimal"]["output"]>;
   readonly type: Maybe<ReservationTypeChoice>;
@@ -3191,10 +3185,10 @@ export type ReservationNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -3208,18 +3202,18 @@ export type ReservationNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -3230,13 +3224,13 @@ export type ReservationNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -3257,13 +3251,10 @@ export type ReservationNodeEdge = {
   readonly node: Maybe<ReservationNode>;
 };
 
-/** An enumeration. */
+/** When user wants to receive reservation notification emails. */
 export enum ReservationNotification {
-  /** All */
   All = "ALL",
-  /** None */
   None = "NONE",
-  /** Only Handling Required */
   OnlyHandlingRequired = "ONLY_HANDLING_REQUIRED",
 }
 
@@ -4106,7 +4097,7 @@ export type ReservationUnitNode = Node & {
   readonly authentication: Authentication;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calculatedSurfaceArea: Maybe<Scalars["Int"]["output"]>;
+  readonly calculatedSurfaceArea: Scalars["Int"]["output"];
   readonly canApplyFreeOfCharge: Scalars["Boolean"]["output"];
   readonly cancellationRule: Maybe<ReservationUnitCancellationRuleNode>;
   readonly cancellationTerms: Maybe<TermsOfUseNode>;
@@ -4124,7 +4115,7 @@ export type ReservationUnitNode = Node & {
   readonly id: Scalars["ID"]["output"];
   readonly images: ReadonlyArray<ReservationUnitImageNode>;
   readonly isArchived: Scalars["Boolean"]["output"];
-  readonly isClosed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isClosed: Scalars["Boolean"]["output"];
   readonly isDraft: Scalars["Boolean"]["output"];
   readonly location: Maybe<LocationNode>;
   readonly maxPersons: Maybe<Scalars["Int"]["output"]>;
@@ -4137,7 +4128,7 @@ export type ReservationUnitNode = Node & {
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
   readonly nameSv: Maybe<Scalars["String"]["output"]>;
-  readonly numActiveUserReservations: Maybe<Scalars["Int"]["output"]>;
+  readonly numActiveUserReservations: Scalars["Int"]["output"];
   readonly paymentMerchant: Maybe<PaymentMerchantNode>;
   readonly paymentProduct: Maybe<PaymentProductNode>;
   readonly paymentTerms: Maybe<TermsOfUseNode>;
@@ -4147,15 +4138,13 @@ export type ReservationUnitNode = Node & {
   readonly pricings: ReadonlyArray<ReservationUnitPricingNode>;
   readonly publishBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly publishEnds: Maybe<Scalars["DateTime"]["output"]>;
-  readonly publishingState: Maybe<ReservationUnitPublishingState>;
+  readonly publishingState: ReservationUnitPublishingState;
   readonly purposes: ReadonlyArray<PurposeNode>;
   readonly qualifiers: ReadonlyArray<QualifierNode>;
   readonly rank: Scalars["Int"]["output"];
   readonly requireAdultReservee: Scalars["Boolean"]["output"];
   readonly requireReservationHandling: Scalars["Boolean"]["output"];
-  readonly reservableTimeSpans: Maybe<
-    ReadonlyArray<Maybe<ReservableTimeSpanType>>
-  >;
+  readonly reservableTimeSpans: Maybe<ReadonlyArray<ReservableTimeSpanType>>;
   readonly reservationBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly reservationBlockWholeDay: Scalars["Boolean"]["output"];
   readonly reservationCancelledInstructions: Scalars["String"]["output"];
@@ -4185,7 +4174,7 @@ export type ReservationUnitNode = Node & {
   readonly reservationPendingInstructionsFi: Maybe<Scalars["String"]["output"]>;
   readonly reservationPendingInstructionsSv: Maybe<Scalars["String"]["output"]>;
   readonly reservationStartInterval: ReservationStartInterval;
-  readonly reservationState: Maybe<ReservationUnitReservationState>;
+  readonly reservationState: ReservationUnitReservationState;
   readonly reservationUnitType: Maybe<ReservationUnitTypeNode>;
   readonly reservations: Maybe<ReadonlyArray<ReservationNode>>;
   readonly reservationsMaxDaysBefore: Maybe<Scalars["Int"]["output"]>;
@@ -4240,8 +4229,8 @@ export type ReservationUnitNodeEquipmentsArgs = {
   name_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ReservationUnitNodePurposesArgs = {
@@ -4446,11 +4435,11 @@ export type ReservationUnitPaymentTypeNode = Node & {
 export type ReservationUnitPricingNode = Node & {
   readonly begins: Scalars["Date"]["output"];
   readonly highestPrice: Scalars["Decimal"]["output"];
-  readonly highestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly highestPriceNet: Scalars["Decimal"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly lowestPrice: Scalars["Decimal"]["output"];
-  readonly lowestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly lowestPriceNet: Scalars["Decimal"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly priceUnit: PriceUnit;
   readonly taxPercentage: TaxPercentageNode;
@@ -4865,7 +4854,7 @@ export enum ResourceLocationType {
 export type ResourceNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly locationType: Maybe<ResourceLocationType>;
+  readonly locationType: ResourceLocationType;
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -5100,7 +5089,7 @@ export type SuitableTimeRangeNode = Node & {
   readonly beginTime: Scalars["Time"]["output"];
   readonly dayOfTheWeek: Weekday;
   readonly endTime: Scalars["Time"]["output"];
-  readonly fulfilled: Maybe<Scalars["Boolean"]["output"]>;
+  readonly fulfilled: Scalars["Boolean"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
@@ -5315,10 +5304,10 @@ export type UnitNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -5332,18 +5321,18 @@ export type UnitNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -5354,13 +5343,13 @@ export type UnitNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -5426,7 +5415,7 @@ export type UnitRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly unitGroups: ReadonlyArray<UnitGroupNode>;
   readonly units: ReadonlyArray<UnitNode>;
@@ -5639,14 +5628,14 @@ export type UserNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -5768,7 +5757,7 @@ export type ApplicationSectionCommonFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly name: string;
-  readonly status: ApplicationSectionStatusChoice | null;
+  readonly status: ApplicationSectionStatusChoice;
   readonly reservationMaxDuration: number;
   readonly numPersons: number;
   readonly reservationsEndDate: string;
@@ -6034,7 +6023,7 @@ export type ApplicationSectionFieldsFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly name: string;
-  readonly status: ApplicationSectionStatusChoice | null;
+  readonly status: ApplicationSectionStatusChoice;
   readonly reservationMaxDuration: number;
   readonly numPersons: number;
   readonly reservationsEndDate: string;
@@ -6049,7 +6038,7 @@ export type ApplicationSectionFieldsFragment = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly organisation: {
       readonly id: string;
@@ -6093,14 +6082,14 @@ export type ReservationCommonFieldsFragment = {
   readonly createdAt: string | null;
   readonly state: ReservationStateChoice | null;
   readonly type: ReservationTypeChoice | null;
-  readonly isBlocked: boolean | null;
+  readonly isBlocked: boolean;
   readonly workingMemo: string | null;
   readonly reserveeName: string | null;
   readonly bufferTimeBefore: number;
   readonly bufferTimeAfter: number;
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
   }>;
   readonly user: {
     readonly id: string;
@@ -6113,8 +6102,8 @@ export type ReservationCommonFieldsFragment = {
 export type ReservationUnitReservationsFragment = {
   readonly name: string | null;
   readonly numPersons: number | null;
-  readonly calendarUrl: string | null;
-  readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+  readonly calendarUrl: string;
+  readonly affectedReservationUnits: ReadonlyArray<number | null>;
   readonly id: string;
   readonly pk: number | null;
   readonly begin: string;
@@ -6122,7 +6111,7 @@ export type ReservationUnitReservationsFragment = {
   readonly createdAt: string | null;
   readonly state: ReservationStateChoice | null;
   readonly type: ReservationTypeChoice | null;
-  readonly isBlocked: boolean | null;
+  readonly isBlocked: boolean;
   readonly workingMemo: string | null;
   readonly reserveeName: string | null;
   readonly bufferTimeBefore: number;
@@ -6137,7 +6126,7 @@ export type ReservationUnitReservationsFragment = {
   }>;
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
   }>;
   readonly user: {
     readonly id: string;
@@ -6235,7 +6224,7 @@ export type DenyDialogFieldsFragment = {
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
     readonly orderUuid: string | null;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
     readonly refundUuid: string | null;
   }>;
 };
@@ -6302,7 +6291,7 @@ export type ChangeReservationTimeFragment = {
   readonly recurringReservation: {
     readonly pk: number | null;
     readonly id: string;
-    readonly weekdays: ReadonlyArray<number | null> | null;
+    readonly weekdays: ReadonlyArray<number>;
     readonly beginDate: string | null;
     readonly endDate: string | null;
   } | null;
@@ -6448,7 +6437,7 @@ export type RecurringReservationQuery = {
   readonly recurringReservation: {
     readonly id: string;
     readonly pk: number | null;
-    readonly weekdays: ReadonlyArray<number | null> | null;
+    readonly weekdays: ReadonlyArray<number>;
     readonly beginDate: string | null;
     readonly endDate: string | null;
     readonly reservations: ReadonlyArray<{
@@ -6463,7 +6452,7 @@ export type RecurringReservationQuery = {
       readonly bufferTimeBefore: number;
       readonly paymentOrder: ReadonlyArray<{
         readonly id: string;
-        readonly status: OrderStatus | null;
+        readonly status: OrderStatus;
       }>;
       readonly reservationUnits: ReadonlyArray<{
         readonly id: string;
@@ -6479,7 +6468,7 @@ export type RecurringReservationQuery = {
       readonly recurringReservation: {
         readonly pk: number | null;
         readonly id: string;
-        readonly weekdays: ReadonlyArray<number | null> | null;
+        readonly weekdays: ReadonlyArray<number>;
         readonly beginDate: string | null;
         readonly endDate: string | null;
       } | null;
@@ -6561,7 +6550,7 @@ export type CurrentUserQuery = {
     readonly pk: number | null;
     readonly unitRoles: ReadonlyArray<{
       readonly id: string;
-      readonly permissions: ReadonlyArray<UserPermissionChoice | null> | null;
+      readonly permissions: ReadonlyArray<UserPermissionChoice>;
       readonly role: UserRoleChoice;
       readonly units: ReadonlyArray<{
         readonly id: string;
@@ -6578,7 +6567,7 @@ export type CurrentUserQuery = {
     }>;
     readonly generalRoles: ReadonlyArray<{
       readonly id: string;
-      readonly permissions: ReadonlyArray<UserPermissionChoice | null> | null;
+      readonly permissions: ReadonlyArray<UserPermissionChoice>;
       readonly role: UserRoleChoice;
     }>;
   } | null;
@@ -6592,8 +6581,8 @@ export type ReservationUnitEditQuery = {
   readonly reservationUnit: {
     readonly id: string;
     readonly pk: number | null;
-    readonly publishingState: ReservationUnitPublishingState | null;
-    readonly reservationState: ReservationUnitReservationState | null;
+    readonly publishingState: ReservationUnitPublishingState;
+    readonly reservationState: ReservationUnitReservationState;
     readonly haukiUrl: string | null;
     readonly requireReservationHandling: boolean;
     readonly nameFi: string | null;
@@ -6711,8 +6700,8 @@ export type ReservationUnitEditQuery = {
     } | null;
     readonly pricings: ReadonlyArray<{
       readonly pk: number | null;
-      readonly lowestPriceNet: string | null;
-      readonly highestPriceNet: string | null;
+      readonly lowestPriceNet: string;
+      readonly highestPriceNet: string;
       readonly id: string;
       readonly begins: string;
       readonly priceUnit: PriceUnit;
@@ -6732,7 +6721,7 @@ export type ReservationUnitEditQuery = {
       readonly reservableTimes: ReadonlyArray<{
         readonly begin: string;
         readonly end: string;
-      } | null> | null;
+      } | null>;
     }>;
   } | null;
 };
@@ -6867,7 +6856,7 @@ export type ApplicationRoundFilterQuery = {
   readonly applicationRound: {
     readonly id: string;
     readonly nameFi: string | null;
-    readonly status: ApplicationRoundStatusChoice | null;
+    readonly status: ApplicationRoundStatusChoice;
     readonly reservationPeriodBegin: string;
     readonly reservationPeriodEnd: string;
     readonly reservationUnits: ReadonlyArray<{
@@ -6989,11 +6978,11 @@ export type ApplicationSectionAllocationsQuery = {
     readonly totalCount: number | null;
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly allocations: number | null;
+        readonly allocations: number;
         readonly id: string;
         readonly pk: number | null;
         readonly name: string;
-        readonly status: ApplicationSectionStatusChoice | null;
+        readonly status: ApplicationSectionStatusChoice;
         readonly reservationMaxDuration: number;
         readonly numPersons: number;
         readonly reservationsEndDate: string;
@@ -7006,7 +6995,7 @@ export type ApplicationSectionAllocationsQuery = {
           readonly endTime: string;
           readonly dayOfTheWeek: Weekday;
           readonly priority: Priority;
-          readonly fulfilled: boolean | null;
+          readonly fulfilled: boolean;
         }>;
         readonly reservationUnitOptions: ReadonlyArray<{
           readonly id: string;
@@ -7048,7 +7037,7 @@ export type ApplicationSectionAllocationsQuery = {
         readonly application: {
           readonly id: string;
           readonly pk: number | null;
-          readonly status: ApplicationStatusChoice | null;
+          readonly status: ApplicationStatusChoice;
           readonly applicantType: ApplicantTypeChoice | null;
           readonly organisation: {
             readonly id: string;
@@ -7103,7 +7092,7 @@ export type ApplicationRoundCriteriaQuery = {
     readonly id: string;
     readonly pk: number | null;
     readonly nameFi: string | null;
-    readonly reservationUnitCount: number | null;
+    readonly reservationUnitCount: number;
     readonly applicationPeriodBegin: string;
     readonly applicationPeriodEnd: string;
     readonly reservationPeriodBegin: string;
@@ -7253,7 +7242,7 @@ export type ApplicationsQuery = {
       readonly node: {
         readonly id: string;
         readonly pk: number | null;
-        readonly status: ApplicationStatusChoice | null;
+        readonly status: ApplicationStatusChoice;
         readonly applicantType: ApplicantTypeChoice | null;
         readonly applicationSections: ReadonlyArray<{
           readonly id: string;
@@ -7350,11 +7339,11 @@ export type ApplicationSectionsQuery = {
     readonly totalCount: number | null;
     readonly edges: ReadonlyArray<{
       readonly node: {
-        readonly allocations: number | null;
+        readonly allocations: number;
         readonly id: string;
         readonly pk: number | null;
         readonly name: string;
-        readonly status: ApplicationSectionStatusChoice | null;
+        readonly status: ApplicationSectionStatusChoice;
         readonly reservationMaxDuration: number;
         readonly numPersons: number;
         readonly reservationsEndDate: string;
@@ -7398,7 +7387,7 @@ export type ApplicationSectionsQuery = {
         readonly application: {
           readonly id: string;
           readonly pk: number | null;
-          readonly status: ApplicationStatusChoice | null;
+          readonly status: ApplicationStatusChoice;
           readonly applicantType: ApplicantTypeChoice | null;
           readonly organisation: {
             readonly id: string;
@@ -7472,8 +7461,8 @@ export type AllocatedTimeSlotsQuery = {
         readonly recurringReservation: {
           readonly id: string;
           readonly pk: number | null;
-          readonly shouldHaveActiveAccessCode: boolean | null;
-          readonly isAccessCodeIsActiveCorrect: boolean | null;
+          readonly shouldHaveActiveAccessCode: boolean;
+          readonly isAccessCodeIsActiveCorrect: boolean;
           readonly reservations: ReadonlyArray<{
             readonly id: string;
             readonly pk: number | null;
@@ -7530,7 +7519,7 @@ export type ApplicationRoundBaseFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly nameFi: string | null;
-  readonly status: ApplicationRoundStatusChoice | null;
+  readonly status: ApplicationRoundStatusChoice;
   readonly applicationPeriodBegin: string;
   readonly applicationPeriodEnd: string;
 };
@@ -7543,13 +7532,13 @@ export type ApplicationRoundsQuery = {
       readonly node: {
         readonly reservationPeriodBegin: string;
         readonly reservationPeriodEnd: string;
-        readonly applicationsCount: number | null;
-        readonly reservationUnitCount: number | null;
+        readonly applicationsCount: number;
+        readonly reservationUnitCount: number;
         readonly statusTimestamp: string | null;
         readonly id: string;
         readonly pk: number | null;
         readonly nameFi: string | null;
-        readonly status: ApplicationRoundStatusChoice | null;
+        readonly status: ApplicationRoundStatusChoice;
         readonly applicationPeriodBegin: string;
         readonly applicationPeriodEnd: string;
       } | null;
@@ -7558,13 +7547,13 @@ export type ApplicationRoundsQuery = {
 };
 
 export type ApplicationRoundAdminFragment = {
-  readonly applicationsCount: number | null;
-  readonly isSettingHandledAllowed: boolean | null;
-  readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice | null;
+  readonly applicationsCount: number;
+  readonly isSettingHandledAllowed: boolean;
+  readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice;
   readonly id: string;
   readonly pk: number | null;
   readonly nameFi: string | null;
-  readonly status: ApplicationRoundStatusChoice | null;
+  readonly status: ApplicationRoundStatusChoice;
   readonly applicationPeriodBegin: string;
   readonly applicationPeriodEnd: string;
   readonly reservationUnits: ReadonlyArray<{
@@ -7585,13 +7574,13 @@ export type ApplicationRoundQueryVariables = Exact<{
 
 export type ApplicationRoundQuery = {
   readonly applicationRound: {
-    readonly applicationsCount: number | null;
-    readonly isSettingHandledAllowed: boolean | null;
-    readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice | null;
+    readonly applicationsCount: number;
+    readonly isSettingHandledAllowed: boolean;
+    readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice;
     readonly id: string;
     readonly pk: number | null;
     readonly nameFi: string | null;
-    readonly status: ApplicationRoundStatusChoice | null;
+    readonly status: ApplicationRoundStatusChoice;
     readonly applicationPeriodBegin: string;
     readonly applicationPeriodEnd: string;
     readonly reservationUnits: ReadonlyArray<{
@@ -7610,7 +7599,7 @@ export type ApplicationRoundQuery = {
 export type ApplicationAdminFragment = {
   readonly pk: number | null;
   readonly id: string;
-  readonly status: ApplicationStatusChoice | null;
+  readonly status: ApplicationStatusChoice;
   readonly lastModifiedDate: string;
   readonly applicantType: ApplicantTypeChoice | null;
   readonly additionalInformation: string | null;
@@ -7620,11 +7609,11 @@ export type ApplicationAdminFragment = {
     readonly nameFi: string | null;
   };
   readonly applicationSections: ReadonlyArray<{
-    readonly allocations: number | null;
+    readonly allocations: number;
     readonly id: string;
     readonly pk: number | null;
     readonly name: string;
-    readonly status: ApplicationSectionStatusChoice | null;
+    readonly status: ApplicationSectionStatusChoice;
     readonly reservationMaxDuration: number;
     readonly numPersons: number;
     readonly reservationsEndDate: string;
@@ -7676,7 +7665,7 @@ export type ApplicationAdminFragment = {
           readonly reservableTimes: ReadonlyArray<{
             readonly begin: string;
             readonly end: string;
-          } | null> | null;
+          } | null>;
         }>;
       };
     }>;
@@ -7736,7 +7725,7 @@ export type ApplicationAdminQuery = {
     readonly workingMemo: string;
     readonly pk: number | null;
     readonly id: string;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly lastModifiedDate: string;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
@@ -7747,11 +7736,11 @@ export type ApplicationAdminQuery = {
       readonly nameFi: string | null;
     };
     readonly applicationSections: ReadonlyArray<{
-      readonly allocations: number | null;
+      readonly allocations: number;
       readonly id: string;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -7803,7 +7792,7 @@ export type ApplicationAdminQuery = {
             readonly reservableTimes: ReadonlyArray<{
               readonly begin: string;
               readonly end: string;
-            } | null> | null;
+            } | null>;
           }>;
         };
       }>;
@@ -7895,7 +7884,7 @@ export type ApplicationRoundTimeSlotsFragment = {
   readonly reservableTimes: ReadonlyArray<{
     readonly begin: string;
     readonly end: string;
-  } | null> | null;
+  } | null>;
 };
 
 export type ReservationUnitOptionFragment = {
@@ -7921,7 +7910,7 @@ export type ReservationUnitOptionFragment = {
       readonly reservableTimes: ReadonlyArray<{
         readonly begin: string;
         readonly end: string;
-      } | null> | null;
+      } | null>;
     }>;
   };
 };
@@ -7952,8 +7941,8 @@ export type ReservationUnitCalendarQuery = {
     readonly reservations: ReadonlyArray<{
       readonly name: string | null;
       readonly numPersons: number | null;
-      readonly calendarUrl: string | null;
-      readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+      readonly calendarUrl: string;
+      readonly affectedReservationUnits: ReadonlyArray<number | null>;
       readonly id: string;
       readonly pk: number | null;
       readonly begin: string;
@@ -7961,7 +7950,7 @@ export type ReservationUnitCalendarQuery = {
       readonly createdAt: string | null;
       readonly state: ReservationStateChoice | null;
       readonly type: ReservationTypeChoice | null;
-      readonly isBlocked: boolean | null;
+      readonly isBlocked: boolean;
       readonly workingMemo: string | null;
       readonly reserveeName: string | null;
       readonly bufferTimeBefore: number;
@@ -7979,7 +7968,7 @@ export type ReservationUnitCalendarQuery = {
       }>;
       readonly paymentOrder: ReadonlyArray<{
         readonly id: string;
-        readonly status: OrderStatus | null;
+        readonly status: OrderStatus;
       }>;
       readonly user: {
         readonly id: string;
@@ -7993,8 +7982,8 @@ export type ReservationUnitCalendarQuery = {
   readonly affectingReservations: ReadonlyArray<{
     readonly name: string | null;
     readonly numPersons: number | null;
-    readonly calendarUrl: string | null;
-    readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+    readonly calendarUrl: string;
+    readonly affectedReservationUnits: ReadonlyArray<number | null>;
     readonly id: string;
     readonly pk: number | null;
     readonly begin: string;
@@ -8002,7 +7991,7 @@ export type ReservationUnitCalendarQuery = {
     readonly createdAt: string | null;
     readonly state: ReservationStateChoice | null;
     readonly type: ReservationTypeChoice | null;
-    readonly isBlocked: boolean | null;
+    readonly isBlocked: boolean;
     readonly workingMemo: string | null;
     readonly reserveeName: string | null;
     readonly bufferTimeBefore: number;
@@ -8017,7 +8006,7 @@ export type ReservationUnitCalendarQuery = {
     }>;
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
     }>;
     readonly user: {
       readonly id: string;
@@ -8129,8 +8118,8 @@ export type ReservationUnitsByUnitQuery = {
   readonly affectingReservations: ReadonlyArray<{
     readonly name: string | null;
     readonly numPersons: number | null;
-    readonly calendarUrl: string | null;
-    readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+    readonly calendarUrl: string;
+    readonly affectedReservationUnits: ReadonlyArray<number | null>;
     readonly id: string;
     readonly pk: number | null;
     readonly begin: string;
@@ -8138,7 +8127,7 @@ export type ReservationUnitsByUnitQuery = {
     readonly createdAt: string | null;
     readonly state: ReservationStateChoice | null;
     readonly type: ReservationTypeChoice | null;
-    readonly isBlocked: boolean | null;
+    readonly isBlocked: boolean;
     readonly workingMemo: string | null;
     readonly reserveeName: string | null;
     readonly bufferTimeBefore: number;
@@ -8153,7 +8142,7 @@ export type ReservationUnitsByUnitQuery = {
     }>;
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
     }>;
     readonly user: {
       readonly id: string;
@@ -8255,7 +8244,7 @@ export type ReservationsInIntervalFragment = {
   readonly bufferTimeBefore: number;
   readonly bufferTimeAfter: number;
   readonly type: ReservationTypeChoice | null;
-  readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+  readonly affectedReservationUnits: ReadonlyArray<number | null>;
   readonly recurringReservation: {
     readonly id: string;
     readonly pk: number | null;
@@ -8283,7 +8272,7 @@ export type ReservationTimesInReservationUnitQuery = {
       readonly bufferTimeBefore: number;
       readonly bufferTimeAfter: number;
       readonly type: ReservationTypeChoice | null;
-      readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+      readonly affectedReservationUnits: ReadonlyArray<number | null>;
       readonly recurringReservation: {
         readonly id: string;
         readonly pk: number | null;
@@ -8297,7 +8286,7 @@ export type ReservationTimesInReservationUnitQuery = {
     readonly bufferTimeBefore: number;
     readonly bufferTimeAfter: number;
     readonly type: ReservationTypeChoice | null;
-    readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+    readonly affectedReservationUnits: ReadonlyArray<number | null>;
     readonly recurringReservation: {
       readonly id: string;
       readonly pk: number | null;
@@ -8311,7 +8300,7 @@ export type BannerNotificationListFragment = {
   readonly name: string;
   readonly activeFrom: string | null;
   readonly activeUntil: string | null;
-  readonly state: BannerNotificationState | null;
+  readonly state: BannerNotificationState;
   readonly target: BannerNotificationTarget;
   readonly level: BannerNotificationLevel;
 };
@@ -8335,7 +8324,7 @@ export type BannerNotificationListQuery = {
         readonly name: string;
         readonly activeFrom: string | null;
         readonly activeUntil: string | null;
-        readonly state: BannerNotificationState | null;
+        readonly state: BannerNotificationState;
         readonly target: BannerNotificationTarget;
         readonly level: BannerNotificationLevel;
       } | null;
@@ -8391,7 +8380,7 @@ export type BannerNotificationPageQuery = {
     readonly target: BannerNotificationTarget;
     readonly activeUntil: string | null;
     readonly draft: boolean;
-    readonly state: BannerNotificationState | null;
+    readonly state: BannerNotificationState;
   } | null;
 };
 
@@ -8399,10 +8388,10 @@ export type SearchReservationUnitsQueryVariables = Exact<{
   after?: InputMaybe<Scalars["String"]["input"]>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<
     | ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
@@ -8431,8 +8420,8 @@ export type SearchReservationUnitsQuery = {
         readonly nameFi: string | null;
         readonly maxPersons: number | null;
         readonly surfaceArea: number | null;
-        readonly publishingState: ReservationUnitPublishingState | null;
-        readonly reservationState: ReservationUnitReservationState | null;
+        readonly publishingState: ReservationUnitPublishingState;
+        readonly reservationState: ReservationUnitReservationState;
         readonly unit: {
           readonly id: string;
           readonly nameFi: string | null;
@@ -8468,7 +8457,7 @@ export type ApprovalButtonsFragment = {
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
     readonly orderUuid: string | null;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
     readonly refundUuid: string | null;
   }>;
   readonly reservationUnits: ReadonlyArray<{
@@ -8599,7 +8588,7 @@ export type ReservationTitleSectionFieldsFragment = {
   readonly recurringReservation: { readonly id: string } | null;
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
   }>;
 };
 
@@ -8616,7 +8605,7 @@ export type ReservationEditPageQuery = {
     readonly createdAt: string | null;
     readonly state: ReservationStateChoice | null;
     readonly type: ReservationTypeChoice | null;
-    readonly isBlocked: boolean | null;
+    readonly isBlocked: boolean;
     readonly workingMemo: string | null;
     readonly reserveeName: string | null;
     readonly bufferTimeBefore: number;
@@ -8652,7 +8641,7 @@ export type ReservationEditPageQuery = {
       readonly beginTime: string | null;
       readonly endDate: string | null;
       readonly endTime: string | null;
-      readonly weekdays: ReadonlyArray<number | null> | null;
+      readonly weekdays: ReadonlyArray<number>;
     } | null;
     readonly reservationUnits: ReadonlyArray<{
       readonly id: string;
@@ -8701,7 +8690,7 @@ export type ReservationEditPageQuery = {
     }>;
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
     }>;
     readonly user: {
       readonly id: string;
@@ -8782,7 +8771,7 @@ export type CalendarReservationFragment = {
   readonly type: ReservationTypeChoice | null;
   readonly bufferTimeBefore: number;
   readonly bufferTimeAfter: number;
-  readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+  readonly affectedReservationUnits: ReadonlyArray<number | null>;
   readonly accessType: AccessType;
   readonly user: { readonly id: string; readonly email: string } | null;
 };
@@ -8812,7 +8801,7 @@ export type ReservationsByReservationUnitQuery = {
       readonly type: ReservationTypeChoice | null;
       readonly bufferTimeBefore: number;
       readonly bufferTimeAfter: number;
-      readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+      readonly affectedReservationUnits: ReadonlyArray<number | null>;
       readonly accessType: AccessType;
       readonly user: { readonly id: string; readonly email: string } | null;
     }> | null;
@@ -8828,7 +8817,7 @@ export type ReservationsByReservationUnitQuery = {
     readonly type: ReservationTypeChoice | null;
     readonly bufferTimeBefore: number;
     readonly bufferTimeAfter: number;
-    readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+    readonly affectedReservationUnits: ReadonlyArray<number | null>;
     readonly accessType: AccessType;
     readonly user: { readonly id: string; readonly email: string } | null;
   }> | null;
@@ -8837,7 +8826,7 @@ export type ReservationsByReservationUnitQuery = {
 export type ReservationAccessTypeFragment = {
   readonly id: string;
   readonly accessType: AccessType;
-  readonly isAccessCodeIsActiveCorrect: boolean | null;
+  readonly isAccessCodeIsActiveCorrect: boolean;
   readonly pindoraInfo: {
     readonly accessCode: string;
     readonly accessCodeIsActive: boolean;
@@ -8853,11 +8842,11 @@ export type ReservationRecurringFieldsFragment = {
   readonly beginTime: string | null;
   readonly endDate: string | null;
   readonly endTime: string | null;
-  readonly weekdays: ReadonlyArray<number | null> | null;
+  readonly weekdays: ReadonlyArray<number>;
   readonly name: string;
   readonly description: string;
-  readonly usedAccessTypes: ReadonlyArray<AccessType | null> | null;
-  readonly isAccessCodeIsActiveCorrect: boolean | null;
+  readonly usedAccessTypes: ReadonlyArray<AccessType | null>;
+  readonly isAccessCodeIsActiveCorrect: boolean;
   readonly pindoraInfo: {
     readonly accessCode: string;
     readonly accessCodeIsActive: boolean;
@@ -8871,7 +8860,7 @@ export type ReservationRecurringFieldsFragment = {
 export type RecurringReservationFieldsFragment = {
   readonly id: string;
   readonly pk: number | null;
-  readonly weekdays: ReadonlyArray<number | null> | null;
+  readonly weekdays: ReadonlyArray<number>;
   readonly beginDate: string | null;
   readonly endDate: string | null;
   readonly rejectedOccurrences: ReadonlyArray<{
@@ -8891,7 +8880,7 @@ export type RecurringReservationFieldsFragment = {
     readonly bufferTimeBefore: number;
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
     }>;
     readonly reservationUnits: ReadonlyArray<{
       readonly id: string;
@@ -8904,7 +8893,7 @@ export type RecurringReservationFieldsFragment = {
     readonly recurringReservation: {
       readonly pk: number | null;
       readonly id: string;
-      readonly weekdays: ReadonlyArray<number | null> | null;
+      readonly weekdays: ReadonlyArray<number>;
       readonly beginDate: string | null;
       readonly endDate: string | null;
     } | null;
@@ -8924,14 +8913,14 @@ export type ReservationPageQuery = {
     readonly createdAt: string | null;
     readonly state: ReservationStateChoice | null;
     readonly type: ReservationTypeChoice | null;
-    readonly isBlocked: boolean | null;
+    readonly isBlocked: boolean;
     readonly workingMemo: string | null;
     readonly reserveeName: string | null;
     readonly bufferTimeBefore: number;
     readonly bufferTimeAfter: number;
     readonly name: string | null;
     readonly accessType: AccessType;
-    readonly isAccessCodeIsActiveCorrect: boolean | null;
+    readonly isAccessCodeIsActiveCorrect: boolean;
     readonly numPersons: number | null;
     readonly description: string | null;
     readonly freeOfChargeReason: string | null;
@@ -8962,12 +8951,12 @@ export type ReservationPageQuery = {
       readonly beginTime: string | null;
       readonly endDate: string | null;
       readonly endTime: string | null;
-      readonly weekdays: ReadonlyArray<number | null> | null;
+      readonly weekdays: ReadonlyArray<number>;
       readonly pk: number | null;
       readonly name: string;
       readonly description: string;
-      readonly usedAccessTypes: ReadonlyArray<AccessType | null> | null;
-      readonly isAccessCodeIsActiveCorrect: boolean | null;
+      readonly usedAccessTypes: ReadonlyArray<AccessType | null>;
+      readonly isAccessCodeIsActiveCorrect: boolean;
       readonly pindoraInfo: {
         readonly accessCode: string;
         readonly accessCodeIsActive: boolean;
@@ -9046,7 +9035,7 @@ export type ReservationPageQuery = {
     }>;
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
       readonly orderUuid: string | null;
       readonly refundUuid: string | null;
     }>;
@@ -9119,7 +9108,7 @@ export type SeriesPageQuery = {
       readonly beginTime: string | null;
       readonly id: string;
       readonly pk: number | null;
-      readonly weekdays: ReadonlyArray<number | null> | null;
+      readonly weekdays: ReadonlyArray<number>;
       readonly beginDate: string | null;
       readonly endDate: string | null;
       readonly rejectedOccurrences: ReadonlyArray<{
@@ -9139,7 +9128,7 @@ export type SeriesPageQuery = {
         readonly bufferTimeBefore: number;
         readonly paymentOrder: ReadonlyArray<{
           readonly id: string;
-          readonly status: OrderStatus | null;
+          readonly status: OrderStatus;
         }>;
         readonly reservationUnits: ReadonlyArray<{
           readonly id: string;
@@ -9155,7 +9144,7 @@ export type SeriesPageQuery = {
         readonly recurringReservation: {
           readonly pk: number | null;
           readonly id: string;
-          readonly weekdays: ReadonlyArray<number | null> | null;
+          readonly weekdays: ReadonlyArray<number>;
           readonly beginDate: string | null;
           readonly endDate: string | null;
         } | null;
@@ -9180,7 +9169,7 @@ export type ReservationSeriesQuery = {
   readonly recurringReservation: {
     readonly id: string;
     readonly pk: number | null;
-    readonly weekdays: ReadonlyArray<number | null> | null;
+    readonly weekdays: ReadonlyArray<number>;
     readonly beginDate: string | null;
     readonly endDate: string | null;
     readonly rejectedOccurrences: ReadonlyArray<{
@@ -9200,7 +9189,7 @@ export type ReservationSeriesQuery = {
       readonly bufferTimeBefore: number;
       readonly paymentOrder: ReadonlyArray<{
         readonly id: string;
-        readonly status: OrderStatus | null;
+        readonly status: OrderStatus;
       }>;
       readonly reservationUnits: ReadonlyArray<{
         readonly id: string;
@@ -9216,7 +9205,7 @@ export type ReservationSeriesQuery = {
       readonly recurringReservation: {
         readonly pk: number | null;
         readonly id: string;
-        readonly weekdays: ReadonlyArray<number | null> | null;
+        readonly weekdays: ReadonlyArray<number>;
         readonly beginDate: string | null;
         readonly endDate: string | null;
       } | null;
@@ -9287,7 +9276,7 @@ export type CreateTagStringFragment = {
     readonly beginTime: string | null;
     readonly endDate: string | null;
     readonly endTime: string | null;
-    readonly weekdays: ReadonlyArray<number | null> | null;
+    readonly weekdays: ReadonlyArray<number>;
   } | null;
 };
 
@@ -9375,7 +9364,7 @@ export type ReservationsQuery = {
         readonly createdAt: string | null;
         readonly state: ReservationStateChoice | null;
         readonly type: ReservationTypeChoice | null;
-        readonly isBlocked: boolean | null;
+        readonly isBlocked: boolean;
         readonly workingMemo: string | null;
         readonly reserveeName: string | null;
         readonly bufferTimeBefore: number;
@@ -9390,7 +9379,7 @@ export type ReservationsQuery = {
         }>;
         readonly paymentOrder: ReadonlyArray<{
           readonly id: string;
-          readonly status: OrderStatus | null;
+          readonly status: OrderStatus;
         }>;
         readonly user: {
           readonly id: string;
@@ -9433,7 +9422,7 @@ export type ResourceFieldsFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly nameFi: string | null;
-  readonly locationType: ResourceLocationType | null;
+  readonly locationType: ResourceLocationType;
   readonly space: {
     readonly id: string;
     readonly nameFi: string | null;
@@ -9456,7 +9445,7 @@ export type SpaceFieldsFragment = {
     readonly id: string;
     readonly pk: number | null;
     readonly nameFi: string | null;
-    readonly locationType: ResourceLocationType | null;
+    readonly locationType: ResourceLocationType;
     readonly space: {
       readonly id: string;
       readonly nameFi: string | null;
@@ -9498,7 +9487,7 @@ export type UnitWithSpacesAndResourcesQuery = {
         readonly id: string;
         readonly pk: number | null;
         readonly nameFi: string | null;
-        readonly locationType: ResourceLocationType | null;
+        readonly locationType: ResourceLocationType;
         readonly space: {
           readonly id: string;
           readonly nameFi: string | null;
@@ -15785,10 +15774,10 @@ export const SearchReservationUnitsDocument = gql`
     $after: String
     $first: Int
     $textSearch: String
-    $maxPersonsGte: Decimal
-    $maxPersonsLte: Decimal
-    $surfaceAreaGte: Decimal
-    $surfaceAreaLte: Decimal
+    $maxPersonsGte: Int
+    $maxPersonsLte: Int
+    $surfaceAreaGte: Int
+    $surfaceAreaLte: Int
     $unit: [Int]
     $reservationUnitType: [Int]
     $orderBy: [ReservationUnitOrderingChoices]

--- a/apps/admin-ui/src/component/EditTimeModal.tsx
+++ b/apps/admin-ui/src/component/EditTimeModal.tsx
@@ -15,7 +15,6 @@ import {
   type ChangeReservationTimeFragment,
   ReservationTypeChoice,
   useStaffAdjustReservationTimeMutation,
-  type ReservationPageQuery,
   type ReservationSeriesAddMutationInput,
   useAddReservationToSeriesMutation,
 } from "@gql/gql-types";
@@ -39,6 +38,7 @@ import { formatDateTimeRange } from "@/common/util";
 import { gql } from "@apollo/client";
 import { filterNonNullable } from "common/src/helpers";
 import { errorToast, successToast } from "common/src/common/toast";
+import { type ReservationToCopyT } from "./ReservationsList";
 
 const StyledForm = styled.form`
   margin-top: var(--spacing-m);
@@ -311,10 +311,6 @@ function DialogContent({
   );
 }
 
-type ReservationToCopyT = Pick<
-  NonNullable<ReservationPageQuery["reservation"]>,
-  "type" | "reservationUnits" | "recurringReservation"
->;
 export type NewReservationModalProps = CommonProps & {
   reservationToCopy: ReservationToCopyT;
   onAccept: () => void;

--- a/apps/admin-ui/src/component/RecurringReservationsView.tsx
+++ b/apps/admin-ui/src/component/RecurringReservationsView.tsx
@@ -10,6 +10,7 @@ import { type ApolloQueryResult } from "@apollo/client";
 import {
   NewReservationListItem,
   ReservationList,
+  type ReservationToCopyT,
 } from "@/component/ReservationsList";
 import { ReservationListButton } from "@/component/ReservationListButton";
 import { DenyDialog } from "@/component/DenyDialog";
@@ -29,7 +30,7 @@ type Props = {
   onReservationUpdated?: () => void;
   // optional reservation to copy when creating a new reservation
   // contains a lot more information than the RecurringReservationQuery
-  reservationToCopy?: ReservationPageQuery["reservation"];
+  reservationToCopy?: ReservationToCopyT;
 };
 
 export function RecurringReservationsView({

--- a/apps/admin-ui/src/component/ReservationsList.tsx
+++ b/apps/admin-ui/src/component/ReservationsList.tsx
@@ -3,8 +3,9 @@ import { toUIDate } from "common/src/common/util";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import {
+  type Maybe,
   RejectionReadinessChoice,
-  ReservationPageQuery,
+  type ReservationPageQuery,
   UserPermissionChoice,
 } from "@gql/gql-types";
 import { Button, ButtonSize, ButtonVariant, IconCross } from "hds-react";
@@ -154,8 +155,12 @@ function StatusElement({ item }: { item: NewReservationListItem }) {
   );
 }
 
+type QueryT = NonNullable<ReservationPageQuery["reservation"]>;
+export type ReservationToCopyT =
+  | Maybe<Pick<QueryT, "type" | "recurringReservation" | "reservationUnits">>
+  | undefined;
 type AddNewReservationButtonProps = {
-  reservationToCopy: ReservationPageQuery["reservation"];
+  reservationToCopy: ReservationToCopyT;
   refetch: () => void;
 };
 

--- a/apps/admin-ui/src/spa/reservation-units/ReservationUnitsDataLoader.tsx
+++ b/apps/admin-ui/src/spa/reservation-units/ReservationUnitsDataLoader.tsx
@@ -116,10 +116,10 @@ export function ReservationUnitsDataReader(): JSX.Element {
     variables: {
       orderBy,
       first: LARGE_LIST_PAGE_SIZE,
-      maxPersonsLte: maxPersonsLte?.toString(),
-      maxPersonsGte: maxPersonsGte?.toString(),
-      surfaceAreaLte: surfaceAreaLte?.toString(),
-      surfaceAreaGte: surfaceAreaGte?.toString(),
+      maxPersonsLte: maxPersonsLte,
+      maxPersonsGte: maxPersonsGte,
+      surfaceAreaLte: surfaceAreaLte,
+      surfaceAreaGte: surfaceAreaGte,
       textSearch: searchFilter,
       unit,
       publishingState: reservationUnitStates.map((state) =>

--- a/apps/admin-ui/src/spa/reservation-units/queries.tsx
+++ b/apps/admin-ui/src/spa/reservation-units/queries.tsx
@@ -5,10 +5,10 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
     $after: String
     $first: Int
     $textSearch: String
-    $maxPersonsGte: Decimal
-    $maxPersonsLte: Decimal
-    $surfaceAreaGte: Decimal
-    $surfaceAreaLte: Decimal
+    $maxPersonsGte: Int
+    $maxPersonsLte: Int
+    $surfaceAreaGte: Int
+    $surfaceAreaLte: Int
     $unit: [Int]
     $reservationUnitType: [Int]
     $orderBy: [ReservationUnitOrderingChoices]

--- a/apps/admin-ui/src/spa/reservations/[id]/eventStyleGetter.ts
+++ b/apps/admin-ui/src/spa/reservations/[id]/eventStyleGetter.ts
@@ -38,8 +38,8 @@ export const legend = [
   },
 ];
 
-// TODO fragment
 export type ReservationType = NonNullable<ReservationPageQuery["reservation"]>;
+export type CalendarEventType = CalendarEvent<EventType>;
 export type EventBufferType = Pick<
   ReservationType,
   "begin" | "end" | "bufferTimeAfter" | "bufferTimeBefore"
@@ -49,7 +49,6 @@ export type EventType = EventBufferType &
     ReservationType,
     "pk" | "type" | "state" | "name" | "recurringReservation"
   >;
-export type CalendarEventType = CalendarEvent<EventType>;
 
 // TODO combine with the eventStyleGetter in my-units/eventStyleGetter.ts
 const eventStyleGetter =

--- a/apps/ui/components/application/ReservationUnitModalContent.tsx
+++ b/apps/ui/components/application/ReservationUnitModalContent.tsx
@@ -170,7 +170,7 @@ export function ReservationUnitModalContent({
     const variables: SearchReservationUnitsQueryVariables = {
       ...baseVariables,
       textSearch: data.textSearch,
-      personsAllowed: data.personsAllowed?.toString(),
+      personsAllowed: data.personsAllowed,
       reservationUnitType: data.reservationUnitTypes,
       unit: data.units,
       purposes: data.purposes,

--- a/apps/ui/components/recurring/ApplicationRoundCard.test.tsx
+++ b/apps/ui/components/recurring/ApplicationRoundCard.test.tsx
@@ -8,10 +8,10 @@ import { vi, describe, test, expect, beforeEach, afterEach } from "vitest";
 import { getApplicationRoundPath } from "@/modules/urls";
 
 function createApplicationRoundCard({
-  status = null,
+  status = ApplicationRoundStatusChoice.Open,
   name = "Test",
 }: {
-  status?: ApplicationRoundStatusChoice | null;
+  status?: ApplicationRoundStatusChoice;
   name: string;
 }): ApplicationRoundCardFragment {
   return {
@@ -41,7 +41,6 @@ describe("ApplicationRoundCard Open Round", () => {
   test("should render both links", () => {
     const card = createApplicationRoundCard({
       name: "Test",
-      status: ApplicationRoundStatusChoice.Open,
     });
     const view = render(<ApplicationRoundCard applicationRound={card} />);
     const startLink = view.getByRole("link", {

--- a/apps/ui/components/reservation-unit/utils.test.ts
+++ b/apps/ui/components/reservation-unit/utils.test.ts
@@ -12,7 +12,12 @@ import {
   getNextAvailableTime,
   type LastPossibleReservationDateProps,
 } from "./utils";
-import { dateToKey, ReservableMap, RoundPeriod } from "@/modules/reservable";
+import { ReservationStartInterval } from "common/gql/gql-types";
+import {
+  dateToKey,
+  ReservableMap,
+  type RoundPeriod,
+} from "@/modules/reservable";
 import {
   vi,
   describe,
@@ -23,7 +28,7 @@ import {
   afterAll,
 } from "vitest";
 import { TIMERS_TO_FAKE } from "@/test/test.utils";
-import { ReservationStartInterval } from "@/gql/gql-types";
+import { base64encode } from "common/src/helpers";
 
 describe("getLastPossibleReservationDate", () => {
   beforeAll(() => {
@@ -197,30 +202,27 @@ describe("getNextAvailableTime", () => {
     reservationsMinDaysBefore?: number | null;
     reservationsMaxDaysBefore?: number | null;
     activeApplicationRounds?: RoundPeriod[];
-  }): AvailableTimesProps {
-    const reservationUnit: AvailableTimesProps["reservationUnit"] = {
-      id: "123",
-      bufferTimeBefore: 0,
-      bufferTimeAfter: 0,
-      reservationStartInterval: ReservationStartInterval.Interval_30Mins,
-      reservationsMinDaysBefore,
-      reservationsMaxDaysBefore,
-      maxReservationDuration: null,
-      minReservationDuration: null,
-      reservationBegins: null,
-      reservationEnds: null,
-      reservableTimeSpans: [],
-    };
+  }): Readonly<AvailableTimesProps> {
     return {
       start,
       duration,
       reservationUnit: {
-        ...reservationUnit,
+        id: base64encode("ReservationUnit:1"),
+        reservationsMinDaysBefore,
+        reservationsMaxDaysBefore,
+        bufferTimeBefore: 0,
+        bufferTimeAfter: 0,
+        reservationStartInterval: ReservationStartInterval.Interval_30Mins,
+        maxReservationDuration: null,
+        minReservationDuration: null,
+        reservationBegins: null,
+        reservationEnds: null,
+        reservableTimeSpans: [],
       },
-      reservableTimes,
       activeApplicationRounds,
       blockingReservations: [],
-    };
+      reservableTimes,
+    } as const;
   }
 
   test("finds the next available time for today", () => {

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -221,14 +221,14 @@ export type ApplicantNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -300,7 +300,7 @@ export type ApplicationNode = Node & {
   readonly organisation: Maybe<OrganisationNode>;
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationStatusChoice>;
+  readonly status: ApplicationStatusChoice;
   readonly user: Maybe<ApplicantNode>;
   readonly workingMemo: Scalars["String"]["output"];
 };
@@ -377,7 +377,7 @@ export enum ApplicationOrderingChoices {
 export type ApplicationRoundNode = Node & {
   readonly applicationPeriodBegin: Scalars["DateTime"]["output"];
   readonly applicationPeriodEnd: Scalars["DateTime"]["output"];
-  readonly applicationsCount: Maybe<Scalars["Int"]["output"]>;
+  readonly applicationsCount: Scalars["Int"]["output"];
   readonly criteria: Scalars["String"]["output"];
   readonly criteriaEn: Maybe<Scalars["String"]["output"]>;
   readonly criteriaFi: Maybe<Scalars["String"]["output"]>;
@@ -385,7 +385,7 @@ export type ApplicationRoundNode = Node & {
   readonly handledDate: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isSettingHandledAllowed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isSettingHandledAllowed: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -398,13 +398,13 @@ export type ApplicationRoundNode = Node & {
   readonly publicDisplayBegin: Scalars["DateTime"]["output"];
   readonly publicDisplayEnd: Scalars["DateTime"]["output"];
   readonly purposes: ReadonlyArray<ReservationPurposeNode>;
-  readonly reservationCreationStatus: Maybe<ApplicationRoundReservationCreationStatusChoice>;
+  readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice;
   readonly reservationPeriodBegin: Scalars["Date"]["output"];
   readonly reservationPeriodEnd: Scalars["Date"]["output"];
-  readonly reservationUnitCount: Maybe<Scalars["Int"]["output"]>;
+  readonly reservationUnitCount: Scalars["Int"]["output"];
   readonly reservationUnits: ReadonlyArray<ReservationUnitNode>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationRoundStatusChoice>;
+  readonly status: ApplicationRoundStatusChoice;
   readonly statusTimestamp: Maybe<Scalars["DateTime"]["output"]>;
   readonly termsOfUse: Maybe<TermsOfUseNode>;
 };
@@ -436,10 +436,10 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -453,18 +453,18 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -475,13 +475,13 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -529,7 +529,7 @@ export type ApplicationRoundTimeSlotNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservableTimes: Maybe<ReadonlyArray<Maybe<TimeSlotType>>>;
+  readonly reservableTimes: ReadonlyArray<Maybe<TimeSlotType>>;
   readonly weekday: Scalars["Int"]["output"];
 };
 
@@ -610,7 +610,7 @@ export type ApplicationSectionForApplicationSerializerInput = {
 
 export type ApplicationSectionNode = Node & {
   readonly ageGroup: Maybe<AgeGroupNode>;
-  readonly allocations: Maybe<Scalars["Int"]["output"]>;
+  readonly allocations: Scalars["Int"]["output"];
   readonly application: ApplicationNode;
   readonly appliedReservationsPerWeek: Scalars["Int"]["output"];
   readonly extUuid: Scalars["UUID"]["output"];
@@ -628,8 +628,8 @@ export type ApplicationSectionNode = Node & {
   readonly reservationUnitOptions: ReadonlyArray<ReservationUnitOptionNode>;
   readonly reservationsBeginDate: Scalars["Date"]["output"];
   readonly reservationsEndDate: Scalars["Date"]["output"];
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly status: Maybe<ApplicationSectionStatusChoice>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly status: ApplicationSectionStatusChoice;
   readonly suitableTimeRanges: ReadonlyArray<SuitableTimeRangeNode>;
 };
 
@@ -889,7 +889,7 @@ export type BannerNotificationNode = Node & {
   readonly messageSv: Maybe<Scalars["String"]["output"]>;
   readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly state: Maybe<BannerNotificationState>;
+  readonly state: BannerNotificationState;
   readonly target: BannerNotificationTarget;
 };
 
@@ -1189,7 +1189,7 @@ export type GeneralRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly user: UserNode;
 };
@@ -1201,7 +1201,7 @@ export type HelsinkiProfileDataNode = {
   readonly firstName: Maybe<Scalars["String"]["output"]>;
   readonly isStrongLogin: Scalars["Boolean"]["output"];
   readonly lastName: Maybe<Scalars["String"]["output"]>;
-  readonly loginMethod: Maybe<LoginMethod>;
+  readonly loginMethod: LoginMethod;
   readonly municipalityCode: Maybe<Scalars["String"]["output"]>;
   readonly municipalityName: Maybe<Scalars["String"]["output"]>;
   readonly phone: Maybe<Scalars["String"]["output"]>;
@@ -1693,7 +1693,7 @@ export type PaymentMerchantNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly name: Scalars["String"]["output"];
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 export type PaymentOrderNode = Node & {
@@ -1707,14 +1707,14 @@ export type PaymentOrderNode = Node & {
   readonly receiptUrl: Maybe<Scalars["String"]["output"]>;
   readonly refundUuid: Maybe<Scalars["UUID"]["output"]>;
   readonly reservationPk: Maybe<Scalars["String"]["output"]>;
-  readonly status: Maybe<OrderStatus>;
+  readonly status: OrderStatus;
 };
 
 export type PaymentProductNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly merchant: Maybe<PaymentMerchantNode>;
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 /** An enumeration. */
@@ -1766,9 +1766,7 @@ export type PindoraSectionInfoType = {
   readonly accessCodePhoneNumber: Scalars["String"]["output"];
   readonly accessCodeSmsMessage: Scalars["String"]["output"];
   readonly accessCodeSmsNumber: Scalars["String"]["output"];
-  readonly accessCodeValidity: ReadonlyArray<
-    Maybe<PindoraSectionValidityInfoType>
-  >;
+  readonly accessCodeValidity: ReadonlyArray<PindoraSectionValidityInfoType>;
 };
 
 export type PindoraSectionValidityInfoType = {
@@ -2229,8 +2227,8 @@ export type QueryEquipmentsArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryEquipmentsAllArgs = {
@@ -2440,10 +2438,10 @@ export type QueryReservationUnitsArgs = {
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
   last?: InputMaybe<Scalars["Int"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -2458,18 +2456,18 @@ export type QueryReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -2480,13 +2478,13 @@ export type QueryReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -2681,7 +2679,7 @@ export type QueryUserArgs = {
 
 export type RecurringReservationNode = Node & {
   readonly abilityGroup: Maybe<AbilityGroupNode>;
-  readonly accessType: Maybe<AccessTypeWithMultivalued>;
+  readonly accessType: AccessTypeWithMultivalued;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly allocatedTimeSlot: Maybe<AllocatedTimeSlotNode>;
   readonly beginDate: Maybe<Scalars["Date"]["output"]>;
@@ -2693,7 +2691,7 @@ export type RecurringReservationNode = Node & {
   readonly extUuid: Scalars["UUID"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple series, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraSeriesInfoType>;
@@ -2702,10 +2700,10 @@ export type RecurringReservationNode = Node & {
   readonly rejectedOccurrences: ReadonlyArray<RejectedOccurrenceNode>;
   readonly reservationUnit: ReservationUnitNode;
   readonly reservations: ReadonlyArray<ReservationNode>;
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly usedAccessTypes: Maybe<ReadonlyArray<Maybe<AccessType>>>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly usedAccessTypes: ReadonlyArray<Maybe<AccessType>>;
   readonly user: Maybe<UserNode>;
-  readonly weekdays: Maybe<ReadonlyArray<Maybe<Scalars["Int"]["output"]>>>;
+  readonly weekdays: ReadonlyArray<Scalars["Int"]["output"]>;
 };
 
 export type RecurringReservationNodeRejectedOccurrencesArgs = {
@@ -3105,8 +3103,8 @@ export type ReservationNode = Node & {
   readonly accessCodeShouldBeActive: Maybe<Scalars["Boolean"]["output"]>;
   readonly accessType: AccessType;
   /** Which reservation units' reserveability is affected by this reservation? */
-  readonly affectedReservationUnits: Maybe<
-    ReadonlyArray<Maybe<Scalars["Int"]["output"]>>
+  readonly affectedReservationUnits: ReadonlyArray<
+    Maybe<Scalars["Int"]["output"]>
   >;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly applyingForFreeOfCharge: Maybe<Scalars["Boolean"]["output"]>;
@@ -3120,7 +3118,7 @@ export type ReservationNode = Node & {
   readonly billingPhone: Maybe<Scalars["String"]["output"]>;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calendarUrl: Maybe<Scalars["String"]["output"]>;
+  readonly calendarUrl: Scalars["String"]["output"];
   readonly cancelDetails: Maybe<Scalars["String"]["output"]>;
   readonly cancelReason: Maybe<ReservationCancelReasonNode>;
   readonly createdAt: Maybe<Scalars["DateTime"]["output"]>;
@@ -3134,13 +3132,11 @@ export type ReservationNode = Node & {
   readonly homeCity: Maybe<CityNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isBlocked: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
+  readonly isBlocked: Scalars["Boolean"]["output"];
   readonly isHandled: Maybe<Scalars["Boolean"]["output"]>;
   readonly name: Maybe<Scalars["String"]["output"]>;
   readonly numPersons: Maybe<Scalars["Int"]["output"]>;
-  /** @deprecated Please use to 'paymentOrder' instead. */
-  readonly order: Maybe<PaymentOrderNode>;
   readonly paymentOrder: ReadonlyArray<PaymentOrderNode>;
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple reservations, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraReservationInfoType>;
@@ -3164,8 +3160,6 @@ export type ReservationNode = Node & {
   readonly reserveeOrganisationName: Maybe<Scalars["String"]["output"]>;
   readonly reserveePhone: Maybe<Scalars["String"]["output"]>;
   readonly reserveeType: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please use to 'type' instead. */
-  readonly staffEvent: Maybe<Scalars["Boolean"]["output"]>;
   readonly state: Maybe<ReservationStateChoice>;
   readonly taxPercentageValue: Maybe<Scalars["Decimal"]["output"]>;
   readonly type: Maybe<ReservationTypeChoice>;
@@ -3191,10 +3185,10 @@ export type ReservationNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -3208,18 +3202,18 @@ export type ReservationNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -3230,13 +3224,13 @@ export type ReservationNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -3257,13 +3251,10 @@ export type ReservationNodeEdge = {
   readonly node: Maybe<ReservationNode>;
 };
 
-/** An enumeration. */
+/** When user wants to receive reservation notification emails. */
 export enum ReservationNotification {
-  /** All */
   All = "ALL",
-  /** None */
   None = "NONE",
-  /** Only Handling Required */
   OnlyHandlingRequired = "ONLY_HANDLING_REQUIRED",
 }
 
@@ -4106,7 +4097,7 @@ export type ReservationUnitNode = Node & {
   readonly authentication: Authentication;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calculatedSurfaceArea: Maybe<Scalars["Int"]["output"]>;
+  readonly calculatedSurfaceArea: Scalars["Int"]["output"];
   readonly canApplyFreeOfCharge: Scalars["Boolean"]["output"];
   readonly cancellationRule: Maybe<ReservationUnitCancellationRuleNode>;
   readonly cancellationTerms: Maybe<TermsOfUseNode>;
@@ -4124,7 +4115,7 @@ export type ReservationUnitNode = Node & {
   readonly id: Scalars["ID"]["output"];
   readonly images: ReadonlyArray<ReservationUnitImageNode>;
   readonly isArchived: Scalars["Boolean"]["output"];
-  readonly isClosed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isClosed: Scalars["Boolean"]["output"];
   readonly isDraft: Scalars["Boolean"]["output"];
   readonly location: Maybe<LocationNode>;
   readonly maxPersons: Maybe<Scalars["Int"]["output"]>;
@@ -4137,7 +4128,7 @@ export type ReservationUnitNode = Node & {
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
   readonly nameSv: Maybe<Scalars["String"]["output"]>;
-  readonly numActiveUserReservations: Maybe<Scalars["Int"]["output"]>;
+  readonly numActiveUserReservations: Scalars["Int"]["output"];
   readonly paymentMerchant: Maybe<PaymentMerchantNode>;
   readonly paymentProduct: Maybe<PaymentProductNode>;
   readonly paymentTerms: Maybe<TermsOfUseNode>;
@@ -4147,15 +4138,13 @@ export type ReservationUnitNode = Node & {
   readonly pricings: ReadonlyArray<ReservationUnitPricingNode>;
   readonly publishBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly publishEnds: Maybe<Scalars["DateTime"]["output"]>;
-  readonly publishingState: Maybe<ReservationUnitPublishingState>;
+  readonly publishingState: ReservationUnitPublishingState;
   readonly purposes: ReadonlyArray<PurposeNode>;
   readonly qualifiers: ReadonlyArray<QualifierNode>;
   readonly rank: Scalars["Int"]["output"];
   readonly requireAdultReservee: Scalars["Boolean"]["output"];
   readonly requireReservationHandling: Scalars["Boolean"]["output"];
-  readonly reservableTimeSpans: Maybe<
-    ReadonlyArray<Maybe<ReservableTimeSpanType>>
-  >;
+  readonly reservableTimeSpans: Maybe<ReadonlyArray<ReservableTimeSpanType>>;
   readonly reservationBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly reservationBlockWholeDay: Scalars["Boolean"]["output"];
   readonly reservationCancelledInstructions: Scalars["String"]["output"];
@@ -4185,7 +4174,7 @@ export type ReservationUnitNode = Node & {
   readonly reservationPendingInstructionsFi: Maybe<Scalars["String"]["output"]>;
   readonly reservationPendingInstructionsSv: Maybe<Scalars["String"]["output"]>;
   readonly reservationStartInterval: ReservationStartInterval;
-  readonly reservationState: Maybe<ReservationUnitReservationState>;
+  readonly reservationState: ReservationUnitReservationState;
   readonly reservationUnitType: Maybe<ReservationUnitTypeNode>;
   readonly reservations: Maybe<ReadonlyArray<ReservationNode>>;
   readonly reservationsMaxDaysBefore: Maybe<Scalars["Int"]["output"]>;
@@ -4240,8 +4229,8 @@ export type ReservationUnitNodeEquipmentsArgs = {
   name_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ReservationUnitNodePurposesArgs = {
@@ -4446,11 +4435,11 @@ export type ReservationUnitPaymentTypeNode = Node & {
 export type ReservationUnitPricingNode = Node & {
   readonly begins: Scalars["Date"]["output"];
   readonly highestPrice: Scalars["Decimal"]["output"];
-  readonly highestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly highestPriceNet: Scalars["Decimal"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly lowestPrice: Scalars["Decimal"]["output"];
-  readonly lowestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly lowestPriceNet: Scalars["Decimal"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly priceUnit: PriceUnit;
   readonly taxPercentage: TaxPercentageNode;
@@ -4865,7 +4854,7 @@ export enum ResourceLocationType {
 export type ResourceNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly locationType: Maybe<ResourceLocationType>;
+  readonly locationType: ResourceLocationType;
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -5100,7 +5089,7 @@ export type SuitableTimeRangeNode = Node & {
   readonly beginTime: Scalars["Time"]["output"];
   readonly dayOfTheWeek: Weekday;
   readonly endTime: Scalars["Time"]["output"];
-  readonly fulfilled: Maybe<Scalars["Boolean"]["output"]>;
+  readonly fulfilled: Scalars["Boolean"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
@@ -5315,10 +5304,10 @@ export type UnitNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -5332,18 +5321,18 @@ export type UnitNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -5354,13 +5343,13 @@ export type UnitNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -5426,7 +5415,7 @@ export type UnitRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly unitGroups: ReadonlyArray<UnitGroupNode>;
   readonly units: ReadonlyArray<UnitNode>;
@@ -5639,14 +5628,14 @@ export type UserNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -5816,7 +5805,7 @@ export type ApplicationSectionReservationFragment = {
       readonly accessCodeEndsAt: string;
       readonly reservationSeriesId: number;
       readonly reservationId: number;
-    } | null>;
+    }>;
   } | null;
   readonly reservationUnitOptions: ReadonlyArray<{
     readonly id: string;
@@ -5830,9 +5819,9 @@ export type ApplicationSectionReservationFragment = {
         readonly pk: number | null;
         readonly beginTime: string | null;
         readonly endTime: string | null;
-        readonly weekdays: ReadonlyArray<number | null> | null;
-        readonly accessType: AccessTypeWithMultivalued | null;
-        readonly usedAccessTypes: ReadonlyArray<AccessType | null> | null;
+        readonly weekdays: ReadonlyArray<number>;
+        readonly accessType: AccessTypeWithMultivalued;
+        readonly usedAccessTypes: ReadonlyArray<AccessType | null>;
         readonly pindoraInfo: {
           readonly accessCode: string;
           readonly accessCodeIsActive: boolean;
@@ -5922,7 +5911,7 @@ export type ApplicationReservationsQuery = {
           readonly accessCodeEndsAt: string;
           readonly reservationSeriesId: number;
           readonly reservationId: number;
-        } | null>;
+        }>;
       } | null;
       readonly reservationUnitOptions: ReadonlyArray<{
         readonly id: string;
@@ -5936,9 +5925,9 @@ export type ApplicationReservationsQuery = {
             readonly pk: number | null;
             readonly beginTime: string | null;
             readonly endTime: string | null;
-            readonly weekdays: ReadonlyArray<number | null> | null;
-            readonly accessType: AccessTypeWithMultivalued | null;
-            readonly usedAccessTypes: ReadonlyArray<AccessType | null> | null;
+            readonly weekdays: ReadonlyArray<number>;
+            readonly accessType: AccessTypeWithMultivalued;
+            readonly usedAccessTypes: ReadonlyArray<AccessType | null>;
             readonly pindoraInfo: {
               readonly accessCode: string;
               readonly accessCodeIsActive: boolean;
@@ -6088,20 +6077,20 @@ export type TimeSelectorFragment = {
   readonly reservableTimes: ReadonlyArray<{
     readonly begin: string;
     readonly end: string;
-  } | null> | null;
+  } | null>;
 };
 
 export type ApplicationViewFragment = {
   readonly id: string;
   readonly pk: number | null;
-  readonly status: ApplicationStatusChoice | null;
+  readonly status: ApplicationStatusChoice;
   readonly applicantType: ApplicantTypeChoice | null;
   readonly additionalInformation: string | null;
   readonly applicationSections: ReadonlyArray<{
     readonly id: string;
     readonly pk: number | null;
     readonly name: string;
-    readonly status: ApplicationSectionStatusChoice | null;
+    readonly status: ApplicationSectionStatusChoice;
     readonly reservationMaxDuration: number;
     readonly numPersons: number;
     readonly reservationsEndDate: string;
@@ -6145,7 +6134,7 @@ export type ApplicationViewFragment = {
   readonly applicationRound: {
     readonly id: string;
     readonly sentDate: string | null;
-    readonly status: ApplicationRoundStatusChoice | null;
+    readonly status: ApplicationRoundStatusChoice;
     readonly notesWhenApplyingFi: string | null;
     readonly notesWhenApplyingEn: string | null;
     readonly notesWhenApplyingSv: string | null;
@@ -6234,7 +6223,7 @@ export type ApplicationViewFragment = {
 export type ApplicationCardFragment = {
   readonly id: string;
   readonly pk: number | null;
-  readonly status: ApplicationStatusChoice | null;
+  readonly status: ApplicationStatusChoice;
   readonly lastModifiedDate: string;
   readonly applicantType: ApplicantTypeChoice | null;
   readonly applicationRound: {
@@ -6267,7 +6256,7 @@ export type ApplicationsGroupFragment = {
   readonly sentDate: string | null;
   readonly id: string;
   readonly pk: number | null;
-  readonly status: ApplicationStatusChoice | null;
+  readonly status: ApplicationStatusChoice;
   readonly lastModifiedDate: string;
   readonly applicantType: ApplicantTypeChoice | null;
   readonly applicationRound: {
@@ -6316,7 +6305,7 @@ export type ApplicationRoundCardFragment = {
   readonly reservationPeriodEnd: string;
   readonly applicationPeriodBegin: string;
   readonly applicationPeriodEnd: string;
-  readonly status: ApplicationRoundStatusChoice | null;
+  readonly status: ApplicationRoundStatusChoice;
 };
 
 export type RecurringCardFragment = {
@@ -6436,7 +6425,7 @@ export type AvailableTimesReservationUnitFieldsFragment = {
   readonly reservableTimeSpans: ReadonlyArray<{
     readonly startDatetime: string | null;
     readonly endDatetime: string | null;
-  } | null> | null;
+  }> | null;
 };
 
 export type ReservationCardFragment = {
@@ -6485,7 +6474,7 @@ export type ReservationCardFragment = {
   }>;
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
   }>;
 };
 
@@ -6571,7 +6560,7 @@ export type ReservationTimePickerFieldsFragment = {
   readonly reservableTimeSpans: ReadonlyArray<{
     readonly startDatetime: string | null;
     readonly endDatetime: string | null;
-  } | null> | null;
+  }> | null;
   readonly pricings: ReadonlyArray<{
     readonly id: string;
     readonly begins: string;
@@ -6589,7 +6578,7 @@ export type ReservationTimePickerFieldsFragment = {
 export type SingleSearchCardFragment = {
   readonly reservationBegins: string | null;
   readonly reservationEnds: string | null;
-  readonly isClosed: boolean | null;
+  readonly isClosed: boolean;
   readonly firstReservableDatetime: string | null;
   readonly currentAccessType: AccessType | null;
   readonly maxPersons: number | null;
@@ -6736,7 +6725,7 @@ export type OptionsQuery = {
 export type ApplicationFormFragment = {
   readonly id: string;
   readonly pk: number | null;
-  readonly status: ApplicationStatusChoice | null;
+  readonly status: ApplicationStatusChoice;
   readonly applicantType: ApplicantTypeChoice | null;
   readonly additionalInformation: string | null;
   readonly applicationRound: {
@@ -6779,7 +6768,7 @@ export type ApplicationFormFragment = {
     readonly id: string;
     readonly pk: number | null;
     readonly name: string;
-    readonly status: ApplicationSectionStatusChoice | null;
+    readonly status: ApplicationSectionStatusChoice;
     readonly reservationMaxDuration: number;
     readonly numPersons: number;
     readonly reservationsEndDate: string;
@@ -6951,7 +6940,7 @@ export type PindoraSectionFragment = {
     readonly accessCodeEndsAt: string;
     readonly reservationSeriesId: number;
     readonly reservationId: number;
-  } | null>;
+  }>;
 };
 
 export type CreateReservationMutationVariables = Exact<{
@@ -7019,14 +7008,14 @@ export type ReservationOrderStatusFragment = {
   readonly state: ReservationStateChoice | null;
   readonly paymentOrder: ReadonlyArray<{
     readonly id: string;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
   }>;
 };
 
 export type OrderFieldsFragment = {
   readonly id: string;
   readonly reservationPk: string | null;
-  readonly status: OrderStatus | null;
+  readonly status: OrderStatus;
   readonly paymentType: PaymentType;
   readonly receiptUrl: string | null;
   readonly checkoutUrl: string | null;
@@ -7078,7 +7067,7 @@ export type OrderQuery = {
   readonly order: {
     readonly id: string;
     readonly reservationPk: string | null;
-    readonly status: OrderStatus | null;
+    readonly status: OrderStatus;
     readonly paymentType: PaymentType;
     readonly receiptUrl: string | null;
     readonly checkoutUrl: string | null;
@@ -7146,14 +7135,14 @@ export type BlockingReservationFieldsFragment = {
   readonly pk: number | null;
   readonly id: string;
   readonly state: ReservationStateChoice | null;
-  readonly isBlocked: boolean | null;
+  readonly isBlocked: boolean;
   readonly begin: string;
   readonly end: string;
   readonly numPersons: number | null;
-  readonly calendarUrl: string | null;
+  readonly calendarUrl: string;
   readonly bufferTimeBefore: number;
   readonly bufferTimeAfter: number;
-  readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+  readonly affectedReservationUnits: ReadonlyArray<number | null>;
 };
 
 export type CurrentUserQueryVariables = Exact<{ [key: string]: never }>;
@@ -7165,7 +7154,7 @@ export type CurrentUserQuery = {
     readonly firstName: string;
     readonly lastName: string;
     readonly email: string;
-    readonly isAdAuthenticated: boolean | null;
+    readonly isAdAuthenticated: boolean;
   } | null;
 };
 
@@ -7183,7 +7172,7 @@ export type IsReservableFieldsFragment = {
   readonly reservableTimeSpans: ReadonlyArray<{
     readonly startDatetime: string | null;
     readonly endDatetime: string | null;
-  } | null> | null;
+  }> | null;
 };
 
 export type CanReservationBeChangedFragment = {
@@ -7247,7 +7236,7 @@ export type ReservationPriceFieldsFragment = {
 };
 
 export type NotReservableFieldsFragment = {
-  readonly reservationState: ReservationUnitReservationState | null;
+  readonly reservationState: ReservationUnitReservationState;
   readonly reservationKind: ReservationKind;
   readonly id: string;
   readonly bufferTimeBefore: number;
@@ -7264,7 +7253,7 @@ export type NotReservableFieldsFragment = {
   readonly reservableTimeSpans: ReadonlyArray<{
     readonly startDatetime: string | null;
     readonly endDatetime: string | null;
-  } | null> | null;
+  }> | null;
   readonly metadataSet: {
     readonly id: string;
     readonly requiredFields: ReadonlyArray<{
@@ -7345,7 +7334,7 @@ export type ApplicationSectionCommonFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly name: string;
-  readonly status: ApplicationSectionStatusChoice | null;
+  readonly status: ApplicationSectionStatusChoice;
   readonly reservationMaxDuration: number;
   readonly numPersons: number;
   readonly reservationsEndDate: string;
@@ -7619,7 +7608,7 @@ export type ApplicationPage1Query = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
     readonly applicationRound: {
@@ -7662,7 +7651,7 @@ export type ApplicationPage1Query = {
       readonly id: string;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -7756,14 +7745,14 @@ export type ApplicationPage2Query = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
     readonly applicationSections: ReadonlyArray<{
       readonly id: string;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -7793,7 +7782,7 @@ export type ApplicationPage2Query = {
             readonly reservableTimes: ReadonlyArray<{
               readonly begin: string;
               readonly end: string;
-            } | null> | null;
+            } | null>;
           }>;
         };
       }>;
@@ -7904,7 +7893,7 @@ export type ApplicationPage3Query = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
     readonly applicationRound: {
@@ -7947,7 +7936,7 @@ export type ApplicationPage3Query = {
       readonly id: string;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -8034,14 +8023,14 @@ export type ApplicationPagePreviewQuery = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
     readonly applicationSections: ReadonlyArray<{
       readonly id: string;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -8085,7 +8074,7 @@ export type ApplicationPagePreviewQuery = {
     readonly applicationRound: {
       readonly id: string;
       readonly sentDate: string | null;
-      readonly status: ApplicationRoundStatusChoice | null;
+      readonly status: ApplicationRoundStatusChoice;
       readonly notesWhenApplyingFi: string | null;
       readonly notesWhenApplyingEn: string | null;
       readonly notesWhenApplyingSv: string | null;
@@ -8275,7 +8264,7 @@ export type ApplicationSectionViewQuery = {
         readonly application: {
           readonly id: string;
           readonly pk: number | null;
-          readonly status: ApplicationStatusChoice | null;
+          readonly status: ApplicationStatusChoice;
           readonly applicationRound: {
             readonly id: string;
             readonly nameEn: string | null;
@@ -8291,7 +8280,7 @@ export type ApplicationSectionViewQuery = {
             readonly accessCodeEndsAt: string;
             readonly reservationSeriesId: number;
             readonly reservationId: number;
-          } | null>;
+          }>;
         } | null;
         readonly reservationUnitOptions: ReadonlyArray<{
           readonly id: string;
@@ -8305,9 +8294,9 @@ export type ApplicationSectionViewQuery = {
               readonly pk: number | null;
               readonly beginTime: string | null;
               readonly endTime: string | null;
-              readonly weekdays: ReadonlyArray<number | null> | null;
-              readonly accessType: AccessTypeWithMultivalued | null;
-              readonly usedAccessTypes: ReadonlyArray<AccessType | null> | null;
+              readonly weekdays: ReadonlyArray<number>;
+              readonly accessType: AccessTypeWithMultivalued;
+              readonly usedAccessTypes: ReadonlyArray<AccessType | null>;
               readonly pindoraInfo: {
                 readonly accessCode: string;
                 readonly accessCodeIsActive: boolean;
@@ -8387,7 +8376,7 @@ export type ApplicationSentPageQuery = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
   } | null;
 };
 
@@ -8399,7 +8388,7 @@ export type ApplicationViewQuery = {
   readonly application: {
     readonly id: string;
     readonly pk: number | null;
-    readonly status: ApplicationStatusChoice | null;
+    readonly status: ApplicationStatusChoice;
     readonly applicantType: ApplicantTypeChoice | null;
     readonly additionalInformation: string | null;
     readonly applicationSections: ReadonlyArray<{
@@ -8407,7 +8396,7 @@ export type ApplicationViewQuery = {
       readonly hasReservations: boolean;
       readonly pk: number | null;
       readonly name: string;
-      readonly status: ApplicationSectionStatusChoice | null;
+      readonly status: ApplicationSectionStatusChoice;
       readonly reservationMaxDuration: number;
       readonly numPersons: number;
       readonly reservationsEndDate: string;
@@ -8451,7 +8440,7 @@ export type ApplicationViewQuery = {
     readonly applicationRound: {
       readonly id: string;
       readonly sentDate: string | null;
-      readonly status: ApplicationRoundStatusChoice | null;
+      readonly status: ApplicationRoundStatusChoice;
       readonly notesWhenApplyingFi: string | null;
       readonly notesWhenApplyingEn: string | null;
       readonly notesWhenApplyingSv: string | null;
@@ -8555,7 +8544,7 @@ export type ApplicationsQuery = {
         readonly sentDate: string | null;
         readonly id: string;
         readonly pk: number | null;
-        readonly status: ApplicationStatusChoice | null;
+        readonly status: ApplicationStatusChoice;
         readonly lastModifiedDate: string;
         readonly applicantType: ApplicantTypeChoice | null;
         readonly applicationRound: {
@@ -8683,7 +8672,7 @@ export type ApplicationRoundFieldsFragment = {
   readonly reservationPeriodEnd: string;
   readonly applicationPeriodBegin: string;
   readonly applicationPeriodEnd: string;
-  readonly status: ApplicationRoundStatusChoice | null;
+  readonly status: ApplicationRoundStatusChoice;
   readonly reservationUnits: ReadonlyArray<{
     readonly id: string;
     readonly pk: number | null;
@@ -8719,7 +8708,7 @@ export type ApplicationRoundsUiQuery = {
         readonly reservationPeriodEnd: string;
         readonly applicationPeriodBegin: string;
         readonly applicationPeriodEnd: string;
-        readonly status: ApplicationRoundStatusChoice | null;
+        readonly status: ApplicationRoundStatusChoice;
         readonly reservationUnits: ReadonlyArray<{
           readonly id: string;
           readonly pk: number | null;
@@ -8744,7 +8733,7 @@ export type ReservationQuery = {
     readonly name: string | null;
     readonly bufferTimeBefore: number;
     readonly bufferTimeAfter: number;
-    readonly calendarUrl: string | null;
+    readonly calendarUrl: string;
     readonly applyingForFreeOfCharge: boolean | null;
     readonly freeOfChargeReason: string | null;
     readonly description: string | null;
@@ -8776,7 +8765,7 @@ export type ReservationQuery = {
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
       readonly reservationPk: string | null;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
       readonly paymentType: PaymentType;
       readonly receiptUrl: string | null;
       readonly checkoutUrl: string | null;
@@ -8896,7 +8885,7 @@ export type ApplicationRoundTimeSlotFieldsFragment = {
   readonly reservableTimes: ReadonlyArray<{
     readonly begin: string;
     readonly end: string;
-  } | null> | null;
+  } | null>;
 };
 
 export type ReservationUnitPageQueryVariables = Exact<{
@@ -8918,8 +8907,8 @@ export type ReservationUnitPageQuery = {
     readonly descriptionEn: string | null;
     readonly descriptionSv: string | null;
     readonly canApplyFreeOfCharge: boolean;
-    readonly numActiveUserReservations: number | null;
-    readonly publishingState: ReservationUnitPublishingState | null;
+    readonly numActiveUserReservations: number;
+    readonly publishingState: ReservationUnitPublishingState;
     readonly currentAccessType: AccessType | null;
     readonly id: string;
     readonly pk: number | null;
@@ -8928,7 +8917,7 @@ export type ReservationUnitPageQuery = {
     readonly nameSv: string | null;
     readonly reservationsMinDaysBefore: number | null;
     readonly reservationsMaxDaysBefore: number | null;
-    readonly reservationState: ReservationUnitReservationState | null;
+    readonly reservationState: ReservationUnitReservationState;
     readonly reservationKind: ReservationKind;
     readonly minPersons: number | null;
     readonly maxPersons: number | null;
@@ -8976,7 +8965,7 @@ export type ReservationUnitPageQuery = {
       readonly reservableTimes: ReadonlyArray<{
         readonly begin: string;
         readonly end: string;
-      } | null> | null;
+      } | null>;
     }>;
     readonly applicationRounds: ReadonlyArray<{
       readonly id: string;
@@ -9050,7 +9039,7 @@ export type ReservationUnitPageQuery = {
     readonly reservableTimeSpans: ReadonlyArray<{
       readonly startDatetime: string | null;
       readonly endDatetime: string | null;
-    } | null> | null;
+    }> | null;
     readonly pricings: ReadonlyArray<{
       readonly id: string;
       readonly begins: string;
@@ -9068,14 +9057,14 @@ export type ReservationUnitPageQuery = {
     readonly pk: number | null;
     readonly id: string;
     readonly state: ReservationStateChoice | null;
-    readonly isBlocked: boolean | null;
+    readonly isBlocked: boolean;
     readonly begin: string;
     readonly end: string;
     readonly numPersons: number | null;
-    readonly calendarUrl: string | null;
+    readonly calendarUrl: string;
     readonly bufferTimeBefore: number;
     readonly bufferTimeAfter: number;
-    readonly affectedReservationUnits: ReadonlyArray<number | null> | null;
+    readonly affectedReservationUnits: ReadonlyArray<number | null>;
   }> | null;
 };
 
@@ -9245,7 +9234,7 @@ export type ReservationConfirmationPageQuery = {
     readonly id: string;
     readonly pk: number | null;
     readonly name: string | null;
-    readonly calendarUrl: string | null;
+    readonly calendarUrl: string;
     readonly reserveeFirstName: string | null;
     readonly reserveeLastName: string | null;
     readonly reserveeEmail: string | null;
@@ -9276,7 +9265,7 @@ export type ReservationConfirmationPageQuery = {
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
       readonly reservationPk: string | null;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
       readonly paymentType: PaymentType;
       readonly receiptUrl: string | null;
       readonly checkoutUrl: string | null;
@@ -9493,7 +9482,7 @@ export type ReservationPageQuery = {
     readonly id: string;
     readonly pk: number | null;
     readonly applyingForFreeOfCharge: boolean | null;
-    readonly calendarUrl: string | null;
+    readonly calendarUrl: string;
     readonly reserveeFirstName: string | null;
     readonly reserveeLastName: string | null;
     readonly reserveeEmail: string | null;
@@ -9524,7 +9513,7 @@ export type ReservationPageQuery = {
     readonly paymentOrder: ReadonlyArray<{
       readonly id: string;
       readonly reservationPk: string | null;
-      readonly status: OrderStatus | null;
+      readonly status: OrderStatus;
       readonly paymentType: PaymentType;
       readonly receiptUrl: string | null;
       readonly checkoutUrl: string | null;
@@ -9724,7 +9713,7 @@ export type ListReservationsQuery = {
         }>;
         readonly paymentOrder: ReadonlyArray<{
           readonly id: string;
-          readonly status: OrderStatus | null;
+          readonly status: OrderStatus;
         }>;
       } | null;
     } | null>;
@@ -9741,7 +9730,7 @@ export type SearchReservationUnitsQueryVariables = Exact<{
     | ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<
     | ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
     | InputMaybe<Scalars["Int"]["input"]>
@@ -9767,7 +9756,7 @@ export type SearchReservationUnitsQueryVariables = Exact<{
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
   first?: InputMaybe<Scalars["Int"]["input"]>;
   before?: InputMaybe<Scalars["String"]["input"]>;
@@ -9788,7 +9777,7 @@ export type SearchReservationUnitsQuery = {
       readonly node: {
         readonly reservationBegins: string | null;
         readonly reservationEnds: string | null;
-        readonly isClosed: boolean | null;
+        readonly isClosed: boolean;
         readonly firstReservableDatetime: string | null;
         readonly currentAccessType: AccessType | null;
         readonly maxPersons: number | null;
@@ -14559,7 +14548,7 @@ export const SearchReservationUnitsDocument = gql`
     $textSearch: String
     $pk: [Int]
     $applicationRound: [Int]
-    $personsAllowed: Decimal
+    $personsAllowed: Int
     $unit: [Int]
     $reservationUnitType: [Int]
     $purposes: [Int]
@@ -14571,7 +14560,7 @@ export const SearchReservationUnitsDocument = gql`
     $reservableDateEnd: Date
     $reservableTimeStart: Time
     $reservableTimeEnd: Time
-    $reservableMinimumDurationMinutes: Decimal
+    $reservableMinimumDurationMinutes: Int
     $showOnlyReservable: Boolean
     $first: Int
     $before: String

--- a/apps/ui/modules/reservable.test.ts
+++ b/apps/ui/modules/reservable.test.ts
@@ -14,7 +14,7 @@ import {
   isStartTimeValid,
 } from "./reservable";
 import {
-  BlockingReservationFieldsFragment,
+  type BlockingReservationFieldsFragment,
   type IsReservableFieldsFragment,
   ReservationStartInterval,
   ReservationStateChoice,
@@ -474,8 +474,8 @@ describe("isRangeReservable", () => {
       start,
       end,
       state = ReservationStateChoice.Confirmed,
-      bufferTimeAfter,
-      bufferTimeBefore,
+      bufferTimeAfter = 0,
+      bufferTimeBefore = 0,
       isBlocked = false,
     }: {
       start: Date;
@@ -488,14 +488,14 @@ describe("isRangeReservable", () => {
       return {
         id: base64encode("ReservationNode:1"),
         pk: 1,
-        bufferTimeAfter: 60 * 60 * (bufferTimeAfter ?? 0),
-        bufferTimeBefore: 60 * 60 * (bufferTimeBefore ?? 0),
+        bufferTimeAfter: 60 * 60 * bufferTimeAfter,
+        bufferTimeBefore: 60 * 60 * bufferTimeBefore,
         state,
         begin: start.toISOString(),
         end: end.toISOString(),
         isBlocked,
         numPersons: null,
-        calendarUrl: null,
+        calendarUrl: "",
         affectedReservationUnits: [],
       };
     }

--- a/apps/ui/modules/reservation.test.ts
+++ b/apps/ui/modules/reservation.test.ts
@@ -1,12 +1,12 @@
 import { addDays, addHours, addMinutes, startOfToday } from "date-fns";
 import {
-  type PaymentOrderNode,
   ReservationStateChoice,
   ReservationStartInterval,
   OrderStatus,
   type ReservationOrderStatusFragment,
   type CanUserCancelReservationFragment,
   type IsReservableFieldsFragment,
+  type PaymentOrderNode,
 } from "@gql/gql-types";
 import {
   isUserAllowedToMoveReservationHere,

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -152,7 +152,7 @@ export function processVariables({
   const duration = dur != null && dur > 0 ? dur : null;
   const isSeasonal = kind === ReservationKind.Season;
   const textSearch = values.get("textSearch");
-  const personsAllowed = toNumber(values.get("personsAllowed"))?.toString();
+  const personsAllowed = toNumber(values.get("personsAllowed"));
   const purposes = mapParamToNumber(values.getAll("purposes"), 1);
   const unit = mapParamToNumber(values.getAll("units"), 1);
   const reservationUnitTypes = mapParamToNumber(
@@ -215,7 +215,7 @@ export function processVariables({
       : {}),
     ...(duration != null
       ? {
-          reservableMinimumDurationMinutes: duration.toString(),
+          reservableMinimumDurationMinutes: duration,
         }
       : {}),
     ...(!isSeasonal && showOnlyReservable

--- a/apps/ui/pages/search/index.tsx
+++ b/apps/ui/pages/search/index.tsx
@@ -128,7 +128,7 @@ export const SEARCH_RESERVATION_UNITS = gql`
     $textSearch: String
     $pk: [Int]
     $applicationRound: [Int]
-    $personsAllowed: Decimal
+    $personsAllowed: Int
     $unit: [Int]
     $reservationUnitType: [Int]
     $purposes: [Int]
@@ -140,7 +140,7 @@ export const SEARCH_RESERVATION_UNITS = gql`
     $reservableDateEnd: Date
     $reservableTimeStart: Time
     $reservableTimeEnd: Time
-    $reservableMinimumDurationMinutes: Decimal
+    $reservableMinimumDurationMinutes: Int
     $showOnlyReservable: Boolean
     $first: Int
     $before: String

--- a/apps/ui/test/test.gql.utils.ts
+++ b/apps/ui/test/test.gql.utils.ts
@@ -3,6 +3,7 @@ import {
   type ApplicationFormFragment,
   ApplicationRoundFieldsFragment,
   ApplicationRoundStatusChoice,
+  ApplicationSectionStatusChoice,
   ApplicationStatusChoice,
   CreateApplicationDocument,
   type CreateApplicationMutationResult,
@@ -210,6 +211,7 @@ function createSearchVariablesMock({
     accessTypeEndDate: "2025-01-01T00:00:00Z",
     reservableDateStart: "2024-02-01T00:00:00Z",
     applicationRound: [1],
+    personsAllowed: null,
     first: 36,
     orderBy: [
       ReservationUnitOrderingChoices.NameFiAsc,
@@ -329,7 +331,7 @@ function createMockApplicationSection({
   return {
     id: base64encode(`ApplicationSectionNode:${pk}`),
     pk,
-    status: null, // (or Unallocated)
+    status: ApplicationSectionStatusChoice.Unallocated,
     ...page1Data,
     ...page2Data,
   };

--- a/backend/tests/test_graphql_api/test_reservation/test_query.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_query.py
@@ -85,7 +85,7 @@ def test_reservation__query__all_fields(graphql):
         isHandled
         name
         numPersons
-        order { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }
+        paymentOrder { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }
         price
         priceNet
         purpose { nameFi }
@@ -149,7 +149,7 @@ def test_reservation__query__all_fields(graphql):
         "isHandled": False,
         "name": reservation.name,
         "numPersons": reservation.num_persons,
-        "order": None,
+        "paymentOrder": [],
         "price": f"{reservation.price:.2f}",
         "priceNet": f"{reservation.price_net:.2f}",
         "purpose": None,
@@ -385,7 +385,9 @@ def test_reservation__query__order__all_fields(graphql):
         remote_id="b3fef99e-6c18-422e-943d-cf00702af53e",
     )
 
-    fields = "order { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }"
+    fields = (
+        "paymentOrder { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }"
+    )
     query = reservations_query(fields=fields)
 
     graphql.login_with_superuser()
@@ -393,16 +395,18 @@ def test_reservation__query__order__all_fields(graphql):
 
     assert response.has_errors is False, response
     assert response.node(0) == {
-        "order": {
-            "reservationPk": str(reservation.pk),
-            "checkoutUrl": None,
-            "orderUuid": "b3fef99e-6c18-422e-943d-cf00702af53e",
-            "paymentType": "INVOICE",
-            "receiptUrl": None,
-            "refundUuid": None,
-            "status": "DRAFT",
-            "expiresInMinutes": 5,
-        }
+        "paymentOrder": [
+            {
+                "reservationPk": str(reservation.pk),
+                "checkoutUrl": None,
+                "orderUuid": "b3fef99e-6c18-422e-943d-cf00702af53e",
+                "paymentType": "INVOICE",
+                "receiptUrl": None,
+                "refundUuid": None,
+                "status": "DRAFT",
+                "expiresInMinutes": 5,
+            },
+        ],
     }
 
 

--- a/backend/tests/test_graphql_api/test_reservation/test_query.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_query.py
@@ -103,7 +103,6 @@ def test_reservation__query__all_fields(graphql):
         reserveeOrganisationName
         reserveePhone
         reserveeType
-        staffEvent
         state
         taxPercentageValue
         type
@@ -168,7 +167,6 @@ def test_reservation__query__all_fields(graphql):
         "reserveeOrganisationName": reservation.reservee_organisation_name,
         "reserveePhone": reservation.reservee_phone,
         "reserveeType": reservation.reservee_type,
-        "staffEvent": False,
         "state": reservation.state,
         "taxPercentageValue": f"{reservation.tax_percentage_value:.2f}",
         "type": reservation.type,

--- a/backend/tests/test_graphql_api/test_reservation/test_query_permissions.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_query_permissions.py
@@ -192,7 +192,6 @@ def test_reservation__query__fields_requiring_staff_permissions__superuser(graph
 
     fields = """
         pk
-        staffEvent
         type
         workingMemo
         handlingDetails
@@ -206,7 +205,6 @@ def test_reservation__query__fields_requiring_staff_permissions__superuser(graph
     assert len(response.edges) == 1
     assert response.node(0) == {
         "pk": reservation.pk,
-        "staffEvent": True,
         "type": ReservationTypeChoice.STAFF.value,
         "workingMemo": reservation.working_memo,
         "handlingDetails": reservation.handling_details,
@@ -224,7 +222,6 @@ def test_reservation__query__fields_requiring_staff_permissions__regular_user(gr
 
     fields = """
         pk
-        staffEvent
         type
         workingMemo
         handlingDetails
@@ -238,7 +235,6 @@ def test_reservation__query__fields_requiring_staff_permissions__regular_user(gr
     assert len(response.edges) == 1
     assert response.node(0) == {
         "pk": reservation.pk,
-        "staffEvent": None,
         "type": None,
         "workingMemo": None,
         "handlingDetails": None,

--- a/backend/tests/test_graphql_api/test_reservation/test_query_permissions.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_query_permissions.py
@@ -122,7 +122,6 @@ def test_reservation__query__regular_user_cannot_see_personal_information_from_o
         description
         reserveeId
         cancelDetails
-        order { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }
         homeCity { nameFi }
         reserveeType
         reserveeIsUnregisteredAssociation
@@ -160,7 +159,6 @@ def test_reservation__query__regular_user_cannot_see_personal_information_from_o
         "isHandled": None,
         "name": None,
         "numPersons": None,
-        "order": None,
         "price": None,
         "priceNet": None,
         "purpose": None,
@@ -301,7 +299,7 @@ def test_reservation__query__reservation_owner_can_see_personal_information_from
         isHandled
         name
         numPersons
-        order { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }
+        paymentOrder { orderUuid status paymentType receiptUrl checkoutUrl reservationPk refundUuid expiresInMinutes }
         price
         priceNet
         purpose { nameFi }
@@ -344,7 +342,7 @@ def test_reservation__query__reservation_owner_can_see_personal_information_from
     assert response.node(0)["isHandled"] is not None, "field not found"
     assert response.node(0)["name"] is not None, "field not found"
     assert response.node(0)["numPersons"] is not None, "field not found"
-    assert response.node(0)["order"] is not None, "field not found"
+    assert response.node(0)["paymentOrder"] is not None, "field not found"
     assert response.node(0)["price"] is not None, "field not found"
     assert response.node(0)["priceNet"] is not None, "field not found"
     assert response.node(0)["purpose"] is not None, "field not found"

--- a/backend/tests/test_graphql_api/test_user/test_query_current_user.py
+++ b/backend/tests/test_graphql_api/test_user/test_query_current_user.py
@@ -245,7 +245,7 @@ def test_query_current_user__reservation_notification(graphql):
     assert response.has_errors is False, response
     assert response.first_query_object == {
         "pk": user.pk,
-        "reservationNotification": user.reservation_notification,
+        "reservationNotification": user.reservation_notification.value.upper(),
     }
 
 

--- a/backend/tilavarauspalvelu/api/graphql/types/application/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/application/types.py
@@ -29,7 +29,7 @@ __all__ = [
 
 
 class ApplicationNode(DjangoNode):
-    status = AnnotatedField(graphene.Enum.from_enum(ApplicationStatusChoice), expression=L("status"))
+    status = AnnotatedField(graphene.Enum.from_enum(ApplicationStatusChoice), expression=L("status"), required=True)
 
     application_sections = ApplicationSectionNode.ListField()
     user = ApplicantNode.RelatedField()

--- a/backend/tilavarauspalvelu/api/graphql/types/application_round/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/application_round/types.py
@@ -24,6 +24,7 @@ class ApplicationRoundNode(DjangoNode):
     status = AnnotatedField(
         graphene.Enum.from_enum(ApplicationRoundStatusChoice),
         expression=L("status"),
+        required=True,
     )
     status_timestamp = AnnotatedField(
         graphene.DateTime,
@@ -32,10 +33,12 @@ class ApplicationRoundNode(DjangoNode):
     reservation_creation_status = AnnotatedField(
         graphene.Enum.from_enum(ApplicationRoundReservationCreationStatusChoice),
         expression=L("reservation_creation_status"),
+        required=True,
     )
     is_setting_handled_allowed = AnnotatedField(
         graphene.Boolean,
         expression=L("is_setting_handled_allowed"),
+        required=True,
     )
     applications_count = AnnotatedField(
         graphene.Int,
@@ -46,6 +49,7 @@ class ApplicationRoundNode(DjangoNode):
                 sent_date__isnull=False,
             ),
         ),
+        required=True,
     )
     reservation_unit_count = AnnotatedField(
         graphene.Int,
@@ -54,6 +58,7 @@ class ApplicationRoundNode(DjangoNode):
                 application_rounds=models.OuterRef("pk"),
             ),
         ),
+        required=True,
     )
 
     class Meta:

--- a/backend/tilavarauspalvelu/api/graphql/types/application_round_time_slot/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/application_round_time_slot/types.py
@@ -19,7 +19,7 @@ class TimeSlot(TypedDict):
 
 
 class ApplicationRoundTimeSlotNode(DjangoNode):
-    reservable_times = TypedDictListField(TimeSlot)
+    reservable_times = TypedDictListField(TimeSlot, required=True)
 
     class Meta:
         model = ApplicationRoundTimeSlot

--- a/backend/tilavarauspalvelu/api/graphql/types/application_section/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/application_section/types.py
@@ -45,16 +45,28 @@ class PindoraSectionInfoType(graphene.ObjectType):
     access_code_sms_number = graphene.String(required=True)
     access_code_sms_message = graphene.String(required=True)
 
-    access_code_validity = graphene.List(PindoraSectionValidityInfoType, required=True)
+    access_code_validity = graphene.List(graphene.NonNull(PindoraSectionValidityInfoType), required=True)
 
 
 class ApplicationSectionNode(DjangoNode):
-    status = AnnotatedField(graphene.Enum.from_enum(ApplicationSectionStatusChoice), expression=L("status"))
-    allocations = AnnotatedField(graphene.Int, expression=L("allocations"))
+    status = AnnotatedField(
+        graphene.Enum.from_enum(ApplicationSectionStatusChoice),
+        expression=L("status"),
+        required=True,
+    )
+    allocations = AnnotatedField(
+        graphene.Int,
+        expression=L("allocations"),
+        required=True,
+    )
 
     has_reservations = ManuallyOptimizedField(graphene.Boolean, required=True)
 
-    should_have_active_access_code = AnnotatedField(graphene.Boolean, expression=L("should_have_active_access_code"))
+    should_have_active_access_code = AnnotatedField(
+        graphene.Boolean,
+        expression=L("should_have_active_access_code"),
+        required=True,
+    )
 
     pindora_info = MultiField(
         PindoraSectionInfoType,

--- a/backend/tilavarauspalvelu/api/graphql/types/banner_notification/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/banner_notification/types.py
@@ -21,7 +21,7 @@ __all__ = [
 
 
 class BannerNotificationNode(DjangoNode):
-    state = graphene.Field(graphene.Enum.from_enum(BannerNotificationState))
+    state = graphene.Field(graphene.Enum.from_enum(BannerNotificationState), required=True)
 
     class Meta:
         model = BannerNotification

--- a/backend/tilavarauspalvelu/api/graphql/types/equipment/filtersets.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/equipment/filtersets.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-import django_filters
-from graphene_django_extensions.filters import IntMultipleChoiceFilter, ModelFilterSet
+from graphene_django_extensions.filters import IntChoiceFilter, IntMultipleChoiceFilter, ModelFilterSet
 
 from tilavarauspalvelu.models import Equipment
 
@@ -13,8 +12,8 @@ __all__ = [
 
 class EquipmentFilterSet(ModelFilterSet):
     pk = IntMultipleChoiceFilter()
-    rank_gte = django_filters.NumberFilter(field_name="category__rank", lookup_expr="gte")
-    rank_lte = django_filters.NumberFilter(field_name="category__rank", lookup_expr="lte")
+    rank_gte = IntChoiceFilter(field_name="category__rank", lookup_expr="gte")
+    rank_lte = IntChoiceFilter(field_name="category__rank", lookup_expr="lte")
 
     class Meta:
         model = Equipment

--- a/backend/tilavarauspalvelu/api/graphql/types/helsinki_profile/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/helsinki_profile/types.py
@@ -37,7 +37,7 @@ class HelsinkiProfileDataNode(graphene.ObjectType):
     city = graphene.String()
     municipality_code = graphene.String()
     municipality_name = graphene.String()
-    login_method = graphene.Field(graphene.Enum.from_enum(LoginMethod))
+    login_method = graphene.Field(graphene.Enum.from_enum(LoginMethod), required=True)
     is_strong_login = graphene.Boolean(required=True)
 
     @classmethod

--- a/backend/tilavarauspalvelu/api/graphql/types/merchants/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/merchants/types.py
@@ -23,7 +23,7 @@ __all__ = [
 
 
 class PaymentMerchantNode(DjangoNode):
-    pk = graphene.UUID()
+    pk = graphene.UUID(required=True)
 
     class Meta:
         model = PaymentMerchant
@@ -34,7 +34,7 @@ class PaymentMerchantNode(DjangoNode):
 
 
 class PaymentProductNode(DjangoNode):
-    pk = graphene.UUID()
+    pk = graphene.UUID(required=True)
 
     class Meta:
         model = PaymentProduct
@@ -48,8 +48,8 @@ class PaymentOrderNode(DjangoNode):
     order_uuid = MultiField(graphene.UUID, fields=["remote_id"])
     refund_uuid = MultiField(graphene.UUID, fields=["refund_id"])
 
-    payment_type = graphene.Field(graphene.NonNull(graphene.Enum.from_enum(PaymentType)))
-    status = graphene.Field(graphene.Enum.from_enum(OrderStatus))  # TODO: NonNull, requires frontend changes
+    payment_type = graphene.Field(graphene.Enum.from_enum(PaymentType), required=True)
+    status = graphene.Field(graphene.Enum.from_enum(OrderStatus), required=True)
 
     checkout_url = MultiField(graphene.String, fields=["checkout_url", "status", "created_at"])
     receipt_url = graphene.String()

--- a/backend/tilavarauspalvelu/api/graphql/types/permissions/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/permissions/types.py
@@ -24,7 +24,10 @@ __all__ = [
 
 
 class GeneralRoleNode(DjangoNode):
-    permissions = graphene.List(graphene.Enum.from_enum(UserPermissionChoice))
+    permissions = graphene.List(
+        graphene.NonNull(graphene.Enum.from_enum(UserPermissionChoice)),
+        required=True,
+    )
 
     class Meta:
         model = GeneralRole
@@ -45,7 +48,10 @@ class GeneralRoleNode(DjangoNode):
 
 
 class UnitRoleNode(DjangoNode):
-    permissions = ManuallyOptimizedField(graphene.List(graphene.Enum.from_enum(UserPermissionChoice)))
+    permissions = ManuallyOptimizedField(
+        graphene.List(graphene.NonNull(graphene.Enum.from_enum(UserPermissionChoice))),
+        required=True,
+    )
 
     class Meta:
         model = UnitRole
@@ -101,7 +107,7 @@ class UnitRoleNode(DjangoNode):
 
 
 class PermissionCheckerType(ObjectType):
-    has_permission = graphene.Field(graphene.NonNull(graphene.Boolean))
+    has_permission = graphene.Boolean(required=True)
 
     @classmethod
     def run(

--- a/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/recurring_reservation/types.py
@@ -47,15 +47,27 @@ class PindoraSeriesInfoType(graphene.ObjectType):
 
 
 class RecurringReservationNode(DjangoNode):
-    weekdays = graphene.List(graphene.Int)
+    weekdays = graphene.List(graphene.NonNull(graphene.Int), required=True)
 
-    access_type = AnnotatedField(graphene.Enum.from_enum(AccessTypeWithMultivalued), expression=L("access_type"))
-    used_access_types = AnnotatedField(
-        graphene.List(graphene.Enum.from_enum(AccessType)), expression=L("used_access_types")
+    access_type = AnnotatedField(
+        graphene.Enum.from_enum(AccessTypeWithMultivalued),
+        expression=L("access_type"),
+        required=True,
     )
-    should_have_active_access_code = AnnotatedField(graphene.Boolean, expression=L("should_have_active_access_code"))
+    used_access_types = AnnotatedField(
+        graphene.List(graphene.Enum.from_enum(AccessType)),
+        expression=L("used_access_types"),
+        required=True,
+    )
+    should_have_active_access_code = AnnotatedField(
+        graphene.Boolean,
+        expression=L("should_have_active_access_code"),
+        required=True,
+    )
     is_access_code_is_active_correct = AnnotatedField(
-        graphene.Boolean, expression=L("is_access_code_is_active_correct")
+        graphene.Boolean,
+        expression=L("is_access_code_is_active_correct"),
+        required=True,
     )
 
     pindora_info = MultiField(

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation/types.py
@@ -56,20 +56,34 @@ def staff_field_check(user: AnyUser, reservation: Reservation) -> bool | None:
 
 
 class ReservationNode(DjangoNode):
-    reservee_name = AnnotatedField(graphene.String, expression=L("reservee_name"))
-
-    is_blocked = AnnotatedField(graphene.Boolean, expression=models.Q(type=ReservationTypeChoice.BLOCKED.value))
-    is_handled = AnnotatedField(graphene.Boolean, expression=models.Q(handled_at__isnull=False))
-
-    access_code_should_be_active = AnnotatedField(graphene.Boolean, expression=L("access_code_should_be_active"))
-    is_access_code_is_active_correct = AnnotatedField(
-        graphene.Boolean, expression=L("is_access_code_is_active_correct")
+    reservee_name = AnnotatedField(
+        graphene.String,
+        expression=L("reservee_name"),
     )
 
-    calendar_url = graphene.String()
+    is_blocked = AnnotatedField(
+        graphene.Boolean,
+        expression=models.Q(type=ReservationTypeChoice.BLOCKED.value),
+        required=True,
+    )
+    is_handled = AnnotatedField(
+        graphene.Boolean,
+        expression=models.Q(handled_at__isnull=False),
+    )
+    access_code_should_be_active = AnnotatedField(
+        graphene.Boolean,
+        expression=L("access_code_should_be_active"),
+    )
+    is_access_code_is_active_correct = AnnotatedField(
+        graphene.Boolean,
+        expression=L("is_access_code_is_active_correct"),
+        required=True,
+    )
+
+    calendar_url = graphene.String(required=True)
 
     affected_reservation_units = AnnotatedField(
-        graphene.List(graphene.Int),
+        graphene.List(graphene.Int, required=True),
         description="Which reservation units' reserveability is affected by this reservation?",
         expression=(
             SubqueryArray(
@@ -78,6 +92,7 @@ class ReservationNode(DjangoNode):
                 distinct=True,
             )
         ),
+        required=True,
     )
 
     pindora_info = MultiField(

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation/types.py
@@ -65,12 +65,6 @@ class ReservationNode(DjangoNode):
     is_blocked = AnnotatedField(graphene.Boolean, expression=models.Q(type=ReservationTypeChoice.BLOCKED.value))
     is_handled = AnnotatedField(graphene.Boolean, expression=models.Q(handled_at__isnull=False))
 
-    staff_event = AnnotatedField(
-        graphene.Boolean,
-        expression=models.Q(type=ReservationTypeChoice.STAFF.value),
-        deprecation_reason="Please use to 'type' instead.",
-    )
-
     access_code_should_be_active = AnnotatedField(graphene.Boolean, expression=L("access_code_should_be_active"))
     is_access_code_is_active_correct = AnnotatedField(
         graphene.Boolean, expression=L("is_access_code_is_active_correct")
@@ -212,7 +206,6 @@ class ReservationNode(DjangoNode):
             "is_handled",
             "order",
             "payment_order",
-            "staff_event",
             "calendar_url",
         ]
         restricted_fields = {
@@ -225,7 +218,6 @@ class ReservationNode(DjangoNode):
                     "handling_details",
                     "working_memo",
                     "handled_at",
-                    "staff_event",
                 }
                 # FIELDS ARE PRIVATE BY DEFAULT
                 else private_field_check

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation_unit/filtersets.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation_unit/filtersets.py
@@ -8,7 +8,7 @@ from django.contrib.postgres.search import SearchQuery
 from django.db import models
 from django.db.models import Q
 from graphene_django_extensions import ModelFilterSet
-from graphene_django_extensions.filters import EnumMultipleChoiceFilter, IntMultipleChoiceFilter
+from graphene_django_extensions.filters import EnumMultipleChoiceFilter, IntChoiceFilter, IntMultipleChoiceFilter
 
 from tilavarauspalvelu.enums import (
     AccessType,
@@ -65,11 +65,11 @@ class ReservationUnitFilterSet(ModelFilterSet, ReservationUnitFilterSetMixin):
     unit = IntMultipleChoiceFilter()
     reservation_unit_type = IntMultipleChoiceFilter()
 
-    min_persons_gte = django_filters.NumberFilter(field_name="min_persons", method="get_min_persons_gte")
-    min_persons_lte = django_filters.NumberFilter(field_name="min_persons", method="get_min_persons_lte")
-    max_persons_gte = django_filters.NumberFilter(field_name="max_persons", method="get_max_persons_gte")
-    max_persons_lte = django_filters.NumberFilter(field_name="max_persons", method="get_max_persons_lte")
-    persons_allowed = django_filters.NumberFilter(method="get_persons_allowed")
+    min_persons_gte = IntChoiceFilter(field_name="min_persons", method="get_min_persons_gte")
+    min_persons_lte = IntChoiceFilter(field_name="min_persons", method="get_min_persons_lte")
+    max_persons_gte = IntChoiceFilter(field_name="max_persons", method="get_max_persons_gte")
+    max_persons_lte = IntChoiceFilter(field_name="max_persons", method="get_max_persons_lte")
+    persons_allowed = IntChoiceFilter(method="get_persons_allowed")
 
     text_search = django_filters.CharFilter(method="get_text_search")
 
@@ -86,14 +86,14 @@ class ReservationUnitFilterSet(ModelFilterSet, ReservationUnitFilterSetMixin):
     name_en = django_filters.CharFilter(field_name="name_en", lookup_expr="istartswith")
     name_sv = django_filters.CharFilter(field_name="name_sv", lookup_expr="istartswith")
 
-    surface_area_gte = django_filters.NumberFilter(field_name="surface_area", lookup_expr="gte")
-    surface_area_lte = django_filters.NumberFilter(field_name="surface_area", lookup_expr="lte")
+    surface_area_gte = IntChoiceFilter(field_name="surface_area", lookup_expr="gte")
+    surface_area_lte = IntChoiceFilter(field_name="surface_area", lookup_expr="lte")
 
-    rank_gte = django_filters.NumberFilter(field_name="rank", lookup_expr="gte")
-    rank_lte = django_filters.NumberFilter(field_name="rank", lookup_expr="lte")
+    rank_gte = IntChoiceFilter(field_name="rank", lookup_expr="gte")
+    rank_lte = IntChoiceFilter(field_name="rank", lookup_expr="lte")
 
-    type_rank_gte = django_filters.NumberFilter(field_name="reservation_unit_type__rank", lookup_expr="gte")
-    type_rank_lte = django_filters.NumberFilter(field_name="reservation_unit_type__rank", lookup_expr="lte")
+    type_rank_gte = IntChoiceFilter(field_name="reservation_unit_type__rank", lookup_expr="gte")
+    type_rank_lte = IntChoiceFilter(field_name="reservation_unit_type__rank", lookup_expr="lte")
 
     reservation_kind = django_filters.CharFilter(field_name="reservation_kind", method="get_reservation_kind")
 
@@ -116,7 +116,7 @@ class ReservationUnitFilterSet(ModelFilterSet, ReservationUnitFilterSetMixin):
     reservable_date_end = django_filters.DateFilter(method="get_filter_reservable")
     reservable_time_start = django_filters.TimeFilter(method="get_filter_reservable")
     reservable_time_end = django_filters.TimeFilter(method="get_filter_reservable")
-    reservable_minimum_duration_minutes = django_filters.NumberFilter(method="get_filter_reservable")
+    reservable_minimum_duration_minutes = IntChoiceFilter(method="get_filter_reservable")
     show_only_reservable = django_filters.BooleanFilter(method="get_filter_reservable")
     calculate_first_reservable_time = django_filters.BooleanFilter(method="get_filter_reservable")
 

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation_unit/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation_unit/types.py
@@ -56,31 +56,33 @@ class ReservationUnitNode(DjangoNode):
     publishing_state = AnnotatedField(
         graphene.Enum.from_enum(ReservationUnitPublishingState),
         expression=L("publishing_state"),
+        required=True,
     )
     reservation_state = AnnotatedField(
         graphene.Enum.from_enum(ReservationUnitReservationState),
         expression=L("reservation_state"),
+        required=True,
     )
 
     location = ManuallyOptimizedField(LocationNode)
 
-    is_closed = graphene.Boolean()
+    is_closed = graphene.Boolean(required=True)
     first_reservable_datetime = graphene.DateTime()
     effective_access_type = graphene.Field(graphene.Enum.from_enum(AccessType))
 
     hauki_url = ManuallyOptimizedField(graphene.String)
 
     reservable_time_spans = graphene.List(
-        ReservableTimeSpanType,
+        graphene.NonNull(ReservableTimeSpanType),
         start_date=graphene.Date(required=True),
         end_date=graphene.Date(required=True),
     )
 
     reservations = DjangoListField(ReservationNode)
 
-    num_active_user_reservations = ManuallyOptimizedField(graphene.Int)
+    num_active_user_reservations = ManuallyOptimizedField(graphene.Int, required=True)
 
-    calculated_surface_area = AnnotatedField(graphene.Int, expression=Sum("surface_area"))
+    calculated_surface_area = AnnotatedField(graphene.Int, expression=Sum("surface_area"), required=True)
 
     current_access_type = AnnotatedField(graphene.Enum.from_enum(AccessType), expression=L("current_access_type"))
 

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation_unit_pricing/types.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 
 
 class ReservationUnitPricingNode(DjangoNode):
-    lowest_price_net = graphene.Decimal()
-    highest_price_net = graphene.Decimal()
+    lowest_price_net = graphene.Decimal(required=True)
+    highest_price_net = graphene.Decimal(required=True)
 
     class Meta:
         model = ReservationUnitPricing

--- a/backend/tilavarauspalvelu/api/graphql/types/resource/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/resource/types.py
@@ -11,7 +11,10 @@ from .permissions import ResourcePermission
 
 
 class ResourceNode(DjangoNode):
-    location_type = graphene.Field(graphene.Enum.from_enum(ResourceLocationType))
+    location_type = graphene.Field(
+        graphene.Enum.from_enum(ResourceLocationType),
+        required=True,
+    )
 
     class Meta:
         model = Resource

--- a/backend/tilavarauspalvelu/api/graphql/types/suitable_time_range/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/suitable_time_range/types.py
@@ -12,7 +12,7 @@ from .filtersets import SuitableTimeRangeFilterSet
 
 
 class SuitableTimeRangeNode(DjangoNode):
-    fulfilled = AnnotatedField(graphene.Boolean, expression=L("fulfilled"))
+    fulfilled = AnnotatedField(graphene.Boolean, expression=L("fulfilled"), required=True)
 
     class Meta:
         model = SuitableTimeRange

--- a/backend/tilavarauspalvelu/api/graphql/types/user/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/user/types.py
@@ -8,6 +8,7 @@ from django.db.models.functions import Concat, Trim
 from graphene_django_extensions import DjangoNode
 from query_optimizer import AnnotatedField
 
+from tilavarauspalvelu.enums import ReservationNotification
 from tilavarauspalvelu.models import User
 from tilavarauspalvelu.tasks import save_personal_info_view_log
 
@@ -47,7 +48,7 @@ class UserNode(DjangoNode):
 
     is_ad_authenticated = graphene.Boolean()
     is_strongly_authenticated = graphene.Boolean()
-    reservation_notification = graphene.String()
+    reservation_notification = graphene.Field(graphene.Enum.from_enum(ReservationNotification))
 
     class Meta:
         model = User

--- a/backend/tilavarauspalvelu/api/graphql/types/user/types.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/user/types.py
@@ -44,10 +44,14 @@ _FIELDS = [
 
 
 class UserNode(DjangoNode):
-    name = AnnotatedField(graphene.String, expression=Trim(Concat("first_name", Value(" "), "last_name")))
+    name = AnnotatedField(
+        graphene.String,
+        expression=Trim(Concat("first_name", Value(" "), "last_name")),
+        required=True,
+    )
 
-    is_ad_authenticated = graphene.Boolean()
-    is_strongly_authenticated = graphene.Boolean()
+    is_ad_authenticated = graphene.Boolean(required=True)
+    is_strongly_authenticated = graphene.Boolean(required=True)
     reservation_notification = graphene.Field(graphene.Enum.from_enum(ReservationNotification))
 
     class Meta:

--- a/backend/tilavarauspalvelu/models/application_round/model.py
+++ b/backend/tilavarauspalvelu/models/application_round/model.py
@@ -135,7 +135,7 @@ class ApplicationRound(models.Model):
         return ApplicationRoundStatusChoice.IN_ALLOCATION
 
     @lookup_property(skip_codegen=True)
-    def status_timestamp() -> datetime.datetime:
+    def status_timestamp() -> datetime.datetime | None:
         return models.Case(  # type: ignore[return-value]
             models.When(
                 models.Q(sent_date__isnull=False),  # RESULTS_SENT
@@ -158,7 +158,7 @@ class ApplicationRound(models.Model):
         )
 
     @status_timestamp.override
-    def _(self) -> datetime.datetime:
+    def _(self) -> datetime.datetime | None:
         match self.status:
             case ApplicationRoundStatusChoice.UPCOMING:
                 return self.public_display_begin

--- a/packages/common/gql/gql-types.ts
+++ b/packages/common/gql/gql-types.ts
@@ -221,14 +221,14 @@ export type ApplicantNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -300,7 +300,7 @@ export type ApplicationNode = Node & {
   readonly organisation: Maybe<OrganisationNode>;
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationStatusChoice>;
+  readonly status: ApplicationStatusChoice;
   readonly user: Maybe<ApplicantNode>;
   readonly workingMemo: Scalars["String"]["output"];
 };
@@ -377,7 +377,7 @@ export enum ApplicationOrderingChoices {
 export type ApplicationRoundNode = Node & {
   readonly applicationPeriodBegin: Scalars["DateTime"]["output"];
   readonly applicationPeriodEnd: Scalars["DateTime"]["output"];
-  readonly applicationsCount: Maybe<Scalars["Int"]["output"]>;
+  readonly applicationsCount: Scalars["Int"]["output"];
   readonly criteria: Scalars["String"]["output"];
   readonly criteriaEn: Maybe<Scalars["String"]["output"]>;
   readonly criteriaFi: Maybe<Scalars["String"]["output"]>;
@@ -385,7 +385,7 @@ export type ApplicationRoundNode = Node & {
   readonly handledDate: Maybe<Scalars["DateTime"]["output"]>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isSettingHandledAllowed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isSettingHandledAllowed: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -398,13 +398,13 @@ export type ApplicationRoundNode = Node & {
   readonly publicDisplayBegin: Scalars["DateTime"]["output"];
   readonly publicDisplayEnd: Scalars["DateTime"]["output"];
   readonly purposes: ReadonlyArray<ReservationPurposeNode>;
-  readonly reservationCreationStatus: Maybe<ApplicationRoundReservationCreationStatusChoice>;
+  readonly reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice;
   readonly reservationPeriodBegin: Scalars["Date"]["output"];
   readonly reservationPeriodEnd: Scalars["Date"]["output"];
-  readonly reservationUnitCount: Maybe<Scalars["Int"]["output"]>;
+  readonly reservationUnitCount: Scalars["Int"]["output"];
   readonly reservationUnits: ReadonlyArray<ReservationUnitNode>;
   readonly sentDate: Maybe<Scalars["DateTime"]["output"]>;
-  readonly status: Maybe<ApplicationRoundStatusChoice>;
+  readonly status: ApplicationRoundStatusChoice;
   readonly statusTimestamp: Maybe<Scalars["DateTime"]["output"]>;
   readonly termsOfUse: Maybe<TermsOfUseNode>;
 };
@@ -436,10 +436,10 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -453,18 +453,18 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -475,13 +475,13 @@ export type ApplicationRoundNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -529,7 +529,7 @@ export type ApplicationRoundTimeSlotNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservableTimes: Maybe<ReadonlyArray<Maybe<TimeSlotType>>>;
+  readonly reservableTimes: ReadonlyArray<Maybe<TimeSlotType>>;
   readonly weekday: Scalars["Int"]["output"];
 };
 
@@ -610,7 +610,7 @@ export type ApplicationSectionForApplicationSerializerInput = {
 
 export type ApplicationSectionNode = Node & {
   readonly ageGroup: Maybe<AgeGroupNode>;
-  readonly allocations: Maybe<Scalars["Int"]["output"]>;
+  readonly allocations: Scalars["Int"]["output"];
   readonly application: ApplicationNode;
   readonly appliedReservationsPerWeek: Scalars["Int"]["output"];
   readonly extUuid: Scalars["UUID"]["output"];
@@ -628,8 +628,8 @@ export type ApplicationSectionNode = Node & {
   readonly reservationUnitOptions: ReadonlyArray<ReservationUnitOptionNode>;
   readonly reservationsBeginDate: Scalars["Date"]["output"];
   readonly reservationsEndDate: Scalars["Date"]["output"];
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly status: Maybe<ApplicationSectionStatusChoice>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly status: ApplicationSectionStatusChoice;
   readonly suitableTimeRanges: ReadonlyArray<SuitableTimeRangeNode>;
 };
 
@@ -889,7 +889,7 @@ export type BannerNotificationNode = Node & {
   readonly messageSv: Maybe<Scalars["String"]["output"]>;
   readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly state: Maybe<BannerNotificationState>;
+  readonly state: BannerNotificationState;
   readonly target: BannerNotificationTarget;
 };
 
@@ -1189,7 +1189,7 @@ export type GeneralRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly user: UserNode;
 };
@@ -1201,7 +1201,7 @@ export type HelsinkiProfileDataNode = {
   readonly firstName: Maybe<Scalars["String"]["output"]>;
   readonly isStrongLogin: Scalars["Boolean"]["output"];
   readonly lastName: Maybe<Scalars["String"]["output"]>;
-  readonly loginMethod: Maybe<LoginMethod>;
+  readonly loginMethod: LoginMethod;
   readonly municipalityCode: Maybe<Scalars["String"]["output"]>;
   readonly municipalityName: Maybe<Scalars["String"]["output"]>;
   readonly phone: Maybe<Scalars["String"]["output"]>;
@@ -1693,7 +1693,7 @@ export type PaymentMerchantNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly name: Scalars["String"]["output"];
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 export type PaymentOrderNode = Node & {
@@ -1707,14 +1707,14 @@ export type PaymentOrderNode = Node & {
   readonly receiptUrl: Maybe<Scalars["String"]["output"]>;
   readonly refundUuid: Maybe<Scalars["UUID"]["output"]>;
   readonly reservationPk: Maybe<Scalars["String"]["output"]>;
-  readonly status: Maybe<OrderStatus>;
+  readonly status: OrderStatus;
 };
 
 export type PaymentProductNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly merchant: Maybe<PaymentMerchantNode>;
-  readonly pk: Maybe<Scalars["UUID"]["output"]>;
+  readonly pk: Scalars["UUID"]["output"];
 };
 
 /** An enumeration. */
@@ -1766,9 +1766,7 @@ export type PindoraSectionInfoType = {
   readonly accessCodePhoneNumber: Scalars["String"]["output"];
   readonly accessCodeSmsMessage: Scalars["String"]["output"];
   readonly accessCodeSmsNumber: Scalars["String"]["output"];
-  readonly accessCodeValidity: ReadonlyArray<
-    Maybe<PindoraSectionValidityInfoType>
-  >;
+  readonly accessCodeValidity: ReadonlyArray<PindoraSectionValidityInfoType>;
 };
 
 export type PindoraSectionValidityInfoType = {
@@ -2229,8 +2227,8 @@ export type QueryEquipmentsArgs = {
   offset?: InputMaybe<Scalars["Int"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type QueryEquipmentsAllArgs = {
@@ -2440,10 +2438,10 @@ export type QueryReservationUnitsArgs = {
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
   last?: InputMaybe<Scalars["Int"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -2458,18 +2456,18 @@ export type QueryReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -2480,13 +2478,13 @@ export type QueryReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -2681,7 +2679,7 @@ export type QueryUserArgs = {
 
 export type RecurringReservationNode = Node & {
   readonly abilityGroup: Maybe<AbilityGroupNode>;
-  readonly accessType: Maybe<AccessTypeWithMultivalued>;
+  readonly accessType: AccessTypeWithMultivalued;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly allocatedTimeSlot: Maybe<AllocatedTimeSlotNode>;
   readonly beginDate: Maybe<Scalars["Date"]["output"]>;
@@ -2693,7 +2691,7 @@ export type RecurringReservationNode = Node & {
   readonly extUuid: Scalars["UUID"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
   readonly name: Scalars["String"]["output"];
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple series, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraSeriesInfoType>;
@@ -2702,10 +2700,10 @@ export type RecurringReservationNode = Node & {
   readonly rejectedOccurrences: ReadonlyArray<RejectedOccurrenceNode>;
   readonly reservationUnit: ReservationUnitNode;
   readonly reservations: ReadonlyArray<ReservationNode>;
-  readonly shouldHaveActiveAccessCode: Maybe<Scalars["Boolean"]["output"]>;
-  readonly usedAccessTypes: Maybe<ReadonlyArray<Maybe<AccessType>>>;
+  readonly shouldHaveActiveAccessCode: Scalars["Boolean"]["output"];
+  readonly usedAccessTypes: ReadonlyArray<Maybe<AccessType>>;
   readonly user: Maybe<UserNode>;
-  readonly weekdays: Maybe<ReadonlyArray<Maybe<Scalars["Int"]["output"]>>>;
+  readonly weekdays: ReadonlyArray<Scalars["Int"]["output"]>;
 };
 
 export type RecurringReservationNodeRejectedOccurrencesArgs = {
@@ -3105,8 +3103,8 @@ export type ReservationNode = Node & {
   readonly accessCodeShouldBeActive: Maybe<Scalars["Boolean"]["output"]>;
   readonly accessType: AccessType;
   /** Which reservation units' reserveability is affected by this reservation? */
-  readonly affectedReservationUnits: Maybe<
-    ReadonlyArray<Maybe<Scalars["Int"]["output"]>>
+  readonly affectedReservationUnits: ReadonlyArray<
+    Maybe<Scalars["Int"]["output"]>
   >;
   readonly ageGroup: Maybe<AgeGroupNode>;
   readonly applyingForFreeOfCharge: Maybe<Scalars["Boolean"]["output"]>;
@@ -3120,7 +3118,7 @@ export type ReservationNode = Node & {
   readonly billingPhone: Maybe<Scalars["String"]["output"]>;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calendarUrl: Maybe<Scalars["String"]["output"]>;
+  readonly calendarUrl: Scalars["String"]["output"];
   readonly cancelDetails: Maybe<Scalars["String"]["output"]>;
   readonly cancelReason: Maybe<ReservationCancelReasonNode>;
   readonly createdAt: Maybe<Scalars["DateTime"]["output"]>;
@@ -3134,13 +3132,11 @@ export type ReservationNode = Node & {
   readonly homeCity: Maybe<CityNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAccessCodeIsActiveCorrect: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isBlocked: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAccessCodeIsActiveCorrect: Scalars["Boolean"]["output"];
+  readonly isBlocked: Scalars["Boolean"]["output"];
   readonly isHandled: Maybe<Scalars["Boolean"]["output"]>;
   readonly name: Maybe<Scalars["String"]["output"]>;
   readonly numPersons: Maybe<Scalars["Int"]["output"]>;
-  /** @deprecated Please use to 'paymentOrder' instead. */
-  readonly order: Maybe<PaymentOrderNode>;
   readonly paymentOrder: ReadonlyArray<PaymentOrderNode>;
   /** Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple reservations, queries to Pindora are not optimized. */
   readonly pindoraInfo: Maybe<PindoraReservationInfoType>;
@@ -3164,8 +3160,6 @@ export type ReservationNode = Node & {
   readonly reserveeOrganisationName: Maybe<Scalars["String"]["output"]>;
   readonly reserveePhone: Maybe<Scalars["String"]["output"]>;
   readonly reserveeType: Maybe<CustomerTypeChoice>;
-  /** @deprecated Please use to 'type' instead. */
-  readonly staffEvent: Maybe<Scalars["Boolean"]["output"]>;
   readonly state: Maybe<ReservationStateChoice>;
   readonly taxPercentageValue: Maybe<Scalars["Decimal"]["output"]>;
   readonly type: Maybe<ReservationTypeChoice>;
@@ -3191,10 +3185,10 @@ export type ReservationNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -3208,18 +3202,18 @@ export type ReservationNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -3230,13 +3224,13 @@ export type ReservationNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -3257,13 +3251,10 @@ export type ReservationNodeEdge = {
   readonly node: Maybe<ReservationNode>;
 };
 
-/** An enumeration. */
+/** When user wants to receive reservation notification emails. */
 export enum ReservationNotification {
-  /** All */
   All = "ALL",
-  /** None */
   None = "NONE",
-  /** Only Handling Required */
   OnlyHandlingRequired = "ONLY_HANDLING_REQUIRED",
 }
 
@@ -4106,7 +4097,7 @@ export type ReservationUnitNode = Node & {
   readonly authentication: Authentication;
   readonly bufferTimeAfter: Scalars["Duration"]["output"];
   readonly bufferTimeBefore: Scalars["Duration"]["output"];
-  readonly calculatedSurfaceArea: Maybe<Scalars["Int"]["output"]>;
+  readonly calculatedSurfaceArea: Scalars["Int"]["output"];
   readonly canApplyFreeOfCharge: Scalars["Boolean"]["output"];
   readonly cancellationRule: Maybe<ReservationUnitCancellationRuleNode>;
   readonly cancellationTerms: Maybe<TermsOfUseNode>;
@@ -4124,7 +4115,7 @@ export type ReservationUnitNode = Node & {
   readonly id: Scalars["ID"]["output"];
   readonly images: ReadonlyArray<ReservationUnitImageNode>;
   readonly isArchived: Scalars["Boolean"]["output"];
-  readonly isClosed: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isClosed: Scalars["Boolean"]["output"];
   readonly isDraft: Scalars["Boolean"]["output"];
   readonly location: Maybe<LocationNode>;
   readonly maxPersons: Maybe<Scalars["Int"]["output"]>;
@@ -4137,7 +4128,7 @@ export type ReservationUnitNode = Node & {
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
   readonly nameSv: Maybe<Scalars["String"]["output"]>;
-  readonly numActiveUserReservations: Maybe<Scalars["Int"]["output"]>;
+  readonly numActiveUserReservations: Scalars["Int"]["output"];
   readonly paymentMerchant: Maybe<PaymentMerchantNode>;
   readonly paymentProduct: Maybe<PaymentProductNode>;
   readonly paymentTerms: Maybe<TermsOfUseNode>;
@@ -4147,15 +4138,13 @@ export type ReservationUnitNode = Node & {
   readonly pricings: ReadonlyArray<ReservationUnitPricingNode>;
   readonly publishBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly publishEnds: Maybe<Scalars["DateTime"]["output"]>;
-  readonly publishingState: Maybe<ReservationUnitPublishingState>;
+  readonly publishingState: ReservationUnitPublishingState;
   readonly purposes: ReadonlyArray<PurposeNode>;
   readonly qualifiers: ReadonlyArray<QualifierNode>;
   readonly rank: Scalars["Int"]["output"];
   readonly requireAdultReservee: Scalars["Boolean"]["output"];
   readonly requireReservationHandling: Scalars["Boolean"]["output"];
-  readonly reservableTimeSpans: Maybe<
-    ReadonlyArray<Maybe<ReservableTimeSpanType>>
-  >;
+  readonly reservableTimeSpans: Maybe<ReadonlyArray<ReservableTimeSpanType>>;
   readonly reservationBegins: Maybe<Scalars["DateTime"]["output"]>;
   readonly reservationBlockWholeDay: Scalars["Boolean"]["output"];
   readonly reservationCancelledInstructions: Scalars["String"]["output"];
@@ -4185,7 +4174,7 @@ export type ReservationUnitNode = Node & {
   readonly reservationPendingInstructionsFi: Maybe<Scalars["String"]["output"]>;
   readonly reservationPendingInstructionsSv: Maybe<Scalars["String"]["output"]>;
   readonly reservationStartInterval: ReservationStartInterval;
-  readonly reservationState: Maybe<ReservationUnitReservationState>;
+  readonly reservationState: ReservationUnitReservationState;
   readonly reservationUnitType: Maybe<ReservationUnitTypeNode>;
   readonly reservations: Maybe<ReadonlyArray<ReservationNode>>;
   readonly reservationsMaxDaysBefore: Maybe<Scalars["Int"]["output"]>;
@@ -4240,8 +4229,8 @@ export type ReservationUnitNodeEquipmentsArgs = {
   name_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
   orderBy?: InputMaybe<ReadonlyArray<InputMaybe<EquipmentOrderingChoices>>>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type ReservationUnitNodePurposesArgs = {
@@ -4446,11 +4435,11 @@ export type ReservationUnitPaymentTypeNode = Node & {
 export type ReservationUnitPricingNode = Node & {
   readonly begins: Scalars["Date"]["output"];
   readonly highestPrice: Scalars["Decimal"]["output"];
-  readonly highestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly highestPriceNet: Scalars["Decimal"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly lowestPrice: Scalars["Decimal"]["output"];
-  readonly lowestPriceNet: Maybe<Scalars["Decimal"]["output"]>;
+  readonly lowestPriceNet: Scalars["Decimal"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
   readonly priceUnit: PriceUnit;
   readonly taxPercentage: TaxPercentageNode;
@@ -4865,7 +4854,7 @@ export enum ResourceLocationType {
 export type ResourceNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly locationType: Maybe<ResourceLocationType>;
+  readonly locationType: ResourceLocationType;
   readonly name: Scalars["String"]["output"];
   readonly nameEn: Maybe<Scalars["String"]["output"]>;
   readonly nameFi: Maybe<Scalars["String"]["output"]>;
@@ -5100,7 +5089,7 @@ export type SuitableTimeRangeNode = Node & {
   readonly beginTime: Scalars["Time"]["output"];
   readonly dayOfTheWeek: Weekday;
   readonly endTime: Scalars["Time"]["output"];
-  readonly fulfilled: Maybe<Scalars["Boolean"]["output"]>;
+  readonly fulfilled: Scalars["Boolean"]["output"];
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
@@ -5315,10 +5304,10 @@ export type UnitNodeReservationUnitsArgs = {
   equipments?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   isDraft?: InputMaybe<Scalars["Boolean"]["input"]>;
   isVisible?: InputMaybe<Scalars["Boolean"]["input"]>;
-  maxPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  maxPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  minPersonsLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  maxPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  maxPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsGte?: InputMaybe<Scalars["Int"]["input"]>;
+  minPersonsLte?: InputMaybe<Scalars["Int"]["input"]>;
   nameEn?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Icontains?: InputMaybe<Scalars["String"]["input"]>;
   nameEn_Istartswith?: InputMaybe<Scalars["String"]["input"]>;
@@ -5332,18 +5321,18 @@ export type UnitNodeReservationUnitsArgs = {
   orderBy?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitOrderingChoices>>
   >;
-  personsAllowed?: InputMaybe<Scalars["Decimal"]["input"]>;
+  personsAllowed?: InputMaybe<Scalars["Int"]["input"]>;
   pk?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   publishingState?: InputMaybe<
     ReadonlyArray<InputMaybe<ReservationUnitPublishingState>>
   >;
   purposes?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   qualifiers?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
-  rankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  rankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  rankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  rankLte?: InputMaybe<Scalars["Int"]["input"]>;
   reservableDateEnd?: InputMaybe<Scalars["Date"]["input"]>;
   reservableDateStart?: InputMaybe<Scalars["Date"]["input"]>;
-  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Decimal"]["input"]>;
+  reservableMinimumDurationMinutes?: InputMaybe<Scalars["Int"]["input"]>;
   reservableTimeEnd?: InputMaybe<Scalars["Time"]["input"]>;
   reservableTimeStart?: InputMaybe<Scalars["Time"]["input"]>;
   reservationKind?: InputMaybe<Scalars["String"]["input"]>;
@@ -5354,13 +5343,13 @@ export type UnitNodeReservationUnitsArgs = {
     ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>
   >;
   showOnlyReservable?: InputMaybe<Scalars["Boolean"]["input"]>;
-  surfaceAreaGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  surfaceAreaLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  surfaceAreaGte?: InputMaybe<Scalars["Int"]["input"]>;
+  surfaceAreaLte?: InputMaybe<Scalars["Int"]["input"]>;
   textSearch?: InputMaybe<Scalars["String"]["input"]>;
   tprekDepartmentId?: InputMaybe<Scalars["String"]["input"]>;
   tprekId?: InputMaybe<Scalars["String"]["input"]>;
-  typeRankGte?: InputMaybe<Scalars["Decimal"]["input"]>;
-  typeRankLte?: InputMaybe<Scalars["Decimal"]["input"]>;
+  typeRankGte?: InputMaybe<Scalars["Int"]["input"]>;
+  typeRankLte?: InputMaybe<Scalars["Int"]["input"]>;
   unit?: InputMaybe<ReadonlyArray<InputMaybe<Scalars["Int"]["input"]>>>;
   uuid?: InputMaybe<Scalars["UUID"]["input"]>;
 };
@@ -5426,7 +5415,7 @@ export type UnitRoleNode = Node & {
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
   readonly modified: Scalars["DateTime"]["output"];
-  readonly permissions: Maybe<ReadonlyArray<Maybe<UserPermissionChoice>>>;
+  readonly permissions: ReadonlyArray<UserPermissionChoice>;
   readonly role: UserRoleChoice;
   readonly unitGroups: ReadonlyArray<UnitGroupNode>;
   readonly units: ReadonlyArray<UnitNode>;
@@ -5639,14 +5628,14 @@ export type UserNode = Node & {
   readonly generalRoles: ReadonlyArray<GeneralRoleNode>;
   /** The ID of the object */
   readonly id: Scalars["ID"]["output"];
-  readonly isAdAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
-  readonly isStronglyAuthenticated: Maybe<Scalars["Boolean"]["output"]>;
+  readonly isAdAuthenticated: Scalars["Boolean"]["output"];
+  readonly isStronglyAuthenticated: Scalars["Boolean"]["output"];
   /** Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella. */
   readonly isSuperuser: Scalars["Boolean"]["output"];
   readonly lastName: Scalars["String"]["output"];
-  readonly name: Maybe<Scalars["String"]["output"]>;
+  readonly name: Scalars["String"]["output"];
   readonly pk: Maybe<Scalars["Int"]["output"]>;
-  readonly reservationNotification: Maybe<Scalars["String"]["output"]>;
+  readonly reservationNotification: Maybe<ReservationNotification>;
   readonly unitRoles: ReadonlyArray<UnitRoleNode>;
   /** Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja. */
   readonly username: Scalars["String"]["output"];
@@ -5768,7 +5757,7 @@ export type ApplicationSectionCommonFragment = {
   readonly id: string;
   readonly pk: number | null;
   readonly name: string;
-  readonly status: ApplicationSectionStatusChoice | null;
+  readonly status: ApplicationSectionStatusChoice;
   readonly reservationMaxDuration: number;
   readonly numPersons: number;
   readonly reservationsEndDate: string;

--- a/tilavaraus.graphql
+++ b/tilavaraus.graphql
@@ -221,16 +221,16 @@ type ApplicantNode implements Node {
   The ID of the object
   """
   id: ID!
-  isAdAuthenticated: Boolean
-  isStronglyAuthenticated: Boolean
+  isAdAuthenticated: Boolean!
+  isStronglyAuthenticated: Boolean!
   """
   Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella.
   """
   isSuperuser: Boolean!
   lastName: String!
-  name: String
+  name: String!
   pk: Int
-  reservationNotification: String
+  reservationNotification: ReservationNotification
   unitRoles: [UnitRoleNode!]!
   """
   Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja.
@@ -328,7 +328,7 @@ type ApplicationNode implements Node {
   organisation: OrganisationNode
   pk: Int
   sentDate: DateTime
-  status: ApplicationStatusChoice
+  status: ApplicationStatusChoice!
   user: ApplicantNode
   workingMemo: String!
 }
@@ -384,7 +384,7 @@ enum ApplicationOrderingChoices {
 type ApplicationRoundNode implements Node {
   applicationPeriodBegin: DateTime!
   applicationPeriodEnd: DateTime!
-  applicationsCount: Int
+  applicationsCount: Int!
   criteria: String!
   criteriaEn: String
   criteriaFi: String
@@ -394,7 +394,7 @@ type ApplicationRoundNode implements Node {
   The ID of the object
   """
   id: ID!
-  isSettingHandledAllowed: Boolean
+  isSettingHandledAllowed: Boolean!
   name: String!
   nameEn: String
   nameFi: String
@@ -416,10 +416,10 @@ type ApplicationRoundNode implements Node {
     orderBy: [ReservationPurposeOrderingChoices]
     pk: [Int]
   ): [ReservationPurposeNode!]!
-  reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice
+  reservationCreationStatus: ApplicationRoundReservationCreationStatusChoice!
   reservationPeriodBegin: Date!
   reservationPeriodEnd: Date!
-  reservationUnitCount: Int
+  reservationUnitCount: Int!
   reservationUnits(
     accessType: [AccessType]
     accessTypeBeginDate: Date
@@ -435,10 +435,10 @@ type ApplicationRoundNode implements Node {
     equipments: [Int]
     isDraft: Boolean
     isVisible: Boolean
-    maxPersonsGte: Decimal
-    maxPersonsLte: Decimal
-    minPersonsGte: Decimal
-    minPersonsLte: Decimal
+    maxPersonsGte: Int
+    maxPersonsLte: Int
+    minPersonsGte: Int
+    minPersonsLte: Int
     nameEn: String
     nameEn_Icontains: String
     nameEn_Istartswith: String
@@ -453,34 +453,34 @@ type ApplicationRoundNode implements Node {
     Järjestä
     """
     orderBy: [ReservationUnitOrderingChoices]
-    personsAllowed: Decimal
+    personsAllowed: Int
     pk: [Int]
     publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
     reservableDateEnd: Date
     reservableDateStart: Date
-    reservableMinimumDurationMinutes: Decimal
+    reservableMinimumDurationMinutes: Int
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
     reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    surfaceAreaGte: Decimal
-    surfaceAreaLte: Decimal
+    surfaceAreaGte: Int
+    surfaceAreaLte: Int
     textSearch: String
     tprekDepartmentId: String
     tprekId: String
-    typeRankGte: Decimal
-    typeRankLte: Decimal
+    typeRankGte: Int
+    typeRankLte: Int
     unit: [Int]
     uuid: UUID
   ): [ReservationUnitNode!]!
   sentDate: DateTime
-  status: ApplicationRoundStatusChoice
+  status: ApplicationRoundStatusChoice!
   statusTimestamp: DateTime
   termsOfUse: TermsOfUseNode
 }
@@ -546,7 +546,7 @@ type ApplicationRoundTimeSlotNode implements Node {
   """
   id: ID!
   pk: Int
-  reservableTimes: [TimeSlotType]
+  reservableTimes: [TimeSlotType]!
   weekday: Int!
 }
 
@@ -613,7 +613,7 @@ input ApplicationSectionForApplicationSerializerInput {
 
 type ApplicationSectionNode implements Node {
   ageGroup: AgeGroupNode
-  allocations: Int
+  allocations: Int!
   application: ApplicationNode!
   appliedReservationsPerWeek: Int!
   extUuid: UUID!
@@ -643,8 +643,8 @@ type ApplicationSectionNode implements Node {
   ): [ReservationUnitOptionNode!]!
   reservationsBeginDate: Date!
   reservationsEndDate: Date!
-  shouldHaveActiveAccessCode: Boolean
-  status: ApplicationSectionStatusChoice
+  shouldHaveActiveAccessCode: Boolean!
+  status: ApplicationSectionStatusChoice!
   suitableTimeRanges(
     fulfilled: Boolean
     """
@@ -906,7 +906,7 @@ type BannerNotificationNode implements Node {
   messageSv: String
   name: String!
   pk: Int
-  state: BannerNotificationState
+  state: BannerNotificationState!
   target: BannerNotificationTarget!
 }
 
@@ -1300,7 +1300,7 @@ type GeneralRoleNode implements Node {
   """
   id: ID!
   modified: DateTime!
-  permissions: [UserPermissionChoice]
+  permissions: [UserPermissionChoice!]!
   role: UserRoleChoice!
   user: UserNode!
 }
@@ -1312,7 +1312,7 @@ type HelsinkiProfileDataNode {
   firstName: String
   isStrongLogin: Boolean!
   lastName: String
-  loginMethod: LoginMethod
+  loginMethod: LoginMethod!
   municipalityCode: String
   municipalityName: String
   phone: String
@@ -1712,7 +1712,7 @@ type PaymentMerchantNode implements Node {
   """
   id: ID!
   name: String!
-  pk: UUID
+  pk: UUID!
 }
 
 type PaymentOrderNode implements Node {
@@ -1728,7 +1728,7 @@ type PaymentOrderNode implements Node {
   receiptUrl: String
   refundUuid: UUID
   reservationPk: String
-  status: OrderStatus
+  status: OrderStatus!
 }
 
 type PaymentProductNode implements Node {
@@ -1737,7 +1737,7 @@ type PaymentProductNode implements Node {
   """
   id: ID!
   merchant: PaymentMerchantNode
-  pk: UUID
+  pk: UUID!
 }
 
 """
@@ -1793,7 +1793,7 @@ type PindoraSectionInfoType {
   accessCodePhoneNumber: String!
   accessCodeSmsMessage: String!
   accessCodeSmsNumber: String!
-  accessCodeValidity: [PindoraSectionValidityInfoType]!
+  accessCodeValidity: [PindoraSectionValidityInfoType!]!
 }
 
 type PindoraSectionValidityInfoType {
@@ -2255,8 +2255,8 @@ type Query {
     """
     orderBy: [EquipmentOrderingChoices]
     pk: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
   ): EquipmentNodeConnection
   equipmentsAll(
     """
@@ -2475,10 +2475,10 @@ type Query {
     isDraft: Boolean
     isVisible: Boolean
     last: Int
-    maxPersonsGte: Decimal
-    maxPersonsLte: Decimal
-    minPersonsGte: Decimal
-    minPersonsLte: Decimal
+    maxPersonsGte: Int
+    maxPersonsLte: Int
+    minPersonsGte: Int
+    minPersonsLte: Int
     nameEn: String
     nameEn_Icontains: String
     nameEn_Istartswith: String
@@ -2494,29 +2494,29 @@ type Query {
     Järjestä
     """
     orderBy: [ReservationUnitOrderingChoices]
-    personsAllowed: Decimal
+    personsAllowed: Int
     pk: [Int]
     publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
     reservableDateEnd: Date
     reservableDateStart: Date
-    reservableMinimumDurationMinutes: Decimal
+    reservableMinimumDurationMinutes: Int
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
     reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    surfaceAreaGte: Decimal
-    surfaceAreaLte: Decimal
+    surfaceAreaGte: Int
+    surfaceAreaLte: Int
     textSearch: String
     tprekDepartmentId: String
     tprekId: String
-    typeRankGte: Decimal
-    typeRankLte: Decimal
+    typeRankGte: Int
+    typeRankLte: Int
     unit: [Int]
     uuid: UUID
   ): ReservationUnitNodeConnection
@@ -2725,7 +2725,7 @@ type Query {
 
 type RecurringReservationNode implements Node {
   abilityGroup: AbilityGroupNode
-  accessType: AccessTypeWithMultivalued
+  accessType: AccessTypeWithMultivalued!
   ageGroup: AgeGroupNode
   allocatedTimeSlot: AllocatedTimeSlotNode
   beginDate: Date
@@ -2739,7 +2739,7 @@ type RecurringReservationNode implements Node {
   The ID of the object
   """
   id: ID!
-  isAccessCodeIsActiveCorrect: Boolean
+  isAccessCodeIsActiveCorrect: Boolean!
   name: String!
   """
   Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple series, queries to Pindora are not optimized.
@@ -2791,10 +2791,10 @@ type RecurringReservationNode implements Node {
     unit: [Int]
     user: [Int]
   ): [ReservationNode!]!
-  shouldHaveActiveAccessCode: Boolean
-  usedAccessTypes: [AccessType]
+  shouldHaveActiveAccessCode: Boolean!
+  usedAccessTypes: [AccessType]!
   user: UserNode
-  weekdays: [Int]
+  weekdays: [Int!]!
 }
 
 type RecurringReservationNodeConnection {
@@ -3231,7 +3231,7 @@ type ReservationNode implements Node {
   """
   Which reservation units' reserveability is affected by this reservation?
   """
-  affectedReservationUnits: [Int]
+  affectedReservationUnits: [Int]!
   ageGroup: AgeGroupNode
   applyingForFreeOfCharge: Boolean
   begin: DateTime!
@@ -3244,7 +3244,7 @@ type ReservationNode implements Node {
   billingPhone: String
   bufferTimeAfter: Duration!
   bufferTimeBefore: Duration!
-  calendarUrl: String
+  calendarUrl: String!
   cancelDetails: String
   cancelReason: ReservationCancelReasonNode
   createdAt: DateTime
@@ -3260,13 +3260,11 @@ type ReservationNode implements Node {
   The ID of the object
   """
   id: ID!
-  isAccessCodeIsActiveCorrect: Boolean
-  isBlocked: Boolean
+  isAccessCodeIsActiveCorrect: Boolean!
+  isBlocked: Boolean!
   isHandled: Boolean
   name: String
   numPersons: Int
-  order: PaymentOrderNode
-    @deprecated(reason: "Please use to 'paymentOrder' instead.")
   paymentOrder: [PaymentOrderNode!]!
   """
   Info fetched from Pindora API. Cached per reservation for 30s. Please don't use this when filtering multiple reservations, queries to Pindora are not optimized.
@@ -3292,10 +3290,10 @@ type ReservationNode implements Node {
     equipments: [Int]
     isDraft: Boolean
     isVisible: Boolean
-    maxPersonsGte: Decimal
-    maxPersonsLte: Decimal
-    minPersonsGte: Decimal
-    minPersonsLte: Decimal
+    maxPersonsGte: Int
+    maxPersonsLte: Int
+    minPersonsGte: Int
+    minPersonsLte: Int
     nameEn: String
     nameEn_Icontains: String
     nameEn_Istartswith: String
@@ -3310,29 +3308,29 @@ type ReservationNode implements Node {
     Järjestä
     """
     orderBy: [ReservationUnitOrderingChoices]
-    personsAllowed: Decimal
+    personsAllowed: Int
     pk: [Int]
     publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
     reservableDateEnd: Date
     reservableDateStart: Date
-    reservableMinimumDurationMinutes: Decimal
+    reservableMinimumDurationMinutes: Int
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
     reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    surfaceAreaGte: Decimal
-    surfaceAreaLte: Decimal
+    surfaceAreaGte: Int
+    surfaceAreaLte: Int
     textSearch: String
     tprekDepartmentId: String
     tprekId: String
-    typeRankGte: Decimal
-    typeRankLte: Decimal
+    typeRankGte: Int
+    typeRankLte: Int
     unit: [Int]
     uuid: UUID
   ): [ReservationUnitNode!]!
@@ -3348,7 +3346,6 @@ type ReservationNode implements Node {
   reserveeOrganisationName: String
   reserveePhone: String
   reserveeType: CustomerTypeChoice
-  staffEvent: Boolean @deprecated(reason: "Please use to 'type' instead.")
   state: ReservationStateChoice
   taxPercentageValue: Decimal
   type: ReservationTypeChoice
@@ -3384,20 +3381,11 @@ type ReservationNodeEdge {
 }
 
 """
-An enumeration.
+When user wants to receive reservation notification emails.
 """
 enum ReservationNotification {
-  """
-  All
-  """
   ALL
-  """
-  None
-  """
   NONE
-  """
-  Only Handling Required
-  """
   ONLY_HANDLING_REQUIRED
 }
 
@@ -4244,7 +4232,7 @@ type ReservationUnitNode implements Node {
   authentication: Authentication!
   bufferTimeAfter: Duration!
   bufferTimeBefore: Duration!
-  calculatedSurfaceArea: Int
+  calculatedSurfaceArea: Int!
   canApplyFreeOfCharge: Boolean!
   cancellationRule: ReservationUnitCancellationRuleNode
   cancellationTerms: TermsOfUseNode
@@ -4273,8 +4261,8 @@ type ReservationUnitNode implements Node {
     """
     orderBy: [EquipmentOrderingChoices]
     pk: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
   ): [EquipmentNode!]!
   firstReservableDatetime: DateTime
   haukiUrl: String
@@ -4284,7 +4272,7 @@ type ReservationUnitNode implements Node {
   id: ID!
   images: [ReservationUnitImageNode!]!
   isArchived: Boolean!
-  isClosed: Boolean
+  isClosed: Boolean!
   isDraft: Boolean!
   location: LocationNode
   maxPersons: Int
@@ -4297,7 +4285,7 @@ type ReservationUnitNode implements Node {
   nameEn: String
   nameFi: String
   nameSv: String
-  numActiveUserReservations: Int
+  numActiveUserReservations: Int!
   paymentMerchant: PaymentMerchantNode
   paymentProduct: PaymentProductNode
   paymentTerms: TermsOfUseNode
@@ -4307,7 +4295,7 @@ type ReservationUnitNode implements Node {
   pricings: [ReservationUnitPricingNode!]!
   publishBegins: DateTime
   publishEnds: DateTime
-  publishingState: ReservationUnitPublishingState
+  publishingState: ReservationUnitPublishingState!
   purposes(
     nameEn: String
     nameFi: String
@@ -4334,7 +4322,7 @@ type ReservationUnitNode implements Node {
   reservableTimeSpans(
     endDate: Date!
     startDate: Date!
-  ): [ReservableTimeSpanType]
+  ): [ReservableTimeSpanType!]
   reservationBegins: DateTime
   reservationBlockWholeDay: Boolean!
   reservationCancelledInstructions: String!
@@ -4352,7 +4340,7 @@ type ReservationUnitNode implements Node {
   reservationPendingInstructionsFi: String
   reservationPendingInstructionsSv: String
   reservationStartInterval: ReservationStartInterval!
-  reservationState: ReservationUnitReservationState
+  reservationState: ReservationUnitReservationState!
   reservationUnitType: ReservationUnitTypeNode
   reservations(
     applyingForFreeOfCharge: Boolean
@@ -4557,13 +4545,13 @@ type ReservationUnitPaymentTypeNode implements Node {
 type ReservationUnitPricingNode implements Node {
   begins: Date!
   highestPrice: Decimal!
-  highestPriceNet: Decimal
+  highestPriceNet: Decimal!
   """
   The ID of the object
   """
   id: ID!
   lowestPrice: Decimal!
-  lowestPriceNet: Decimal
+  lowestPriceNet: Decimal!
   pk: Int
   priceUnit: PriceUnit!
   taxPercentage: TaxPercentageNode!
@@ -4934,7 +4922,7 @@ type ResourceNode implements Node {
   The ID of the object
   """
   id: ID!
-  locationType: ResourceLocationType
+  locationType: ResourceLocationType!
   name: String!
   nameEn: String
   nameFi: String
@@ -5213,7 +5201,7 @@ type SuitableTimeRangeNode implements Node {
   beginTime: Time!
   dayOfTheWeek: Weekday!
   endTime: Time!
-  fulfilled: Boolean
+  fulfilled: Boolean!
   """
   The ID of the object
   """
@@ -5491,10 +5479,10 @@ type UnitNode implements Node {
     equipments: [Int]
     isDraft: Boolean
     isVisible: Boolean
-    maxPersonsGte: Decimal
-    maxPersonsLte: Decimal
-    minPersonsGte: Decimal
-    minPersonsLte: Decimal
+    maxPersonsGte: Int
+    maxPersonsLte: Int
+    minPersonsGte: Int
+    minPersonsLte: Int
     nameEn: String
     nameEn_Icontains: String
     nameEn_Istartswith: String
@@ -5509,29 +5497,29 @@ type UnitNode implements Node {
     Järjestä
     """
     orderBy: [ReservationUnitOrderingChoices]
-    personsAllowed: Decimal
+    personsAllowed: Int
     pk: [Int]
     publishingState: [ReservationUnitPublishingState]
     purposes: [Int]
     qualifiers: [Int]
-    rankGte: Decimal
-    rankLte: Decimal
+    rankGte: Int
+    rankLte: Int
     reservableDateEnd: Date
     reservableDateStart: Date
-    reservableMinimumDurationMinutes: Decimal
+    reservableMinimumDurationMinutes: Int
     reservableTimeEnd: Time
     reservableTimeStart: Time
     reservationKind: String
     reservationState: [ReservationUnitReservationState]
     reservationUnitType: [Int]
     showOnlyReservable: Boolean
-    surfaceAreaGte: Decimal
-    surfaceAreaLte: Decimal
+    surfaceAreaGte: Int
+    surfaceAreaLte: Int
     textSearch: String
     tprekDepartmentId: String
     tprekId: String
-    typeRankGte: Decimal
-    typeRankLte: Decimal
+    typeRankGte: Int
+    typeRankLte: Int
     unit: [Int]
     uuid: UUID
   ): [ReservationUnitNode!]!
@@ -5621,7 +5609,7 @@ type UnitRoleNode implements Node {
   """
   id: ID!
   modified: DateTime!
-  permissions: [UserPermissionChoice]
+  permissions: [UserPermissionChoice!]!
   role: UserRoleChoice!
   unitGroups: [UnitGroupNode!]!
   units(
@@ -5832,16 +5820,16 @@ type UserNode implements Node {
   The ID of the object
   """
   id: ID!
-  isAdAuthenticated: Boolean
-  isStronglyAuthenticated: Boolean
+  isAdAuthenticated: Boolean!
+  isStronglyAuthenticated: Boolean!
   """
   Antaa käyttäjälle kaikki oikeudet ilman, että niitä täytyy erikseen luetella.
   """
   isSuperuser: Boolean!
   lastName: String!
-  name: String
+  name: String!
   pk: Int
-  reservationNotification: String
+  reservationNotification: ReservationNotification
   unitRoles: [UnitRoleNode!]!
   """
   Vaaditaan. Enintään 150 merkkiä. Vain kirjaimet, numerot ja @/./+/-/_ ovat sallittuja.


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes various fields' types to be non-null when they were mistakenly typed as nullable.
- Removes a few deprecated fields (`reservation.order` and `reservation.staff_event`)
- Make `user.reservation_notification` an enum in the GraphQL type
- Change `NumberFilters` to `IntChoiceFilters` to change type in GraphQL to Int from Decimal

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- Fronend must adjust to new schema

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3921](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3921)


[TILA-3921]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3921?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ