### PR TITLE
Prevent simultaneous overlapping reservation creation

### DIFF
--- a/backend/tilavarauspalvelu/api/graphql/types/reservation/serializers/requires_handling_serializers.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation/serializers/requires_handling_serializers.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
-from typing import Any, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from graphene_django_extensions import NestingModelSerializer
 from graphene_django_extensions.fields import EnumFriendlyChoiceField
+from rest_framework.exceptions import ValidationError
 from rest_framework.fields import IntegerField
 
+from tilavarauspalvelu.api.graphql.extensions import error_codes
 from tilavarauspalvelu.enums import AccessType, ReservationStateChoice
 from tilavarauspalvelu.integrations.email.main import EmailService
 from tilavarauspalvelu.integrations.keyless_entry import PindoraService
 from tilavarauspalvelu.integrations.sentry import SentryLogger
 from tilavarauspalvelu.models import Reservation
+from utils.date_utils import DEFAULT_TIMEZONE
 from utils.external_service.errors import ExternalServiceError
+
+if TYPE_CHECKING:
+    from tilavarauspalvelu.models import ReservationUnit
 
 __all__ = [
     "ReservationRequiresHandlingSerializer",
@@ -45,12 +51,34 @@ class ReservationRequiresHandlingSerializer(NestingModelSerializer):
         ]
 
     def validate(self, data: ReservationHandlingData) -> ReservationHandlingData:
+        begin = self.instance.begin.astimezone(DEFAULT_TIMEZONE)
+        end = self.instance.end.astimezone(DEFAULT_TIMEZONE)
+
+        if self.instance.state == ReservationStateChoice.DENIED:
+            reservation_unit: ReservationUnit = self.instance.reservation_units.first()
+            reservation_unit.validators.validate_no_overlapping_reservations(begin=begin, end=end)
+
         self.instance.validators.validate_reservation_state_allows_handling()
         data["state"] = ReservationStateChoice.REQUIRES_HANDLING
         return data
 
     def update(self, instance: Reservation, validated_data: dict[str, Any]) -> Reservation:
-        instance = super().update(instance=instance, validated_data=validated_data)
+        previous_state = instance.state
+
+        instance: Reservation = super().update(instance=instance, validated_data=validated_data)
+
+        # If in this mutation, the reservation was changed from 'DENIED' to 'REQUIRES_HANDLING',
+        # it means that the reservation is going to happen again. This is analogous to creating a new reservation,
+        # so we must check for overlapping reservations again. This can fail if another reservation
+        # is created (or "un-denied") for the same reservation unit at almost the same time.
+        if (
+            previous_state not in ReservationStateChoice.states_going_to_occur
+            and instance.actions.overlapping_reservations().exists()
+        ):
+            instance.state = previous_state
+            instance.save(update_fields=["state"])
+            msg = "Overlapping reservations were created at the same time."
+            raise ValidationError(msg, code=error_codes.OVERLAPPING_RESERVATIONS)
 
         # Denied reservations shouldn't have an access code. It will be regenerated if the reservation is approved.
         if instance.access_type == AccessType.ACCESS_CODE:

--- a/backend/tilavarauspalvelu/typing.py
+++ b/backend/tilavarauspalvelu/typing.py
@@ -231,7 +231,7 @@ class ReservationConfirmData(TypedDict):
 
 
 class ReservationAdjustTimeData(TypedDict):
-    pk: int
+    pk: NotRequired[int]
     begin: datetime.datetime
     end: datetime.datetime
 

--- a/backend/tilavarauspalvelu/typing.py
+++ b/backend/tilavarauspalvelu/typing.py
@@ -329,6 +329,16 @@ class StaffReservationData(StaffCreateReservationData):
     pk: int
 
 
+class StaffReservationAdjustTimeData(TypedDict):
+    pk: NotRequired[int]
+    begin: datetime.datetime
+    end: datetime.datetime
+
+    buffer_time_before: NotRequired[datetime.timedelta]
+    buffer_time_after: NotRequired[datetime.timedelta]
+    access_type: NotRequired[AccessType]
+
+
 class ReservationSeriesCreateData(TypedDict):
     pk: int
     user: User


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Make a second overlapping validation check during the endpoint, and remove the created reservation if an overlapping reservation is found
- Make second check also during staff create
- Also do overlapping checks during "return to handling" as this can change a "denied" (not going to happen) to "requires handling" (going to happen), which may make it overlap with newer reservations
- Also also do checks when rescheduling reservations

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3952](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3952)
- [TILA-3956](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3956)


[TILA-3952]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[TILA-3956]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ