### PR TITLE
fix: applications with "received" status shown correctly

### DIFF
--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -198,7 +198,7 @@
     "EXPIRED": "Rauennut",
     "HANDLED": "Käsittelyssä",
     "IN_ALLOCATION": "Käsittelyssä",
-    "RECEIVED": "Käsittelyssä",
+    "RECEIVED": "Lähetetty",
     "RESULTS_SENT": "Käsitelty"
   },
   "applicationEventStatus": {

--- a/packages/common/src/components/statuses/ApplicationStatusLabel.tsx
+++ b/packages/common/src/components/statuses/ApplicationStatusLabel.tsx
@@ -46,11 +46,12 @@ function getCustomerApplicationStatusLabelProps(
       return { type: "success", icon: <IconCheck /> };
     case ApplicationStatusChoice.Handled:
     case ApplicationStatusChoice.InAllocation:
-    case ApplicationStatusChoice.Received:
       return {
         type: "info",
         icon: <IconCogwheel />,
       };
+    case ApplicationStatusChoice.Received:
+      return { type: "alert", icon: <IconEnvelope /> };
     // These two should never be shown to the client, so they are shown as any other unexpected status
     case ApplicationStatusChoice.Cancelled:
     case ApplicationStatusChoice.Expired:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- applications with `RECEIVED` status are now shown with correct type, icon and translation

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3961](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3961)


[TILA-3961]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3961?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ