### PR TITLE
Add graphql error logging to sentry

### DIFF
--- a/apps/admin-ui/src/common/apolloClient.ts
+++ b/apps/admin-ui/src/common/apolloClient.ts
@@ -9,12 +9,12 @@ import {
 // @ts-ignore -- types require nodenext which breaks bundler option that breaks the build
 import createUploadLink from "apollo-upload-client/createUploadLink.mjs";
 import { getCookie } from "typescript-cookie";
-import { onError } from "@apollo/client/link/error";
 import { buildGraphQLUrl } from "common/src/urlBuilder";
 import { env } from "@/env.mjs";
 import { isBrowser } from "./const";
 import { relayStylePagination } from "@apollo/client/utilities";
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
+import { errorLink } from "common/src/apolloUtils";
 
 if (process.env.NODE_ENV !== "production") {
   // Adds messages only in a dev environment
@@ -37,20 +37,6 @@ const authLink = new ApolloLink((operation, forward) => {
   }));
 
   return forward(operation);
-});
-
-const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors) {
-    for (const error of graphQLErrors) {
-      // eslint-disable-next-line no-console
-      console.error(`GQL_ERROR: ${JSON.stringify(error, null, 2)}`);
-    }
-  }
-
-  if (networkError) {
-    // eslint-disable-next-line no-console
-    console.error(`NETWORK_ERROR: ${JSON.stringify(networkError, null, 2)}`);
-  }
 });
 
 export function createClient(apiBaseUrl: string) {

--- a/apps/ui/hooks/index.ts
+++ b/apps/ui/hooks/index.ts
@@ -8,3 +8,4 @@ export { useToastIfQueryParam } from "./useToastIfQueryParam";
 export { useCurrentUser } from "./useCurrentUser";
 export { useAvailableTimes } from "./useAvailableTimes";
 export { useRemoveStoredReservation } from "./useRemoveStoredReservation";
+export { useBlockingReservations } from "./useBlockingReservations";

--- a/apps/ui/modules/apolloClient.ts
+++ b/apps/ui/modules/apolloClient.ts
@@ -1,7 +1,6 @@
 import { ApolloClient, HttpLink, InMemoryCache, from } from "@apollo/client";
 import { getCookie } from "typescript-cookie";
 import { relayStylePagination } from "@apollo/client/utilities";
-import { onError } from "@apollo/client/link/error";
 import qs, { ParsedUrlQuery } from "querystring";
 import { GetServerSidePropsContext, PreviewData } from "next";
 import { IncomingHttpHeaders } from "node:http";
@@ -9,26 +8,13 @@ import { buildGraphQLUrl } from "common/src/urlBuilder";
 import { env } from "@/env.mjs";
 import { isBrowser } from "./const";
 import { loadErrorMessages, loadDevMessages } from "@apollo/client/dev";
+import { errorLink } from "common/src/apolloUtils";
 
 if (process.env.NODE_ENV !== "production") {
   // Adds messages only in a dev environment
   loadDevMessages();
   loadErrorMessages();
 }
-
-const errorLink = onError(({ graphQLErrors, networkError }) => {
-  if (graphQLErrors) {
-    for (const error of graphQLErrors) {
-      // eslint-disable-next-line no-console
-      console.error(`GQL_ERROR: ${JSON.stringify(error, null, 2)}`);
-    }
-  }
-
-  if (networkError) {
-    // eslint-disable-next-line no-console
-    console.error(`NETWORK_ERROR: ${JSON.stringify(networkError, null, 2)}`);
-  }
-});
 
 function getServerCookie(
   headers: IncomingHttpHeaders | undefined,

--- a/apps/ui/pages/503.tsx
+++ b/apps/ui/pages/503.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+import type { GetServerSidePropsContext } from "next";
+import { serverSideTranslations } from "next-i18next/serverSideTranslations";
+import { getCommonServerSideProps } from "@/modules/serverUtils";
+import ErrorContainer from "common/src/components/ErrorContainer";
+
+/// Unlike 404 and 500 this is not a standard next error page
+/// so using getServerSideProps is possible but 503 means we can't do backend calls
+export async function getStaticProps({ locale }: GetServerSidePropsContext) {
+  return {
+    props: {
+      ...getCommonServerSideProps(),
+      ...(await serverSideTranslations(locale ?? "fi")),
+    },
+  };
+}
+
+type Props = {
+  feedbackUrl: string;
+  title?: string;
+  body?: string;
+};
+function Page503({ title, body, feedbackUrl }: Readonly<Props>): JSX.Element {
+  return (
+    <ErrorContainer
+      statusCode={503}
+      title={title}
+      body={body}
+      feedbackUrl={feedbackUrl}
+    />
+  );
+}
+
+export default Page503;

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -106,12 +106,12 @@ import {
   useRemoveStoredReservation,
   useAvailableTimes,
   useToastIfQueryParam,
+  useBlockingReservations,
 } from "@/hooks";
 import { gql } from "@apollo/client";
 import { type ApiError, getApiErrors } from "common/src/apolloUtils";
 import { formatErrorMessage } from "common/src/hooks/useDisplayError";
 import { errorToast } from "common/src/common/toast";
-import { useBlockingReservations } from "@/hooks/useBlockingReservations";
 
 const StyledApplicationRoundScheduleDay = styled.p`
   span:first-child {
@@ -731,6 +731,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         end,
         reservationUnit: pk,
       };
+
       try {
         const res = await apolloClient.mutate<
           CreateReservationMutation,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -40,6 +40,7 @@
   },
   "peerDependencies": {
     "@apollo/client": "^3.13.1",
+    "@sentry/nextjs": "^8.29.0",
     "next": "15.2.4",
     "next-i18next": "^15.4.2",
     "react": "^18.2.0",
@@ -49,6 +50,7 @@
   "devDependencies": {
     "@apollo/client": "^3.13.1",
     "@happy-dom/jest-environment": "^17.4.4",
+    "@sentry/nextjs": "^8.29.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/common/src/common/toast.tsx
+++ b/packages/common/src/common/toast.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   ToastContainer as TC,
   toast as toastFn,
+  ToastOptions,
   type Id,
 } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
@@ -13,14 +14,14 @@ import {
 } from "hds-react";
 import styled from "styled-components";
 
-type ToastProps = {
+type ToastProps<T = unknown> = {
   text: string;
   type?: "success" | "error" | "alert" | "info";
   label?: string;
   ariaLabel?: string;
   duration?: number;
   dataTestId?: string;
-  options?: Record<string, unknown>;
+  options?: ToastOptions<T>;
   icon?: JSX.Element;
 };
 
@@ -128,9 +129,9 @@ export default function toast({
   duration = 5,
   dataTestId,
   ariaLabel = label,
-  options,
+  options = {},
 }: ToastProps): Id {
-  const toastOptions = options || {};
+  const toastOptions: ToastOptions = { ...options };
   if (duration) {
     toastOptions.autoClose = duration * 1000;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -398,6 +398,9 @@ importers:
       '@happy-dom/jest-environment':
         specifier: ^17.4.4
         version: 17.4.4
+      '@sentry/nextjs':
+        specifier: ^8.29.0
+        version: 8.29.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.53.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.26.0(@opentelemetry/api@1.9.0))(next@15.2.4(@babel/core@7.26.10)(@opentelemetry/api@1.9.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.81.0))(react@18.3.1)(webpack@5.94.0)
       '@testing-library/dom':
         specifier: ^10.4.0
         version: 10.4.0


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add logging GraphQL as different errors in sentry based on the backend error code.
- Add 503 error page if middleware GraphQL query fails with networkError (no backend connection / gateway error / 503).
  - Fixes redirect to 500 page when GraphQL query fails uncontrollably.
- Add `Network error` toast if client side GraphQL query fails with networkError.
  - Fixes pure client side queries / mutations failing silently or with unrelated error message.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: drop backend pods to simulate 503 on frontend. both `admin` and `customer`
- Manual testing: check sentry logs in both environments for GraphlQL errors (ex. overlapping reservations).

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4004](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4004)
- [TILA-3989](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3989)
- [TILA-3985](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3985)


[TILA-4004]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ