### PR TITLE
Fix focus and responsive issues in create reservation modal

### DIFF
--- a/apps/admin-ui/src/spa/my-units/[id]/CreateReservationModal.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/CreateReservationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { type RefObject, useEffect } from "react";
 import { gql } from "@apollo/client";
 import { useForm, FormProvider, UseFormReturn } from "react-hook-form";
 import {
@@ -43,6 +43,7 @@ import { successToast } from "common/src/common/toast";
 import { useDisplayError } from "common/src/hooks";
 import { useSearchParams } from "react-router-dom";
 import { SelectFilter } from "@/component/QueryParamFilters";
+import { HDSModal } from "@/component/HDSModal";
 
 // NOTE HDS forces buttons over each other on mobile, we want them side-by-side
 const ActionButtons = styled(Dialog.ActionButtons)`
@@ -60,18 +61,9 @@ const ActionButtons = styled(Dialog.ActionButtons)`
   }
 `;
 
-const FixedDialog = styled(Dialog)`
-  /* Hack to deal with modal trying to fit content. So an error message -> layout shift */
-  width: min(calc(100vw - 2rem), var(--container-width-l)) !important;
-  & > div:nth-child(2) {
-    /* don't layout shift when the modal content changes */
-    height: min(80vh, 1024px);
-  }
-`;
-
 const MandatoryFieldsText = styled.div`
   margin-top: calc(var(--spacing-xs) * -1);
-  grid-column: 1 / span 3;
+  grid-column: 1 / -1;
   font-size: var(--fontsize-body-s);
 `;
 
@@ -96,12 +88,14 @@ type CreateReservationModalProps = {
   reservationUnitOptions: { label: string; value: number }[];
   onClose: () => void;
   start?: Date;
+  focusAfterCloseRef: RefObject<HTMLElement>;
 };
 
 export function CreateReservationModal({
   reservationUnitOptions,
   start,
   onClose,
+  focusAfterCloseRef,
 }: CreateReservationModalProps): JSX.Element {
   const { t } = useTranslation();
   const { isOpen } = useModal();
@@ -198,17 +192,15 @@ export function CreateReservationModal({
   }
 
   return (
-    <FixedDialog
-      variant="primary"
+    <HDSModal
       id="info-dialog"
-      aria-labelledby="modal-header"
-      aria-describedby="modal-description"
       isOpen={isOpen}
-      focusAfterCloseRef={undefined}
+      focusAfterCloseRef={focusAfterCloseRef}
       scrollable
+      onClose={onClose}
     >
       <Dialog.Header id="modal-header" title={t("ReservationDialog.title")} />
-      <Dialog.Content>
+      <Dialog.Content style={{ paddingTop: "var(--spacing-m)" }}>
         <SelectFilter
           name="reservationUnit"
           sort
@@ -233,7 +225,7 @@ export function CreateReservationModal({
           </ErrorBoundary>
         )}
       </Dialog.Content>
-    </FixedDialog>
+    </HDSModal>
   );
 }
 

--- a/apps/admin-ui/src/spa/my-units/[id]/UnitReservations.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/UnitReservations.tsx
@@ -108,12 +108,11 @@ export function UnitReservations({
     .filter(Number.isInteger);
 
   useEffect(() => {
-    if (searchParams.get("date")) {
-      return;
+    if (searchParams.get("date") == null) {
+      const p = new URLSearchParams(searchParams);
+      p.set("date", toUIDate(new Date()));
+      setSearchParams(p, { replace: true });
     }
-    const p = new URLSearchParams(searchParams);
-    p.set("date", toUIDate(new Date()));
-    setSearchParams(p, { replace: true });
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only on page load
   }, []);
 

--- a/apps/admin-ui/src/spa/my-units/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/my-units/[id]/index.tsx
@@ -1,8 +1,8 @@
-import React from "react";
+import React, { useRef } from "react";
 import styled from "styled-components";
 import { useTranslation } from "react-i18next";
 import { useParams, useSearchParams } from "react-router-dom";
-import { Button, ButtonVariant, Tabs } from "hds-react";
+import { Button, ButtonSize, ButtonVariant, Tabs } from "hds-react";
 import { Flex, H1, TabWrapper, TitleSection } from "common/styled";
 import { breakpoints } from "common/src/const";
 import { parseAddress } from "@/common/util";
@@ -54,7 +54,8 @@ export function MyUnitView() {
 
   const { unit } = data ?? {};
 
-  const { hasPermission: canCreateReservations } = useCheckPermission({
+  const createReservationBtnRef = useRef<HTMLButtonElement>(null);
+  const { hasPermission } = useCheckPermission({
     units: pk != null ? [pk] : [],
     permission: UserPermissionChoice.CanCreateStaffReservations,
   });
@@ -85,10 +86,25 @@ export function MyUnitView() {
     })
   );
 
+  const handleOpenModal = () => {
+    setModalContent(
+      <CreateReservationModal
+        start={new Date()}
+        focusAfterCloseRef={createReservationBtnRef}
+        reservationUnitOptions={reservationUnitOptions}
+        onClose={() => {
+          setModalContent(null);
+        }}
+      />
+    );
+  };
+
   const activeTab = selectedTab === "reservation-unit" ? 1 : 0;
 
   const title = loading ? t("common.loading") : (unit?.nameFi ?? "-");
   const location = unit?.location ? parseAddress(unit.location) : "-";
+  const canCreateReservations =
+    hasPermission && unit != null && reservationUnitOptions.length > 0;
   return (
     <>
       <TitleSection>
@@ -97,18 +113,10 @@ export function MyUnitView() {
       </TitleSection>
       <Flex $direction="row" $gap="m">
         <Button
+          ref={createReservationBtnRef}
           variant={ButtonVariant.Secondary}
-          onClick={() =>
-            setModalContent(
-              <CreateReservationModal
-                start={new Date()}
-                reservationUnitOptions={reservationUnitOptions}
-                onClose={() => {
-                  setModalContent(null);
-                }}
-              />
-            )
-          }
+          size={ButtonSize.Small}
+          onClick={handleOpenModal}
           disabled={!canCreateReservations}
         >
           {t("MyUnits.Calendar.header.createReservation")}

--- a/apps/admin-ui/src/spa/reservations/[id]/ReturnToRequiresHandlingDialog.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ReturnToRequiresHandlingDialog.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { type RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import { Button, ButtonVariant, Dialog, IconInfoCircle } from "hds-react";
 import {
@@ -15,10 +15,14 @@ type Props = {
   reservation: ReservationType;
   onClose: () => void;
   onAccept: () => void;
-  focusAfterCloseRef?: React.RefObject<HTMLButtonElement>;
+  focusAfterCloseRef: RefObject<HTMLButtonElement>;
 };
 
-function DialogContent({ reservation, onClose, onAccept }: Props) {
+function DialogContent({
+  reservation,
+  onClose,
+  onAccept,
+}: Omit<Props, "focusAfterCloseRef">): JSX.Element {
   const { t } = useTranslation();
   const displayError = useDisplayError();
 

--- a/apps/admin-ui/src/spa/unit/SpacesResources.tsx
+++ b/apps/admin-ui/src/spa/unit/SpacesResources.tsx
@@ -7,7 +7,7 @@ import { useSpacesResourcesQuery } from "@gql/gql-types";
 import { ResourcesTable } from "./ResourcesTable";
 import { SpacesTable } from "./SpacesTable";
 import { SubPageHead } from "./SubPageHead";
-import Modal, { useModal } from "@/component/HDSModal";
+import { HDSModal, useModal } from "@/component/HDSModal";
 import { NewSpaceModal } from "./space/new-space-modal/NewSpaceModal";
 import { NewResourceModal } from "./resource/NewResourceModal";
 import { base64encode } from "common/src/helpers";
@@ -74,18 +74,18 @@ function SpacesResources(): JSX.Element {
 
   return (
     <>
-      <Modal
+      <HDSModal
         id="space-modal"
-        open={newSpaceDialogIsOpen}
-        close={() => closeNewSpaceModal()}
-        afterCloseFocusRef={newSpacesButtonRef}
+        isOpen={newSpaceDialogIsOpen}
+        onClose={closeNewSpaceModal}
+        focusAfterCloseRef={newSpacesButtonRef}
       >
         <NewSpaceModal
           unit={unit}
           closeModal={() => closeNewSpaceModal()}
           refetch={refetch}
         />
-      </Modal>
+      </HDSModal>
       <LinkPrev />
       <SubPageHead title={t("Unit.spacesAndResources")} unit={unit} />
       <Flex
@@ -97,7 +97,7 @@ function SpacesResources(): JSX.Element {
         <ActionButton
           ref={newSpacesButtonRef}
           variant={ButtonVariant.Supplementary}
-          iconStart={<IconPlusCircleFill aria-hidden="true" />}
+          iconStart={<IconPlusCircleFill />}
           onClick={() => openNewSpaceModal()}
         >
           {t("Unit.addSpace")}
@@ -112,7 +112,7 @@ function SpacesResources(): JSX.Element {
         <H2 $noMargin>{t("Unit.resources")}</H2>
         <ActionButton
           variant={ButtonVariant.Supplementary}
-          iconStart={<IconPlusCircleFill aria-hidden="true" />}
+          iconStart={<IconPlusCircleFill />}
           disabled={unit.spaces.length === 0}
           onClick={() => {
             openWithContent(
@@ -129,14 +129,14 @@ function SpacesResources(): JSX.Element {
         </ActionButton>
       </Flex>
       <ResourcesTable unit={unit} refetch={refetch} />
-      <Modal
+      <HDSModal
         id="resource-modal"
-        open={isNewResourceModalOpen}
-        close={closeNewResourceModal}
-        afterCloseFocusRef={newResourceButtonRef}
+        isOpen={isNewResourceModalOpen}
+        onClose={closeNewResourceModal}
+        focusAfterCloseRef={newResourceButtonRef}
       >
         {modalContent}
-      </Modal>
+      </HDSModal>
     </>
   );
 }

--- a/apps/admin-ui/src/spa/unit/SpacesTable.tsx
+++ b/apps/admin-ui/src/spa/unit/SpacesTable.tsx
@@ -11,7 +11,7 @@ import {
   useDeleteSpaceMutation,
 } from "@gql/gql-types";
 import { PopupMenu } from "common/src/components/PopupMenu";
-import Modal, { useModal as useHDSModal } from "@/component/HDSModal";
+import { HDSModal, useModal as useHDSModal } from "@/component/HDSModal";
 import { NewSpaceModal } from "./space/new-space-modal/NewSpaceModal";
 import { errorToast } from "common/src/common/toast";
 import { CustomTable } from "@/component/Table";
@@ -215,14 +215,14 @@ export function SpacesTable({ unit, refetch }: IProps): JSX.Element {
         cols={cols}
         // no sort on purpose
       />
-      <Modal
+      <HDSModal
         id="modal-id"
-        open={isOpen}
-        close={closeModal}
-        afterCloseFocusRef={ref}
+        isOpen={isOpen}
+        onClose={closeModal}
+        focusAfterCloseRef={ref}
       >
         {modalContent}
-      </Modal>
+      </HDSModal>
       {spaceWaitingForDelete && (
         <ConfirmationDialog
           isOpen

--- a/apps/admin-ui/src/styles/variables.css
+++ b/apps/admin-ui/src/styles/variables.css
@@ -6,6 +6,7 @@
   --tilavaraus-admin-stack-notification: 801;
   --tilavaraus-admin-stack-popup-menu: 501;
   --tilavaraus-admin-stack-main-menu: 500;
+  --tilavaraus-admin-stack-calendar-pick-time-focus: 102;
   --tilavaraus-admin-stack-sticky-reservation-header: 101;
   --tilavaraus-admin-stack-select-over-calendar: 12;
   --tilavaraus-admin-stack-calendar-header-times: 11;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Add keyboard navigation (tab) to `my-unit` reservation calendar.
- Fix focus `my-units` start of page not calendar on first render.
- Fix refocus on modal close to the element the user used to open the modal (calendar cell or button). 
- Fix modal form responsiveness broken due to manual grid col span.
- Fix use small `44px` buttons for create reservation as per design.
- Fix include close button in the CreateReservation modal.
- Fix disable new reservation buttons if there are no reservation units.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manaul testing: check Jira ticket / original ticket.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4048](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4048)


[TILA-4048]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ