### PR TITLE
Fix beat scheduler reference

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -84,7 +84,7 @@ migrations:
 	@python manage.py makemigrations
 
 scheduler:
-	@celery -A config beat --loglevel=INFO --scheduler=django-tvp
+	@celery -A config beat --loglevel=INFO --scheduler=config.celery.beat:VaraamoDatabaseScheduler
 
 translate:
 	@echo ""

--- a/backend/config/celery/health_checks.py
+++ b/backend/config/celery/health_checks.py
@@ -14,12 +14,10 @@ HEALTH_CHECK_FILE = Path("/tmp/celery_heartbeat")  # noqa: S108  # nosec  # NOSO
 
 def create_health_check_file(**kwargs: Any) -> None:
     # Create the file to indicate that the beat is alive.
-    print("Creating health check file")  # noqa: T201, RUF100
     HEALTH_CHECK_FILE.touch(exist_ok=True)
 
 
 # No signal exists for this beat shutdown
 def remove_health_check_file(**kwargs: Any) -> None:
     # Remove the file to indicate that the worker has crashed.
-    print("Removing health check file")  # noqa: T201, RUF100
     HEALTH_CHECK_FILE.unlink(missing_ok=True)

--- a/backend/docker/scheduler.sh
+++ b/backend/docker/scheduler.sh
@@ -2,4 +2,4 @@
 set -euo pipefail
 
 echo "Starting Celery beat task scheduler..."
-exec celery -A config beat --loglevel=INFO --scheduler=django-tvp
+exec celery -A config beat --loglevel=INFO --scheduler=config.celery.beat:VaraamoDatabaseScheduler

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -87,9 +87,6 @@ ruff = "0.11.1"
 [project.entry-points.pytest11]
 tilavarauspalvelu = "tests.plugins"
 
-[project.entry-points."celery.beat_schedulers"]
-django-tvp = "config.celery.beat.VaraamoDatabaseScheduler"
-
 [tool.ruff]
 fix = true
 unsafe-fixes = true


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Use direct scheduler ref to custom beat scheduler since the project is not installed in editable mode during production so entrypoints are not available

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
