### PR TITLE
Fix test query count variable

### DIFF
--- a/backend/tests/test_graphql_api/test_reservation_unit/test_query_first_reservable_time.py
+++ b/backend/tests/test_graphql_api/test_reservation_unit/test_query_first_reservable_time.py
@@ -2517,7 +2517,7 @@ def test__reservation_unit__first_reservable_time__remove_not_reservable(graphql
     assert is_closed(response) is False
 
     # Don't check queries in CI. Don't know why but some queries appear twice...
-    if os.getenv("DJANGO_SETTINGS_ENVIRONMENT") == "CI":
+    if os.getenv("CI") == "true":
         return
 
     # Check that we fetch reservation units in a big chunk which is then filtered


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- [`CI` env variable is always set to 'true' in GitHub Actions](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables). During testing, we always use the "AutomatedTests" environment. The `CI` environment is used for migration checks, etc.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
