### PR TITLE
add: unit name to be shown along reservation unit name

### DIFF
--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -4,7 +4,6 @@ import {
   useApplicationReservationsQuery,
   ReservationStateChoice,
   AccessType,
-  ReservationUnitNode,
   type ApplicationNode,
   ApplicationSectionReservationUnitFragment,
   AccessTypeWithMultivalued,
@@ -660,19 +659,27 @@ function createReservationUnitLink({
 }: {
   lang: LocalizationLanguages;
   reservationUnit: Pick<
-    ReservationUnitNode,
-    "nameSv" | "nameFi" | "nameEn" | "id" | "pk"
+    ApplicationSectionReservationUnitFragment,
+    "nameSv" | "nameFi" | "nameEn" | "id" | "pk" | "unit"
   >;
 }): JSX.Element {
   const { pk } = reservationUnit;
   const name = getTranslationSafe(reservationUnit, "name", lang);
+  const unit = reservationUnit.unit
+    ? `, ${getTranslationSafe(reservationUnit.unit, "name", lang)}`
+    : "";
   if (pk == null || pk <= 0) {
-    return <span>{name}</span>;
+    return (
+      <span>
+        {name}
+        {unit}
+      </span>
+    );
   }
   return (
     <ReservationUnitLink
       href={getReservationUnitPath(pk)}
-      label={name}
+      label={name + unit}
       openInNewTab
       icon={<IconLinkExternal />}
     />
@@ -1211,6 +1218,12 @@ export const APPLICATION_SECTION_RESERVATION_UNIT_FRAGMENT = gql`
     nameEn
     id
     pk
+    unit {
+      id
+      nameFi
+      nameSv
+      nameEn
+    }
     reservationCancelledInstructionsFi
     reservationCancelledInstructionsSv
     reservationCancelledInstructionsEn

--- a/apps/ui/gql/gql-types.ts
+++ b/apps/ui/gql/gql-types.ts
@@ -6004,6 +6004,12 @@ export type ApplicationSectionReservationUnitFragment = {
   readonly reservationCancelledInstructionsSv: string | null;
   readonly reservationCancelledInstructionsEn: string | null;
   readonly currentAccessType: AccessType | null;
+  readonly unit: {
+    readonly id: string;
+    readonly nameFi: string | null;
+    readonly nameSv: string | null;
+    readonly nameEn: string | null;
+  } | null;
   readonly accessTypes: ReadonlyArray<{
     readonly id: string;
     readonly pk: number | null;
@@ -10205,6 +10211,12 @@ export const ApplicationSectionReservationUnitFragmentDoc = gql`
     nameEn
     id
     pk
+    unit {
+      id
+      nameFi
+      nameSv
+      nameEn
+    }
     reservationCancelledInstructionsFi
     reservationCancelledInstructionsSv
     reservationCancelledInstructionsEn

--- a/apps/ui/public/locales/en/application.json
+++ b/apps/ui/public/locales/en/application.json
@@ -224,7 +224,7 @@
       "cancelled": "Cancelled",
       "showAllReservations": "Show all bookings",
       "cancelApplication": "Cancel all bookings",
-      "reservationUnitsTitle": "Location",
+      "reservationUnitsTitle": "Seasonal bookings",
       "reservationsTitle": "Reservations",
       "others": "others",
       "reservationCountPostfix": "bookings"

--- a/apps/ui/public/locales/fi/application.json
+++ b/apps/ui/public/locales/fi/application.json
@@ -220,7 +220,7 @@
       "cancelled": "Peruttu",
       "showAllReservations": "Näytä kaikki varaukset",
       "cancelApplication": "Peru kaikki varaukset",
-      "reservationUnitsTitle": "Toimipiste",
+      "reservationUnitsTitle": "Kausivaraukset",
       "reservationsTitle": "Varaukset",
       "others": "muuta",
       "reservationCountPostfix": "varausta"

--- a/apps/ui/public/locales/sv/application.json
+++ b/apps/ui/public/locales/sv/application.json
@@ -218,7 +218,7 @@
       "cancelled": "Avbokad",
       "showAllReservations": "Visa alla bokningar",
       "cancelApplication": "Avboka alla bokningar",
-      "reservationUnitsTitle": "Verksamhetsställe",
+      "reservationUnitsTitle": "Säsongbokningar",
       "reservationsTitle": "Bokningar",
       "others": "andra",
       "reservationCountPostfix": "bokningar"


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Show the unit name with the reservation unit name in the reservation series listing table, in the accepted application view
- Changes the "Toimipisteet" heading to a more suitable one: "Kausivaraukset"

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3932](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3932)

[TILA-3932]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ