### PR TITLE
fix: don't show null in application access type listing

### DIFF
--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -561,7 +561,7 @@ function ReservationUnitAccessTypeList({
                   : "")}
             </span>
             <span>
-              {period.endDate !== ""
+              {period.endDate != null
                 ? `${period.beginDate} – ${period.endDate}`
                 : t("common:dateGte", { value: period.beginDate })}
             </span>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fix access type duration list showing `null` for endDate in approved reservations (view application)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3946](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3946)


[TILA-3946]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ