### PR TITLE
Fix allocation page going to infinite rerender loop

### DIFF
--- a/apps/admin-ui/src/spa/application-rounds/[id]/allocation/index.tsx
+++ b/apps/admin-ui/src/spa/application-rounds/[id]/allocation/index.tsx
@@ -623,7 +623,7 @@ function AllocationWrapper({
   const [searchParams, setParams] = useSearchParams();
   useEffect(() => {
     const unit = toNumber(searchParams.get("unit"));
-    if (!loading && !filteredUnits.some((u) => u.pk === unit)) {
+    if (unit != null && !loading && !filteredUnits.some((u) => u.pk === unit)) {
       const p = new URLSearchParams(searchParams);
       p.delete("unit");
       setParams(p, { replace: true });


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: on first landing to allocation page `unit` param gets reset by multiple useEffects causing an infinite render loop.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: check that Firefox doesn't crash on first landing to allocation page (through the "Jaa vuoroja" link).

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
