### PR TITLE
add: Make single reservation button to admin my-units view

### DIFF
--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -322,6 +322,7 @@ const translations: ITranslations = {
         byReservationUnit: ["Kaikki varaukset"],
       },
       header: {
+        createReservation: ["Tee varaus"],
         recurringReservation: ["Tee toistuva varaus"],
       },
       legend: {
@@ -1091,7 +1092,7 @@ const translations: ITranslations = {
     removeFailed: ["Tilan poistaminen ei onnistunut."],
   },
   ReservationDialog: {
-    title: ["Varaa {{reservationUnit}}"],
+    title: ["Tee varaus"],
     accept: ["Varaa"],
     saveSuccess: ["Varaus tehty kohteeseen {{reservationUnit}}"],
   },

--- a/apps/admin-ui/src/spa/my-units/[id]/ReservationUnitCalendarView.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/ReservationUnitCalendarView.tsx
@@ -1,11 +1,16 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { addDays, formatISO, startOfDay, subDays } from "date-fns";
 import { AutoGrid, Flex } from "common/styled";
 import { ReservationUnitCalendar } from "./ReservationUnitCalendar";
 import WeekNavigation from "./WeekNavigation";
-import { useTranslation } from "next-i18next";
-import { Option, Select } from "hds-react";
-import { convertOptionToHDS, toNumber } from "common/src/helpers";
+import { toNumber } from "common/src/helpers";
+import { useSearchParams } from "react-router-dom";
+import { SelectFilter } from "@/component/QueryParamFilters";
+import styled from "styled-components";
+
+const SelectFilterStyled = styled(SelectFilter)`
+  z-index: var(--tilavaraus-admin-stack-select-over-calendar);
+`;
 
 export function ReservationUnitCalendarView({
   reservationUnitOptions,
@@ -14,49 +19,20 @@ export function ReservationUnitCalendarView({
   reservationUnitOptions: { label: string; value: number }[];
   unitPk: number;
 }): JSX.Element {
-  const { t } = useTranslation();
-
+  const [params] = useSearchParams();
+  const reservationUnitPk =
+    toNumber(params.get("reservationUnit")) ?? reservationUnitOptions[0]?.value;
   const today = formatISO(startOfDay(new Date()));
 
   const [begin, setBegin] = useState(today);
-  const [reservationUnitPk, setReservationUnitPk] = useState(-1);
-
-  const valueOption =
-    reservationUnitOptions.find((o) => o.value === reservationUnitPk) ?? null;
-
-  // Set the first reservation unit as the default
-  useEffect(() => {
-    const newVal = reservationUnitOptions[0]?.value;
-    if (newVal != null) {
-      setReservationUnitPk(newVal);
-    }
-  }, [reservationUnitOptions]);
-
-  const onChange = (selecte: Option[]) => {
-    const value = selecte.find(() => true)?.value;
-    const v = toNumber(value);
-    if (v != null) {
-      setReservationUnitPk(v);
-    }
-  };
 
   return (
     <>
       <AutoGrid>
-        <Select
-          id="reservation-unit"
-          disabled={reservationUnitOptions.length === 0}
-          style={{
-            zIndex: "var(--tilavaraus-admin-stack-select-over-calendar)",
-          }}
-          texts={{
-            label: t("ReservationUnitsFilter.label"),
-            placeholder: t("common.select"),
-          }}
+        <SelectFilterStyled
+          name="reservationUnit"
           clearable={false}
-          options={reservationUnitOptions.map(convertOptionToHDS)}
-          value={valueOption?.value.toString()}
-          onChange={onChange}
+          options={reservationUnitOptions}
         />
       </AutoGrid>
       <Flex $justifyContent="center" $direction="row">
@@ -70,11 +46,13 @@ export function ReservationUnitCalendarView({
           }}
         />
       </Flex>
-      <ReservationUnitCalendar
-        begin={begin}
-        reservationUnitPk={reservationUnitPk}
-        unitPk={unitPk}
-      />
+      {reservationUnitPk && (
+        <ReservationUnitCalendar
+          begin={begin}
+          reservationUnitPk={reservationUnitPk}
+          unitPk={unitPk}
+        />
+      )}
     </>
   );
 }

--- a/apps/admin-ui/src/spa/my-units/[id]/UnitReservations.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/UnitReservations.tsx
@@ -30,11 +30,13 @@ const LegendContainer = styled.div`
 type InnerProps = {
   unitPk: string;
   reservationUnitTypes: number[];
+  reservationUnitOptions: { label: string; value: number }[];
 };
 
 function UnitReservationsInner({
   unitPk,
   reservationUnitTypes,
+  reservationUnitOptions,
 }: InnerProps): JSX.Element {
   const [searchParams] = useSearchParams();
   const { t } = useTranslation();
@@ -59,6 +61,7 @@ function UnitReservationsInner({
         refetch={refetch}
         unitPk={Number(unitPk)}
         isLoading={loading}
+        reservationUnitOptions={reservationUnitOptions}
       />
       <LegendContainer>
         <LegendsWrapper>
@@ -76,7 +79,11 @@ type Params = {
   reservationUnitId: string;
 };
 
-export function UnitReservations(): JSX.Element {
+export function UnitReservations({
+  reservationUnitOptions,
+}: {
+  reservationUnitOptions: { label: string; value: number }[];
+}): JSX.Element {
   const { unitId } = useParams<Params>();
   const { t } = useTranslation();
 
@@ -121,7 +128,10 @@ export function UnitReservations(): JSX.Element {
           options={reservationUnitTypeOptions}
         />
       </AutoGrid>
-      <SearchTags hide={["date", "tab"]} translateTag={translateTag} />
+      <SearchTags
+        hide={["date", "tab", "reservationUnit"]}
+        translateTag={translateTag}
+      />
       <HR />
       <Flex
         $gap="none"
@@ -148,6 +158,7 @@ export function UnitReservations(): JSX.Element {
         <UnitReservationsInner
           reservationUnitTypes={reservationUnitTypes}
           unitPk={unitId}
+          reservationUnitOptions={reservationUnitOptions}
         />
       ) : null}
     </Flex>

--- a/apps/admin-ui/src/spa/my-units/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/index.tsx
@@ -2,8 +2,8 @@ import React from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
-import { Tabs } from "hds-react";
-import { TabWrapper, TitleSection, H1 } from "common/styled";
+import { Button, ButtonVariant, Tabs } from "hds-react";
+import { Flex, H1, TabWrapper, TitleSection } from "common/styled";
 import { breakpoints } from "common/src/const";
 import { parseAddress } from "@/common/util";
 import { getRecurringReservationUrl } from "@/common/urls";
@@ -16,6 +16,8 @@ import { useCheckPermission } from "@/hooks";
 import { ButtonLikeLink } from "@/component/ButtonLikeLink";
 import { LinkPrev } from "@/component/LinkPrev";
 import { gql } from "@apollo/client";
+import { useModal } from "@/context/ModalContext";
+import { CreateReservationModal } from "@/spa/my-units/[id]/CreateReservationModal";
 
 type Params = {
   unitId: string;
@@ -38,6 +40,7 @@ export function MyUnitView() {
   const { unitId } = useParams<Params>();
   const { t } = useTranslation();
   const pk = toNumber(unitId);
+  const { setModalContent } = useModal();
 
   const isPkValid = pk != null && pk > 0;
   const id = base64encode(`UnitNode:${pk}`);
@@ -92,14 +95,31 @@ export function MyUnitView() {
         <H1 $noMargin>{title}</H1>
         <LocationOnlyOnDesktop>{location}</LocationOnlyOnDesktop>
       </TitleSection>
-      <div>
+      <Flex $direction="row" $gap="m">
+        <Button
+          variant={ButtonVariant.Secondary}
+          onClick={() =>
+            setModalContent(
+              <CreateReservationModal
+                start={new Date()}
+                reservationUnitOptions={reservationUnitOptions}
+                onClose={() => {
+                  setModalContent(null);
+                }}
+              />
+            )
+          }
+          disabled={!canCreateReservations}
+        >
+          {t("MyUnits.Calendar.header.createReservation")}
+        </Button>
         <ButtonLikeLink
           to={canCreateReservations ? recurringReservationUrl : ""}
           disabled={!canCreateReservations}
         >
           {t("MyUnits.Calendar.header.recurringReservation")}
         </ButtonLikeLink>
-      </div>
+      </Flex>
       <TabWrapper>
         <Tabs initiallyActiveTab={activeTab}>
           <Tabs.TabList>
@@ -111,7 +131,7 @@ export function MyUnitView() {
             </Tabs.Tab>
           </Tabs.TabList>
           <TabPanel>
-            <UnitReservations />
+            <UnitReservations reservationUnitOptions={reservationUnitOptions} />
           </TabPanel>
           <TabPanel>
             <ReservationUnitCalendarView


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds a button to make single reservations to the admin my-units view 
- refactors `reservationUnitPk` to be a searchParam (`reservationUnit`) for easier handling of the its state across all the relevant components - this also makes the reservation unit selection in the reservation unit tab persistant
- adds possibility to change the reservation unit to the `CreateReservationModal`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3967](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3967)


[TILA-3967]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ