### PR TITLE
Fix reservation funnel error handling

### DIFF
--- a/apps/ui/hooks/useToastIfQueryParam.ts
+++ b/apps/ui/hooks/useToastIfQueryParam.ts
@@ -1,14 +1,16 @@
 import { useEffect } from "react";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
-import { successToast } from "common/src/common/toast";
+import toast from "common/src/common/toast";
 
 export function useToastIfQueryParam({
   key,
-  successMessage,
+  message,
+  type = "success",
 }: {
   key: string | string[];
-  successMessage: string | (() => string);
+  message: string | (() => string);
+  type?: "success" | "error";
 }) {
   const router = useRouter();
   const { t } = useTranslation();
@@ -41,20 +43,20 @@ export function useToastIfQueryParam({
     };
     const q = router.query;
 
-    const text =
-      typeof successMessage === "string" ? successMessage : successMessage();
-    if (Array.isArray(key)) {
-      if (key.every((k) => q[k])) {
-        successToast({
-          text,
-        });
-        removeTimeUpdatedParam();
-      }
-    } else if (q[key]) {
-      successToast({
+    const text = typeof message === "string" ? message : message();
+    const handle = () => {
+      toast({
         text,
+        type,
       });
       removeTimeUpdatedParam();
+    };
+    if (Array.isArray(key)) {
+      if (key.every((k) => q[k])) {
+        handle();
+      }
+    } else if (q[key]) {
+      handle();
     }
-  }, [router, t, key, successMessage]);
+  }, [router, t, key, message, type]);
 }

--- a/apps/ui/middleware.ts
+++ b/apps/ui/middleware.ts
@@ -260,7 +260,12 @@ function parseUserGQLquery(
 
   if ("reservation" in data) {
     const { reservation } = data;
-    if (
+
+    // Reservation doesn't exist or user has no access to it
+    // have to handle like this otherwise we can't redirect out of the funnel if the reservation was deleted
+    if (reservationId != null && reservation == null) {
+      hasAccess = true;
+    } else if (
       reservation != null &&
       typeof reservation === "object" &&
       "user" in reservation &&
@@ -269,6 +274,7 @@ function parseUserGQLquery(
       "pk" in reservation.user
     ) {
       const { pk } = reservation.user;
+
       if (pk != null && typeof pk === "number") {
         hasAccess = pk === userPk;
       }

--- a/apps/ui/modules/urls.ts
+++ b/apps/ui/modules/urls.ts
@@ -92,11 +92,14 @@ export function getReservationInProgressPath(
   return `${reservationUnitPrefix}/${pk}/reservation/${reservationPk}`;
 }
 
-export function getReservationUnitPath(pk: Maybe<number> | undefined): string {
+export function getReservationUnitPath(
+  pk: Maybe<number> | undefined,
+  params?: Readonly<URLSearchParams>
+): string {
   if (pk == null) {
     return "";
   }
-  return `${reservationUnitPrefix}/${pk}`;
+  return `${reservationUnitPrefix}/${pk}?${params?.toString() ?? ""}`;
 }
 
 export function getFeedbackUrl(

--- a/apps/ui/pages/applications/[id]/view/index.tsx
+++ b/apps/ui/pages/applications/[id]/view/index.tsx
@@ -56,7 +56,7 @@ function View({
 
   useToastIfQueryParam({
     key: "deletedReservationPk",
-    successMessage: t("application:preview.reservationDeleted"),
+    message: t("application:preview.reservationDeleted"),
   });
 
   const translateDeletedSectionMessage = () => {
@@ -80,7 +80,7 @@ function View({
 
   useToastIfQueryParam({
     key: ["cancelled", "future"],
-    successMessage: translateDeletedSectionMessage,
+    message: translateDeletedSectionMessage,
   });
 
   const searchParams = useSearchParams();

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -111,6 +111,7 @@ import { Breadcrumb } from "@/components/common/Breadcrumb";
 import { useDisplayError } from "common/src/hooks";
 import { useRemoveStoredReservation } from "@/hooks/useRemoveStoredReservation";
 import { gql } from "@apollo/client";
+import { useToastIfQueryParam } from "@/hooks";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
 type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
@@ -142,6 +143,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     const end = ignoreMaybeArray(query.end);
 
     if (begin != null && end != null) {
+      // FIXME handle errors (so user never ends to 500 page)
       const input: ReservationCreateMutationInput = {
         begin,
         end,
@@ -577,6 +579,12 @@ function ReservationUnit({
     ),
     [apiBaseUrl, focusSlot, reservationForm, t]
   );
+
+  useToastIfQueryParam({
+    key: "invalidReservation",
+    type: "error",
+    message: t("reservationCalendar:errors.invalidReservationRedirect"),
+  });
 
   const startingTimeOptions = getPossibleTimesForDay({
     reservableTimes,

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -330,12 +330,12 @@ function Reservation({
 
   useToastIfQueryParam({
     key: "timeUpdated",
-    successMessage: t("reservations:saveNewTimeSuccess"),
+    message: t("reservations:saveNewTimeSuccess"),
   });
 
   useToastIfQueryParam({
     key: "deleted",
-    successMessage: t("reservations:reservationCancelledTitle"),
+    message: t("reservations:reservationCancelledTitle"),
   });
 
   const { begin, end } = reservation;

--- a/apps/ui/public/locales/en/errors.json
+++ b/apps/ui/public/locales/en/errors.json
@@ -58,6 +58,7 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "You can only make a seasonal booking application for this item.",
     "CREATE_PERMISSION_DENIED": "No permission to create.",
     "validation": {
+      "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "You have the maximum number of bookings for this space.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "The person making the reservation must be 18 years old",
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "The applicant must be 18 years old.",
       "APPLICATION_SECTION_SUITABLE_TIME_RANGES_TOO_SHORT": "The desired time is too short.",

--- a/apps/ui/public/locales/en/reservationCalendar.json
+++ b/apps/ui/public/locales/en/reservationCalendar.json
@@ -77,7 +77,8 @@
     "bufferCollision": "The booking is too close to the previous or next booking. Please change the booking time.",
     "collision": "The item is already booked at the time you selected. Please change the booking time.",
     "unavailable": "The item cannot be booked at the selected time. Please change the booking time.",
-    "termsNotAccepted": "You must agree to the terms and conditions of contract before continuing."
+    "termsNotAccepted": "You must agree to the terms and conditions of contract before continuing.",
+    "invalidReservationRedirect": "The booking is no longer valid."
   },
   "reservingStartsAt": "The item will be available from {{date}}.",
   "reservationQuotaLabel": "Existing bookings",

--- a/apps/ui/public/locales/fi/errors.json
+++ b/apps/ui/public/locales/fi/errors.json
@@ -57,6 +57,7 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Tähän kohteeseen voit tehdä vain kausivaraushakemuksen.",
     "CREATE_PERMISSION_DENIED": "Ei lupaa luoda.",
     "validation": {
+      "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Sinulla on maksimi määrä varauksia tässä kohteessa.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED":  "Varaajan on oltava täysi-ikäinen.",
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "Hakijan on oltava täysi-ikäinen.",
       "APPLICATION_SECTION_SUITABLE_TIME_RANGES_TOO_SHORT": "Toivottu aika on liian lyhyt.",

--- a/apps/ui/public/locales/fi/reservationCalendar.json
+++ b/apps/ui/public/locales/fi/reservationCalendar.json
@@ -75,7 +75,8 @@
     "bufferCollision": "Varaus on liian lähellä edellistä tai seuraavaa varausta. Muuta varauksen ajankohtaa.",
     "collision": "Kohde on jo varattu valitsemanasi ajankohtana. Muuta varauksen ajankohtaa.",
     "unavailable": "Kohde ei ole varattavissa kyseisenä ajankohtana. Muuta varauksen ajankohtaa.",
-    "termsNotAccepted": "Hyväksy sopimusehdot jatkaaksesi varausta."
+    "termsNotAccepted": "Hyväksy sopimusehdot jatkaaksesi varausta.",
+    "invalidReservationRedirect": "Varaus ei ole enää voimassa."
   },
   "reservingStartsAt": "Kohde on varattavissa {{date}} alkaen.",
   "reservationQuotaLabel": "Olemassaolevia varauksia",

--- a/apps/ui/public/locales/sv/errors.json
+++ b/apps/ui/public/locales/sv/errors.json
@@ -58,6 +58,7 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Du kan bara göra en ansökan om säsongsbokning för detta objekt.",
     "CREATE_PERMISSION_DENIED": "Ingen behörighet att skapa.",
     "validation": {
+      "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Du har det maximala antalet bokningar för detta objekt.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Personen som gör bokningen måste vara myndig.",
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "Sökanden måste vara myndig.",
       "APPLICATION_SECTION_SUITABLE_TIME_RANGES_TOO_SHORT": "Önskad tid är för kort.",

--- a/apps/ui/public/locales/sv/reservationCalendar.json
+++ b/apps/ui/public/locales/sv/reservationCalendar.json
@@ -77,7 +77,8 @@
     "bufferCollision": "Bokningen är för nära föregående eller nästa bokning. Ändra bokningens tidpunkt.",
     "collision": "Objektet är redan bokat vid den tidpunkt du valde. Ändra bokningens tidpunkt.",
     "unavailable": "Objektet går inte att boka vid den tidpunkt du valde. Ändra bokningens tidpunkt.",
-    "termsNotAccepted": "Godkänn avtalsvillkoren för att fortsätta bokningen."
+    "termsNotAccepted": "Godkänn avtalsvillkoren för att fortsätta bokningen.",
+    "invalidReservationRedirect": "Bokningen är inte längre giltig."
   },
   "reservingStartsAt": "Objektet går att boka från och med {{date}}.",
   "reservationQuotaLabel": "Befintliga bokningar",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: redirect initial reservations that got deleted back to reservation-unit instead of 404.
- Fix: don't 500 after login if the `createReservation` mutation fails, toast errors to user instead.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: overlapping reservations (postLogin), removed reservations should redirect out of funnel on refresh (not 404).

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3999](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3999)


[TILA-3999]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ