### PR TITLE
Run `update_access_types_for_reservations` when access types removed

### DIFF
--- a/backend/tilavarauspalvelu/admin/reservation_unit/form.py
+++ b/backend/tilavarauspalvelu/admin/reservation_unit/form.py
@@ -80,6 +80,7 @@ class ReservationUnitAccessTypeForm(forms.ModelForm):
 
 class ReservationUnitAccessTypeFormSet(BaseInlineFormSet):
     form = ReservationUnitAccessTypeForm
+    instance: ReservationUnit
 
     def clean(self) -> None:
         today = local_date()
@@ -92,11 +93,7 @@ class ReservationUnitAccessTypeFormSet(BaseInlineFormSet):
     @transaction.atomic
     def save(self, commit: bool = True) -> list[ReservationUnitAccessType]:  # noqa: FBT001, FBT002
         access_types = super().save(commit=commit)
-        if not access_types:
-            return access_types
-
-        reservation_unit: ReservationUnit = access_types[0].reservation_unit
-        reservation_unit.actions.update_access_types_for_reservations()
+        self.instance.actions.update_access_types_for_reservations()
         return access_types
 
     def _should_delete_form(self, form: ReservationUnitAccessTypeForm) -> bool:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes issue where reservations' access types were not changed when future access types were removed from their reservation unit in the admin panel

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3963](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3963)


[TILA-3963]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ