### PR TITLE
fix: make the purpose text able to wrap in view application page

### DIFF
--- a/apps/ui/components/application/ApplicationSectionList.tsx
+++ b/apps/ui/components/application/ApplicationSectionList.tsx
@@ -20,6 +20,7 @@ import {
   InfoItemContainer,
   InfoItem,
   ScheduleDay,
+  RegularText,
 } from "./styled";
 import { SuitableTimeRangeFormValues } from "./form";
 import { WEEKDAYS } from "common/src/const";
@@ -33,6 +34,7 @@ import {
   Tooltip,
 } from "hds-react";
 import { getDayTimes } from "./module";
+import { NoWrap } from "common/styled";
 
 function formatDurationSeconds(seconds: number, t: TFunction): string {
   const hours = Math.floor(seconds / 3600);
@@ -80,11 +82,17 @@ function getLabelProps(
   }
 }
 
-function InfoListItem({ label, value }: { label: string; value: string }) {
+function InfoListItem({
+  label,
+  value,
+}: {
+  label: string;
+  value: string | JSX.Element;
+}) {
   return (
     <li>
       <h4>{`${label}: `}</h4>
-      <span>{value}</span>
+      {value}
     </li>
   );
 }
@@ -130,32 +138,42 @@ function SingleApplicationSection({
     {
       key: "numPersons",
       label: t("application:preview.applicationEvent.numPersons"),
-      value: `${aes.numPersons} ${t("common:peopleSuffixShort")}`,
+      value: (
+        <NoWrap>{`${aes.numPersons} ${t("common:peopleSuffixShort")}`}</NoWrap>
+      ),
     },
     {
       key: "ageGroup",
       label: t("application:preview.applicationEvent.ageGroup"),
-      value: `${ageGroupToString(aes.ageGroup)} ${t("common:yearSuffixShort")}`,
+      value: (
+        <NoWrap>
+          {`${ageGroupToString(aes.ageGroup)} ${t("common:yearSuffixShort")}`}
+        </NoWrap>
+      ),
     },
     {
       key: "duration",
       label: t("application:preview.applicationEvent.duration"),
-      value: duration,
+      value: <NoWrap>{duration}</NoWrap>,
     },
     {
       key: "eventsPerWeek",
       label: t("application:preview.applicationEvent.eventsPerWeek"),
-      value: `${aes.appliedReservationsPerWeek} ${t("common:amountSuffixShort")}`,
+      value: (
+        <NoWrap>
+          {`${aes.appliedReservationsPerWeek} ${t("common:amountSuffixShort")}`}
+        </NoWrap>
+      ),
     },
     {
       key: "period",
       label: t("application:preview.applicationEvent.period"),
-      value: `${reservationsBegin} - ${reservationsEnd}`,
+      value: <NoWrap>{`${reservationsBegin} - ${reservationsEnd}`}</NoWrap>,
     },
     {
       key: "purpose",
       label: t("application:preview.applicationEvent.purpose"),
-      value: getTranslationSafe(aes.purpose ?? {}, "name", lang),
+      value: <span>{getTranslationSafe(aes.purpose ?? {}, "name", lang)}</span>,
     },
   ];
 
@@ -194,7 +212,9 @@ function SingleApplicationSection({
             <ol>
               {filterNonNullable(reservationUnits).map((ru) => (
                 <li key={ru.pk}>
-                  {getTranslationSafe(ru, "name", lang).trim()}
+                  <RegularText>
+                    {getTranslationSafe(ru, "name", lang).trim()}
+                  </RegularText>
                 </li>
               ))}
             </ol>

--- a/apps/ui/components/application/styled.tsx
+++ b/apps/ui/components/application/styled.tsx
@@ -123,7 +123,6 @@ export const InfoItem = styled(Flex).attrs({
       ${fontRegular};
     }
     span {
-      white-space: nowrap;
       ${fontMedium};
     }
   }
@@ -146,6 +145,13 @@ export const InfoItem = styled(Flex).attrs({
     *:last-child > & {
       border-right: 0;
     }
+  }
+`;
+
+export const RegularText = styled.span`
+  &&& {
+    font-size: var(--fontsize-body-m);
+    ${fontRegular};
   }
 `;
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- edit the list styling to keep the medium font weight in the info values, while having only ones within a `<span>` as `nowrap`.
- `nowrap` _could_ in principle be removed from all the application info values, but in the other ones there is good a case to be made for keeping them confined to be on a single line. Since purpose is a free text field it can be a lot longer, and it’s quite natural to have it wrap onto two or more lines if needed due to it being natural text and not "hard values" (== a number followed by a unit, or a range of dates..). The other values can not be long enough to warrant a second line by themselves. If they wouldn't fit on one line together with their label the entire value text should be on a new line.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3960](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3960)


[TILA-3960]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ