### PR TITLE
Fix: Access type issues in approved reservations view

### DIFF
--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -639,7 +639,7 @@ function getReservationSeriesAccessText(
 ) {
   const { accessType, usedAccessTypes, pindoraInfo } = reservationUnit;
   if (usedAccessTypes == null || usedAccessTypes.length === 0) {
-    return "";
+    return "-";
   }
 
   switch (accessType) {

--- a/apps/ui/components/reservation-unit/Head.tsx
+++ b/apps/ui/components/reservation-unit/Head.tsx
@@ -14,6 +14,7 @@ import {
   convertLanguageCode,
   formatDuration,
   getTranslationSafe,
+  toUIDate,
 } from "common/src/common/util";
 import {
   ReservationKind,
@@ -21,7 +22,7 @@ import {
 } from "@gql/gql-types";
 import { Flex, H1, H3 } from "common/styled";
 import { breakpoints } from "common/src/const";
-import { formatDateTime } from "@/modules/util";
+import { formatDateRange, formatDateTime } from "@/modules/util";
 import { IconWithText } from "../common/IconWithText";
 import { Images } from "./";
 import {
@@ -172,7 +173,7 @@ function AccessTypeTooltip({
     <Tooltip>
       <ul>
         {accessTypeDurations.map((accessTypeDuration) => (
-          <li key={accessTypeDuration.beginDate}>
+          <li key={toUIDate(accessTypeDuration.beginDate)}>
             <span>
               {t(
                 `reservationUnit:accessTypes.${accessTypeDuration.accessType}`
@@ -181,8 +182,11 @@ function AccessTypeTooltip({
             </span>
             <span>
               {accessTypeDuration.endDate != null
-                ? `${accessTypeDuration.beginDate} – ${accessTypeDuration.endDate}`
-                : `${t("common:dateGte", { value: accessTypeDuration.beginDate })}`}
+                ? formatDateRange(
+                    accessTypeDuration.beginDate,
+                    accessTypeDuration.endDate
+                  )
+                : `${t("common:dateGte", { value: toUIDate(accessTypeDuration.beginDate) })}`}
             </span>
           </li>
         ))}

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -131,6 +131,15 @@ export function formatDateTimeRange(
   return `${day} ${beginDate}${separator} ${time}–${endTime} ${endDate}`.trim();
 }
 
+// A function which takes two Date objects, and returns a string with the date range in dd.mm.yyyy format and a separator,
+// as long as begin and end are not the same day. If they are, it returns only the day in question in dd.mm.yyyy format.
+export function formatDateRange(begin: Date, end: Date): string {
+  const beginDate = toUIDate(begin);
+  const endDate = toUIDate(end);
+
+  return `${beginDate}${!isSameDay(begin, end) ? " – " + endDate : ""}`.trim();
+}
+
 function formatDay(t: TFunction, date: Date): string {
   return t("common:dateWithWeekday", {
     date,

--- a/apps/ui/pages/applications/[id]/view/index.tsx
+++ b/apps/ui/pages/applications/[id]/view/index.tsx
@@ -150,7 +150,10 @@ function View({
             </Tabs.Tab>
           </Tabs.TabList>
           <TabPanel>
-            <ApprovedReservations application={application} />
+            <ApprovedReservations
+              application={application}
+              applicationRound={applicationRound}
+            />
           </TabPanel>
           <TabPanel>
             <ViewApplication application={application} tos={tos} />


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Shows access types only for the duration of the seasonal application round
- Uses the application round season start/end dates as the access type period start/end dates, for periods which start before and/or end after the application round season
- Displays "-" as access type for a reservation series which has no `usedAccessTypes`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- empty `usedAccessTypes` aren't available from the BE until the code in #1745 is implemented - but this is not blocking/breaking so it doesn't hinder merging this PR

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3965](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3965)
- [TILA-3976](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3976)


[TILA-3965]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ