### PR TITLE
Don't include access codes in emails if it is not actually active

### DIFF
--- a/backend/tests/test_graphql_api/test_reservation/test_adjust_time.py
+++ b/backend/tests/test_graphql_api/test_reservation/test_adjust_time.py
@@ -10,7 +10,7 @@ from django.test import override_settings
 from tilavarauspalvelu.enums import AccessType, ReservationStartInterval, ReservationStateChoice
 from tilavarauspalvelu.integrations.email.main import EmailService
 from tilavarauspalvelu.integrations.keyless_entry import PindoraClient, PindoraService
-from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError
+from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraAPIError, PindoraNotFoundError
 from tilavarauspalvelu.models import Reservation, ReservationUnitHierarchy
 from utils.date_utils import DEFAULT_TIMEZONE, local_date, local_datetime
 
@@ -505,7 +505,7 @@ def test_reservation__adjust_time__update_reservation_buffer_on_adjust(graphql):
     assert reservation.buffer_time_after == datetime.timedelta(hours=2)
 
 
-@patch_method(PindoraClient.get_reservation)  # Called by email sending
+@patch_method(PindoraClient.get_reservation, side_effect=PindoraNotFoundError("Not found"))  # Called by email sending
 @patch_method(PindoraService.sync_access_code)
 def test_reservation__adjust_time__same_access_type(graphql):
     reservation = ReservationFactory.create_for_time_adjustment(
@@ -546,7 +546,7 @@ def test_reservation__adjust_time__same_access_type__requires_handling(graphql):
     assert PindoraService.sync_access_code.call_count == 1
 
 
-@patch_method(PindoraClient.get_reservation)  # Called by email sending
+@patch_method(PindoraClient.get_reservation, side_effect=PindoraNotFoundError("Not found"))  # Called by email sending
 @patch_method(PindoraService.sync_access_code)
 def test_reservation__adjust_time__change_to_access_code(graphql):
     reservation = ReservationFactory.create_for_time_adjustment(

--- a/backend/tests/test_integrations/test_email/helpers.py
+++ b/backend/tests/test_integrations/test_email/helpers.py
@@ -203,6 +203,12 @@ KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT = {
     "access_code": "123456",
     "access_code_validity_period": "11:00-15:00",
 }
+KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT = {
+    "access_code_is_used": False,
+    "access_code": "",
+    "access_code_validity_period": "",
+}
+
 
 KEYLESS_ENTRY_CONTEXT_EN = {
     "access_code_is_used": False,

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_approved.py
@@ -31,6 +31,7 @@ from tests.test_integrations.test_email.helpers import (
     EMAIL_CLOSING_TEXT_EN,
     EMAIL_LOGO_HTML,
     KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
+    KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
     KEYLESS_ENTRY_CONTEXT_EN,
     KEYLESS_ENTRY_CONTEXT_FI,
     KEYLESS_ENTRY_CONTEXT_SV,
@@ -151,6 +152,7 @@ def test_get_context__reservation_approved__instance(email_reservation):
     PindoraClient.get_reservation,
     return_value=PindoraReservationResponse(
         access_code="123456",
+        access_code_is_active=True,
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
         access_code_valid_minutes_before=0,
@@ -169,6 +171,41 @@ def test_get_context__reservation_approved__access_code(email_reservation):
     params = {
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         "reservation_id": email_reservation.id,
+    }
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_approved(**get_mock_params(**params, language="en")) == expected
+
+    email_reservation.access_type = AccessType.ACCESS_CODE
+    email_reservation.save()
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_approved(reservation=email_reservation, language="en") == expected
+
+
+@patch_method(
+    PindoraClient.get_reservation,
+    return_value=PindoraReservationResponse(
+        access_code="123456",
+        access_code_is_active=False,
+        begin=datetime.datetime(2024, 1, 1, 11),
+        end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
+    ),
+)
+@pytest.mark.django_db
+@freeze_time("2024-01-01 12:00:00+02:00")
+def test_get_context__reservation_approved__access_code__inactive(email_reservation):
+    expected = {
+        **LANGUAGE_CONTEXT["en"],
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": f"{email_reservation.id}",
+        "access_code_is_used": True,
+    }
+
+    params = {
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": email_reservation.id,
+        "access_code_is_used": True,
     }
     with TranslationsFromPOFiles():
         assert get_context_for_reservation_approved(**get_mock_params(**params, language="en")) == expected

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_confirmed.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_confirmed.py
@@ -30,6 +30,7 @@ from tests.test_integrations.test_email.helpers import (
     EMAIL_CLOSING_TEXT_EN,
     EMAIL_LOGO_HTML,
     KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
+    KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
     KEYLESS_ENTRY_CONTEXT_EN,
     KEYLESS_ENTRY_CONTEXT_FI,
     KEYLESS_ENTRY_CONTEXT_SV,
@@ -125,6 +126,7 @@ def test_get_context__reservation_confirmed__instance(email_reservation):
     PindoraClient.get_reservation,
     return_value=PindoraReservationResponse(
         access_code="123456",
+        access_code_is_active=True,
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
         access_code_valid_minutes_before=0,
@@ -143,6 +145,41 @@ def test_get_context__reservation_confirmed__access_code(email_reservation):
     params = {
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         "reservation_id": email_reservation.id,
+    }
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_confirmed(**get_mock_params(**params, language="en")) == expected
+
+    email_reservation.access_type = AccessType.ACCESS_CODE
+    email_reservation.save()
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_confirmed(reservation=email_reservation, language="en") == expected
+
+
+@patch_method(
+    PindoraClient.get_reservation,
+    return_value=PindoraReservationResponse(
+        access_code="123456",
+        access_code_is_active=False,
+        begin=datetime.datetime(2024, 1, 1, 11),
+        end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
+    ),
+)
+@pytest.mark.django_db
+@freeze_time("2024-01-01 12:00:00+02:00")
+def test_get_context__reservation_confirmed__access_code__inactive(email_reservation):
+    expected = {
+        **LANGUAGE_CONTEXT["en"],
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": f"{email_reservation.id}",
+        "access_code_is_used": True,
+    }
+
+    params = {
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": email_reservation.id,
+        "access_code_is_used": True,
     }
     with TranslationsFromPOFiles():
         assert get_context_for_reservation_confirmed(**get_mock_params(**params, language="en")) == expected

--- a/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_reservation_modified.py
@@ -30,6 +30,7 @@ from tests.test_integrations.test_email.helpers import (
     EMAIL_CLOSING_TEXT_EN,
     EMAIL_LOGO_HTML,
     KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
+    KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
     KEYLESS_ENTRY_CONTEXT_EN,
     KEYLESS_ENTRY_CONTEXT_FI,
     KEYLESS_ENTRY_CONTEXT_SV,
@@ -125,6 +126,7 @@ def test_get_context__reservation_modified_instance(email_reservation):
     PindoraClient.get_reservation,
     return_value=PindoraReservationResponse(
         access_code="123456",
+        access_code_is_active=True,
         begin=datetime.datetime(2024, 1, 1, 11),
         end=datetime.datetime(2024, 1, 1, 15),
         access_code_valid_minutes_before=0,
@@ -143,6 +145,41 @@ def test_get_context__reservation_modified__access_code(email_reservation):
     params = {
         **KEYLESS_ENTRY_ACCESS_CODE_IS_USED_CONTEXT,
         "reservation_id": email_reservation.id,
+    }
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_modified(**get_mock_params(**params, language="en")) == expected
+
+    email_reservation.access_type = AccessType.ACCESS_CODE
+    email_reservation.save()
+    with TranslationsFromPOFiles():
+        assert get_context_for_reservation_modified(reservation=email_reservation, language="en") == expected
+
+
+@patch_method(
+    PindoraClient.get_reservation,
+    return_value=PindoraReservationResponse(
+        access_code="123456",
+        access_code_is_active=False,
+        begin=datetime.datetime(2024, 1, 1, 11),
+        end=datetime.datetime(2024, 1, 1, 15),
+        access_code_valid_minutes_before=0,
+        access_code_valid_minutes_after=0,
+    ),
+)
+@pytest.mark.django_db
+@freeze_time("2024-01-01 12:00:00+02:00")
+def test_get_context__reservation_modified__access_code__inactive(email_reservation):
+    expected = {
+        **LANGUAGE_CONTEXT["en"],
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": f"{email_reservation.id}",
+        "access_code_is_used": True,
+    }
+
+    params = {
+        **KEYLESS_ENTRY_ACCESS_CODE_NOT_USED_CONTEXT,
+        "reservation_id": email_reservation.id,
+        "access_code_is_used": True,
     }
     with TranslationsFromPOFiles():
         assert get_context_for_reservation_modified(**get_mock_params(**params, language="en")) == expected

--- a/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series_access_code.py
+++ b/backend/tests/test_integrations/test_email/test_email_types/test_seasonal_reservation_modified_series_access_code.py
@@ -140,6 +140,7 @@ def test_get_context_for_seasonal_reservation_modified_series_access_codes__inst
 
     PindoraClient.get_seasonal_booking.return_value = PindoraSeasonalBookingResponse(
         access_code="123456",
+        access_code_is_active=True,
         reservation_unit_code_validity=[
             PindoraSeasonalBookingAccessCodeValidity(
                 reservation_unit_id=reservation_unit_1.uuid,
@@ -167,6 +168,72 @@ def test_get_context_for_seasonal_reservation_modified_series_access_codes__inst
         "application_id": section.application_id,
         "application_section_id": section.id,
         "access_code_is_used": True,
+        "language": "en",
+    }
+    with TranslationsFromPOFiles():
+        context = get_context_for_seasonal_reservation_modified_series_access_code(**get_mock_params(**params))
+        assert context == expected
+
+    with TranslationsFromPOFiles():
+        allocation = email_reservation.recurring_reservation.allocated_time_slot
+        section = allocation.reservation_unit_option.application_section
+        context = get_context_for_seasonal_reservation_modified_series_access_code(section, language="en")
+        assert context == expected
+
+
+@pytest.mark.django_db
+@freeze_time("2024-01-01 12:00:00+02:00")
+@patch_method(PindoraClient.get_seasonal_booking)
+def test_get_context_for_seasonal_reservation_modified_series_access_codes__instance__inactive(email_reservation):
+    section = email_reservation.actions.get_application_section()
+
+    section.actions.get_reservations().update(access_type=AccessType.ACCESS_CODE)
+
+    all_series = section.actions.get_reservation_series()
+    reservation_unit_1 = all_series[0].reservation_unit
+    reservation_unit_2 = all_series[1].reservation_unit
+
+    PindoraClient.get_seasonal_booking.return_value = PindoraSeasonalBookingResponse(
+        access_code="123456",
+        access_code_is_active=False,
+        reservation_unit_code_validity=[
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_1.uuid,
+                begin=datetime.datetime(2024, 1, 1, 11),
+                end=datetime.datetime(2024, 1, 1, 15),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+            PindoraSeasonalBookingAccessCodeValidity(
+                reservation_unit_id=reservation_unit_2.uuid,
+                begin=datetime.datetime(2024, 1, 2, 20, 45),
+                end=datetime.datetime(2024, 1, 2, 22, 5),
+                access_code_valid_minutes_before=0,
+                access_code_valid_minutes_after=0,
+            ),
+        ],
+    )
+
+    expected = {
+        **LANGUAGE_CONTEXT["en"],
+        **get_application_details_urls(section),
+        "access_code": "",
+        "access_code_is_used": True,
+        "allocations": [
+            {"weekday_value": "Monday", "time_value": "13:00-15:00", "access_code_validity_period": ""},
+            {"weekday_value": "Tuesday", "time_value": "21:00-22:00", "access_code_validity_period": ""},
+        ],
+    }
+
+    params = {
+        "application_id": section.application_id,
+        "application_section_id": section.id,
+        "access_code_is_used": True,
+        "access_code": "",
+        "allocations": [
+            {"weekday_value": "Monday", "time_value": "13:00-15:00", "access_code_validity_period": ""},
+            {"weekday_value": "Tuesday", "time_value": "21:00-22:00", "access_code_validity_period": ""},
+        ],
         "language": "en",
     }
     with TranslationsFromPOFiles():

--- a/backend/tilavarauspalvelu/admin/email_template/utils.py
+++ b/backend/tilavarauspalvelu/admin/email_template/utils.py
@@ -22,7 +22,7 @@ __all__ = [
 
 
 @get_translated
-def get_mock_params(language: Lang, **kwargs: Any) -> EmailContext | datetime | bool:
+def get_mock_params(*, language: Lang, **kwargs: Any) -> EmailContext | datetime | bool:
     """
     Return mock parameters that can be used for creating ANY email template context.
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- After fetching access code for emails, check if it is actually active in Pindora and don't include it if it isn't

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3938](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3938)


[TILA-3938]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ