### PR TITLE
Fix allocation selected show 24h

### DIFF
--- a/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEventCard.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEventCard.tsx
@@ -21,8 +21,8 @@ import { convertWeekday } from "common/src/conversion";
 import {
   type SectionNodeT,
   createDurationString,
-  formatTime,
   type AllocatedTimeSlotNodeT,
+  formatSuitableTimeRange,
 } from "./modules/applicationRoundAllocation";
 import { useFocusAllocatedSlot, useFocusApplicationEvent } from "./hooks";
 import { PopupMenu } from "common/src/components/PopupMenu";
@@ -396,11 +396,6 @@ function AllocatedScheduleSection({
   currentReservationUnit: ReservationUnitT;
 }): JSX.Element {
   const { t } = useTranslation();
-
-  const day = convertWeekday(allocatedTimeSlot.dayOfTheWeek);
-  const begin = allocatedTimeSlot.beginTime;
-  const end = allocatedTimeSlot.endTime;
-
   const [focused, setFocused] = useFocusAllocatedSlot();
   const isActive = allocatedTimeSlot.pk === focused;
 
@@ -432,9 +427,7 @@ function AllocatedScheduleSection({
         checked={isActive}
       />
       <div>
-        <SemiBold>
-          {t(`dayShort.${day}`)} {formatTime(begin)}-{formatTime(end)}
-        </SemiBold>
+        <SemiBold>{formatSuitableTimeRange(t, allocatedTimeSlot)}</SemiBold>
         <div>
           {truncate(combinedName, MAX_ALLOCATION_CARD_UNIT_NAME_LENGTH)}
         </div>

--- a/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEventCard.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEventCard.tsx
@@ -64,7 +64,7 @@ const borderCss = css<{ $type: AllocationApplicationSectionCardType }>`
   }};
 `;
 
-const Card = styled.button<{ $type: AllocationApplicationSectionCardType }>`
+const Card = styled.div<{ $type: AllocationApplicationSectionCardType }>`
   position: relative;
   display: flex;
   flex-direction: column;

--- a/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEvents.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/allocation/ApplicationEvents.tsx
@@ -19,7 +19,7 @@ import {
 } from "./ApplicationEventCard";
 import { useFocusApplicationEvent } from "./hooks";
 import { type ApolloQueryResult } from "@apollo/client";
-import { filterNonNullable } from "common/src/helpers";
+import { filterNonNullable, toNumber } from "common/src/helpers";
 import {
   type AllocatedTimeSlotNodeT,
   getRelatedTimeSlots,
@@ -122,10 +122,10 @@ export function AllocationPageContent({
   // When selected reservation unit changes, remove any focused application event that's not in the new reservation unit
   // TODO could include it in the hook or wrap it inside it's own
   useEffect(() => {
-    const selectedAeasPk = params.get("aes");
-    if (selectedAeasPk) {
-      const selectedAeas = applicationSections?.find(
-        (ae) => ae.pk === Number(selectedAeasPk)
+    const selectedAesPk = toNumber(params.get("aes"));
+    if (selectedAesPk) {
+      const selectedAeas = applicationSections.find(
+        (ae) => ae.pk === selectedAesPk
       );
       setFocusedApplicationEvent(selectedAeas);
     } else {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix allocation not showing selected application outline when it contained the last hour (end at 00:00).
- Fix allocation not preserving `unit` and `aes` query params when loading the page.
- Fix cleaner time formatting for slots (use our standard `begin–end` with trailing zeros format).
- Fix invalid html due to nested button element.
- Refactor remove unnecessary optionals.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: check allocation page reload / url share and application section ending at midnight.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3975](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3975)


[TILA-3975]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ