### PR TITLE
fix: reporting codegen problems correctly

### DIFF
--- a/README-ui.md
+++ b/README-ui.md
@@ -13,8 +13,9 @@ Include a changelog if applicable.
 
 ## Prerequisites
 
-1. Node 18 (`nvm use`)
-1. pnpm
+1. Node 20 (`nvm use`)
+2. pnpm
+3. GNU parallel (for codegen without watch mode)
 
 ## Scripts
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "codegen:admin": "graphql-codegen --project admin-ui",
     "codegen:ui": "graphql-codegen --project ui",
     "codegen:common": "graphql-codegen --project common",
-    "codegen": "pnpm codegen:admin & pnpm codegen:ui & pnpm codegen:common",
+    "codegen": "parallel pnpm ::: codegen:admin codegen:ui codegen:common",
     "codegen:watch": "pnpm codegen:admin --watch & pnpm codegen:ui --watch & pnpm codegen:common --watch"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: `pnpm codegen` eating error reports occasionally. The actual error message disappears from stdout.
- Requires GNU parallel to run the codegen command outside of watch mode.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests: CI / Tooling change.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
