### PR TITLE
fix: always show access code value in the dialog

### DIFF
--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -555,8 +555,7 @@ function ReservationUnitAccessTypeList({
           <li key={period.pk}>
             <span>
               {t(`reservationUnit:accessTypes.${period.accessType}`) +
-                (reservationUnit?.accessType ===
-                AccessTypeWithMultivalued.AccessCode
+                (period.accessType === AccessType.AccessCode
                   ? ` (${reservationUnit?.pindoraInfo?.accessCode})`
                   : "")}
             </span>


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- The access code value is shown in the "Ohjeet" dialog box, for multivalued access type reservation series (== always when the access type validity period is of type ACCESS_CODE).

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3966](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3966)


[TILA-3966]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ