### PR TITLE
Fix access type durations listing tooltip

### DIFF
--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -177,9 +177,9 @@ function AccessTypeTooltip({
               {": "}
             </span>
             <span>
-              {accessTypeDuration.endDate !== ""
+              {accessTypeDuration.endDate != null
                 ? `${accessTypeDuration.beginDate} – ${accessTypeDuration.endDate}`
-                : `${t("common:beginLabel")} ${accessTypeDuration.beginDate}`}
+                : `${t("common:dateGte", { value: accessTypeDuration.beginDate })}`}
             </span>
           </li>
         ))}

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -672,7 +672,8 @@ export function getReservationUnitAccessPeriods(
       const endDate = acc.nextEndDate
         ? toUIDate(sub(new Date(acc.nextEndDate), { days: 1 }))
         : null;
-      const accessTypeWithEndDate = { ...aT, endDate };
+      const beginDate = toUIDate(new Date(aT.beginDate));
+      const accessTypeWithEndDate = { ...aT, beginDate, endDate };
       acc.nextEndDate = aT.beginDate;
       acc.array.unshift(accessTypeWithEndDate);
       return { nextEndDate: acc.nextEndDate, array: acc.array };


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes the access type durations listing tooltip:
  - Fixes the begin date to be in proper UI date format
  - Fixes durations without end date to not show `null`, and to use the proper translation key

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3946](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3946)


[TILA-3946]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ