### PR TITLE
Show Pindora info in django admin if future access type is access code

### DIFF
--- a/backend/tilavarauspalvelu/models/reservation_unit_access_type/queryset.py
+++ b/backend/tilavarauspalvelu/models/reservation_unit_access_type/queryset.py
@@ -27,5 +27,10 @@ class ReservationUnitAccessTypeQuerySet(models.QuerySet):
         """Get only the access types that are active during the given period."""
         return self.filter(models.Q(begin_date__lte=end_date) & L(end_date__gt=begin_date))
 
+    def active_or_future(self, *, on_date: datetime.date | None = None) -> Self:
+        """Get only the active or future access types."""
+        on_date = on_date or local_date()
+        return self.filter(L(end_date__gt=on_date))
+
 
 class ReservationUnitAccessTypeManager(models.Manager.from_queryset(ReservationUnitAccessTypeQuerySet)): ...


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Previously only showed if current one was access code
- Also show error if Pindora call fails

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3980](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3980)


[TILA-3980]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ