### PR TITLE
Only count reservations that are going to occur for series used access types

### DIFF
--- a/backend/tests/test_models/test_recurring_reservation.py
+++ b/backend/tests/test_models/test_recurring_reservation.py
@@ -87,6 +87,32 @@ def test_recurring_reservation__access_type__multiple_different():
     assert series.used_access_types == [AccessType.ACCESS_CODE, AccessType.PHYSICAL_KEY]
 
 
+def test_recurring_reservation__access_type__only_going_to_occur():
+    series = RecurringReservationFactory.create()
+    ReservationFactory.create(
+        recurring_reservation=series,
+        access_type=AccessType.PHYSICAL_KEY,
+        state=ReservationStateChoice.CANCELLED,
+    )
+    ReservationFactory.create(
+        recurring_reservation=series,
+        access_type=AccessType.ACCESS_CODE,
+    )
+
+    # Test non-ORM code
+    assert series.access_type == AccessTypeWithMultivalued.ACCESS_CODE
+    assert series.used_access_types == [AccessType.ACCESS_CODE]
+
+    series = RecurringReservation.objects.annotate(
+        used_access_types=L("used_access_types"),
+        access_type=L("access_type"),
+    ).first()
+
+    # Test ORM code
+    assert series.access_type == AccessTypeWithMultivalued.ACCESS_CODE
+    assert series.used_access_types == [AccessType.ACCESS_CODE]
+
+
 def test_recurring_reservation__should_have_active_access_code__active():
     series = RecurringReservationFactory.create()
     ReservationFactory.create(


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Changes `series.used_access_types` lookup property to filter with "going_to_occur".

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- Frontend should handle situations where `used_access_types` is empty

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3978](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3978)


[TILA-3978]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ