### PR TITLE
Fix access code tooltip display condition

### DIFF
--- a/apps/admin-ui/gql/gql-types.ts
+++ b/apps/admin-ui/gql/gql-types.ts
@@ -7259,6 +7259,7 @@ export type AllocatedTimeSlotsQuery = {
         recurringReservation?: {
           id: string;
           pk?: number | null;
+          shouldHaveActiveAccessCode?: boolean | null;
           isAccessCodeIsActiveCorrect?: boolean | null;
           reservations: Array<{ id: string; pk?: number | null }>;
         } | null;
@@ -13229,6 +13230,7 @@ export const AllocatedTimeSlotsDocument = gql`
           recurringReservation {
             id
             pk
+            shouldHaveActiveAccessCode
             isAccessCodeIsActiveCorrect
             reservations {
               id

--- a/apps/admin-ui/src/spa/application-rounds/[id]/review/AllocatedEventsTable.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/review/AllocatedEventsTable.tsx
@@ -60,10 +60,11 @@ function timeSlotMapper(t: TFunction, slot: Node): ApplicationScheduleView {
   const applicationPk = application.pk ?? 0;
   const reservationPk = slot.recurringReservation?.reservations[0]?.pk ?? null;
   const link = getReservationUrl(reservationPk);
-  const accessCodeActiveAlert = slot.recurringReservation
-    ?.isAccessCodeIsActiveCorrect
-    ? ""
-    : t("RequestedReservation.accessCodesNotActive");
+  const accessCodeActiveAlert =
+    slot.recurringReservation?.shouldHaveActiveAccessCode &&
+    !slot.recurringReservation?.isAccessCodeIsActiveCorrect
+      ? t("RequestedReservation.accessCodesNotActive")
+      : "";
   return {
     key: `${applicationPk}-${slot.pk}`,
     applicationPk,

--- a/apps/admin-ui/src/spa/application-rounds/[id]/review/queries.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/review/queries.tsx
@@ -174,6 +174,7 @@ export const ALLOCATED_TIME_SLOTS_QUERY = gql`
           recurringReservation {
             id
             pk
+            shouldHaveActiveAccessCode
             isAccessCodeIsActiveCorrect
             reservations {
               id


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- When determining whether to show the "Ovikoodia luodaan" tooltip, we now also check `shouldHaveActiveAccessCode` in order to not show the tooltip unnecessarily

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3955](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3955)


[TILA-3955]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ