### PR TITLE
fix: recurring reservations starting bottom banner position

### DIFF
--- a/apps/ui/components/recurring/StartApplicationBar.tsx
+++ b/apps/ui/components/recurring/StartApplicationBar.tsx
@@ -23,16 +23,10 @@ import { useReservationUnitList } from "@/hooks";
 import { useSearchParams } from "next/navigation";
 import { LoginFragment } from "../LoginFragment";
 import { getPostLoginUrl } from "@/modules/util";
+import { isBrowser } from "@/modules/const";
 
-const BackgroundContainer = styled.div`
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  width: 100%;
-  z-index: var(--tilavaraus-stack-order-start-application-bar);
-
-  background-color: var(--color-bus);
-  color: var(--color-white);
+const SpaceWrapper = styled.div`
+  height: 76px;
 `;
 
 const InnerContainer = styled(Flex).attrs({
@@ -40,10 +34,17 @@ const InnerContainer = styled(Flex).attrs({
   $alignItems: "center",
   $wrap: "wrap",
 })`
-  ${pageSideMargins}
   margin: 0 auto;
   padding-bottom: var(--spacing-s);
   padding-top: var(--spacing-s);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  z-index: var(--tilavaraus-stack-order-start-application-bar);
+  background-color: var(--color-bus);
+  color: var(--color-white);
+  ${pageSideMargins}
 
   /* three div layout */
   & > :last-child {
@@ -71,7 +72,14 @@ export function StartApplicationBar({
   const { t } = useTranslation();
   const router = useRouter();
   const isMobile = useMedia(`(max-width: ${breakpoints.m})`, false);
-
+  let bottomOffset = 0;
+  if (isBrowser) {
+    bottomOffset =
+      (document
+        ?.querySelector(".hds-cc__target")
+        ?.shadowRoot?.querySelector(".hds-cc__container")?.clientHeight ?? -8) +
+      8; // CC-border width is 8px, which isn't included in clientHeight. If it's undefined, use -8 to nullify the result
+  }
   const { getReservationUnits, clearSelections, PARAM_NAME } =
     useReservationUnitList(applicationRound);
   const searchValues = useSearchParams();
@@ -117,9 +125,9 @@ export function StartApplicationBar({
   const count = getReservationUnits().length;
 
   return (
-    <BackgroundContainer>
+    <SpaceWrapper aria-live="polite">
       {count > 0 && (
-        <InnerContainer>
+        <InnerContainer style={{ bottom: bottomOffset + "px" }}>
           <NoWrap id="reservationUnitCount">
             {isMobile
               ? t("shoppingCart:countShort", { count })
@@ -157,6 +165,6 @@ export function StartApplicationBar({
           />
         </InnerContainer>
       )}
-    </BackgroundContainer>
+    </SpaceWrapper>
   );
 }

--- a/apps/ui/pages/recurring/[id]/index.tsx
+++ b/apps/ui/pages/recurring/[id]/index.tsx
@@ -44,6 +44,7 @@ import { getApplicationRoundName } from "@/modules/applicationRound";
 import { gql } from "@apollo/client";
 import { convertLanguageCode } from "common/src/common/util";
 import { useSearchModify } from "@/hooks/useSearchValues";
+import { createPortal } from "react-dom";
 
 type SeasonalSearchProps = ReadonlyDeep<
   Pick<NarrowedProps, "applicationRound" | "options" | "apiBaseUrl">
@@ -131,10 +132,13 @@ function SeasonalSearch({
         fetchMore={(cursor) => fetchMore(cursor)}
         sortingComponent={<SortingComponent />}
       />
-      <StartApplicationBar
-        applicationRound={applicationRound}
-        apiBaseUrl={apiBaseUrl}
-      />
+      {createPortal(
+        <StartApplicationBar
+          applicationRound={applicationRound}
+          apiBaseUrl={apiBaseUrl}
+        />,
+        document.body
+      )}
     </>
   );
 }

--- a/apps/ui/styles/variables.css
+++ b/apps/ui/styles/variables.css
@@ -25,7 +25,7 @@
   --tilavaraus-stack-order-tooltip: 100;
   --tilavaraus-stack-order-navigation: 110;
   --tilavaraus-stack-order-calendar-gutter: 101;
-  --tilavaraus-stack-order-start-application-bar: 20;
+  --tilavaraus-stack-order-start-application-bar: 1010;
 
   --tilavaraus-page-max-width: 1200px;
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- fixes a11y problems regarding the bottom banner, which shows up at the start of a recurring reservation application
- it pushes the page content up, so that no footer links get covered
- it takes into account the cookie consent banner, with which it shares space

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3996](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3996)


[TILA-3996]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ