### PR TITLE
Use language selection and customer/admin in login url searchParams

### DIFF
--- a/apps/admin-ui/src/common/const.ts
+++ b/apps/admin-ui/src/common/const.ts
@@ -4,13 +4,6 @@ import { ApplicationStatusChoice } from "@gql/gql-types";
 export { isBrowser } from "common/src/helpers";
 export { getSignOutUrl } from "common/src/urlBuilder";
 
-export const defaultLanguage = "fi";
-
-// NOTE this is a dangerous variable, it does not change the frontend language
-// instead it changes the possible data translations saved to backend.
-// Changing it without changing the backend will break all form submits.
-export const languages = ["fi", "sv", "en"];
-
 export const PUBLIC_URL = env.NEXT_PUBLIC_BASE_URL ?? "";
 
 export const LIST_PAGE_SIZE = 50;
@@ -40,38 +33,6 @@ export const MAX_ALLOCATION_CARD_UNIT_NAME_LENGTH = 31;
 
 // TODO PUBLIC_URL should be cleaned up and always end in /
 export const HERO_IMAGE_URL = `${PUBLIC_URL}/hero-user@1x.jpg`;
-
-// Why?
-// not sure actually, since we are using the RAW PUBLIC_URL for static data
-// one reason is that localhost:3000 gets turned into localhost:3000/folder when returning from login
-// TODO move the url constructors to packages/common
-// TODO make this into utility function
-// TODO this seems overly complex for what it should be
-function getCleanPublicUrl() {
-  const publicUrl = PUBLIC_URL;
-  const hasPublicUrl = publicUrl !== "/" && publicUrl !== "";
-  // Remove the endslash, so folder/ => folder
-  const publicUrlNoSlash =
-    publicUrl && hasPublicUrl ? publicUrl.replace(/\/$/, "") : "";
-  // Add slash to the beginning so folder => /folder
-  const cleanPublicUrl = publicUrlNoSlash.startsWith("/")
-    ? publicUrlNoSlash
-    : `/${publicUrlNoSlash}`;
-  return cleanPublicUrl;
-}
-
-/// Returns href url for sign in dialog when given redirect url as parameter
-/// @returns url to sign in dialog
-/// TODO use the common version in urlBuilder.ts (missing the publicUrl option)
-export function getSignInUrl(apiBaseUrl: string, callBackUrl: string): string {
-  const authUrl = `${apiBaseUrl}/helauth/`;
-  if (callBackUrl.includes(`/logout`)) {
-    const baseUrl = new URL(callBackUrl).origin;
-    const cleanPublicUrl = getCleanPublicUrl();
-    return `${authUrl}login?next=${baseUrl}${cleanPublicUrl}`;
-  }
-  return `${authUrl}login?next=${callBackUrl}`;
-}
 
 export const VALID_ALLOCATION_APPLICATION_STATUSES = [
   ApplicationStatusChoice.Received,

--- a/apps/admin-ui/src/component/MainLander.tsx
+++ b/apps/admin-ui/src/component/MainLander.tsx
@@ -7,6 +7,7 @@ import { fontBold, H2 } from "common/styled";
 import { breakpoints } from "common/src/const";
 import { HERO_IMAGE_URL } from "@/common/const";
 import { KorosHeading, Heading } from "./KorosHeading";
+import { getLocalizationLang } from "common/src/helpers";
 
 const LoginBtn = styled(Button)`
   --background-color: var(--color-white);
@@ -41,8 +42,8 @@ const Ingress = styled(H2)`
   line-height: 1.8125rem;
 `;
 
-export function MainLander({ apiBaseUrl }: { apiBaseUrl: string }) {
-  const { t } = useTranslation();
+export function MainLander({ apiBaseUrl }: Readonly<{ apiBaseUrl: string }>) {
+  const { t, i18n } = useTranslation();
 
   return (
     <>
@@ -51,7 +52,13 @@ export function MainLander({ apiBaseUrl }: { apiBaseUrl: string }) {
         <LoginBtn
           iconStart={<IconGroup />}
           iconEnd={<IconArrowRight />}
-          onClick={() => signIn(apiBaseUrl)}
+          onClick={() =>
+            signIn({
+              apiBaseUrl,
+              language: getLocalizationLang(i18n.language),
+              client: "admin",
+            })
+          }
         >
           {t("Navigation.login")}
         </LoginBtn>

--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -28,6 +28,7 @@ import {
   singleUnitUrl,
 } from "@/common/urls";
 import { UserPermissionChoice } from "@gql/gql-types";
+import { getLocalizationLang } from "common/src/helpers";
 
 type Props = {
   apiBaseUrl: string;
@@ -260,7 +261,7 @@ function NavigationLink({
   );
 }
 const Navigation = ({ apiBaseUrl }: Props) => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { user } = useSession();
   const firstName = user?.firstName?.trim() ?? "";
   const lastName = user?.lastName?.trim() ?? "";
@@ -310,7 +311,13 @@ const Navigation = ({ apiBaseUrl }: Props) => {
         ) : (
           <Header.ActionBarButton
             label={t("Navigation.login")}
-            onClick={() => signIn(apiBaseUrl)}
+            onClick={() =>
+              signIn({
+                apiBaseUrl,
+                language: getLocalizationLang(i18n.language),
+                client: "admin",
+              })
+            }
           />
         )}
       </ActionBar>

--- a/apps/ui/components/LoginFragment.tsx
+++ b/apps/ui/components/LoginFragment.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "next-i18next";
 import { signIn } from "common/src/browserHelpers";
 import { useSession } from "@/hooks/auth";
 import { Button, ButtonSize } from "hds-react";
+import { getLocalizationLang } from "common/src/helpers";
 
 type Props = {
   apiBaseUrl: string;
@@ -18,13 +19,18 @@ export function LoginFragment({
   isActionDisabled,
   returnUrl,
   type,
-}: Props): JSX.Element {
+}: Readonly<Props>): JSX.Element {
   // TODO pass the isAuthenticated from SSR and remove the hook
   const { isAuthenticated } = useSession();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const handleClick = () => {
-    signIn(apiBaseUrl, returnUrl);
+    signIn({
+      apiBaseUrl,
+      language: getLocalizationLang(i18n.language),
+      client: "customer",
+      returnUrl,
+    });
   };
 
   if (isAuthenticated) {

--- a/apps/ui/components/application/ApprovedReservations.tsx
+++ b/apps/ui/components/application/ApprovedReservations.tsx
@@ -41,8 +41,8 @@ import {
   getLocalizationLang,
   sort,
   toNumber,
-  type LocalizationLanguages,
 } from "common/src/helpers";
+import type { LocalizationLanguages } from "common/src/urlBuilder";
 import {
   Button,
   ButtonSize,

--- a/apps/ui/components/common/Navigation.tsx
+++ b/apps/ui/components/common/Navigation.tsx
@@ -248,7 +248,7 @@ function ActionBar({
   profileLink,
   languageOptions,
 }: Readonly<HeaderProps>) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { isAuthenticated, user } = useSession();
   const { firstName, lastName } = user ?? {};
 
@@ -299,7 +299,12 @@ function ActionBar({
           label={t("common:login")}
           onClick={(e) => {
             e.preventDefault();
-            signIn(apiBaseUrl);
+            signIn({
+              apiBaseUrl,
+              language: getLocalizationLang(i18n.language),
+              returnUrl: window.location.href,
+              client: "customer",
+            });
           }}
           id="login"
           icon={<IconKey />}

--- a/apps/ui/components/reservation-unit/AddressSection.tsx
+++ b/apps/ui/components/reservation-unit/AddressSection.tsx
@@ -14,7 +14,7 @@ import {
   convertLanguageCode,
   getTranslationSafe,
 } from "common/src/common/util";
-import { type LocalizationLanguages } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import { gql } from "@apollo/client";
 
 const AddressSpan = styled.span`

--- a/apps/ui/components/reservation/ReservationCancellation.tsx
+++ b/apps/ui/components/reservation/ReservationCancellation.tsx
@@ -20,7 +20,7 @@ import { useDisplayError } from "common/src/hooks";
 import { getApplicationPath, getReservationPath } from "@/modules/urls";
 import { getPrice } from "@/modules/reservationUnit";
 import { formatDateTimeStrings } from "@/modules/util";
-import { LocalizationLanguages } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import { useRouter } from "next/router";
 import { type CancelFormValues, CancellationForm } from "../CancellationForm";
 import { Card } from "common/src/components";

--- a/apps/ui/components/reservation/ReservationInfoSection.tsx
+++ b/apps/ui/components/reservation/ReservationInfoSection.tsx
@@ -1,6 +1,6 @@
 import { gql } from "@apollo/client";
 import { useTranslation } from "next-i18next";
-import { LocalizationLanguages } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import {
   type ReservationMetadataFieldNode,
   type ReservationInfoFragment,

--- a/apps/ui/middleware.ts
+++ b/apps/ui/middleware.ts
@@ -8,8 +8,12 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import { env } from "@/env.mjs";
-import { getSignInUrl, buildGraphQLUrl } from "common/src/urlBuilder";
-import { base64encode, type LocalizationLanguages } from "common/src/helpers";
+import {
+  getSignInUrl,
+  buildGraphQLUrl,
+  type LocalizationLanguages,
+} from "common/src/urlBuilder";
+import { base64encode, getLocalizationLang } from "common/src/helpers";
 import { ReservationStateChoice, ReservationTypeChoice } from "./gql/gql-types";
 import { getReservationInProgressPath } from "./modules/urls";
 
@@ -389,7 +393,13 @@ function getRedirectProtectedRoute(
     const protocol = headers.get("x-forwarded-proto") ?? "http";
     const host = headers.get("x-forwarded-host") ?? url.host;
     const origin = `${protocol}://${host}`;
-    return getSignInUrl(apiBaseUrl, url.pathname, origin);
+    return getSignInUrl({
+      apiBaseUrl,
+      callBackUrl: url.pathname,
+      language: getLocalizationLang(getLocalizationFromUrl(url)),
+      originOverride: origin,
+      client: "customer",
+    });
   }
   return null;
 }

--- a/apps/ui/modules/applicationRound.ts
+++ b/apps/ui/modules/applicationRound.ts
@@ -1,7 +1,8 @@
 import { type ApplicationRoundNode } from "common/gql/gql-types";
 import { type Maybe } from "@/gql/gql-types";
 import { getTranslationSafe } from "common/src/common/util";
-import type { LocalizationLanguages, ReadonlyDeep } from "common/src/helpers";
+import type { ReadonlyDeep } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 
 type ApplicationRoundType =
   | Maybe<

--- a/apps/ui/modules/reservationUnit.ts
+++ b/apps/ui/modules/reservationUnit.ts
@@ -58,9 +58,9 @@ import {
   timeToMinutes,
   filterNonNullable,
   isPriceFree,
-  type LocalizationLanguages,
   type ReadonlyDeep,
 } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import { type TFunction } from "i18next";
 
 function formatTimeObject(time: { h: number; m: number }): string {

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -5,8 +5,8 @@ import {
   getLocalizationLang,
   ignoreMaybeArray,
   toNumber,
-  type LocalizationLanguages,
 } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import {
   EquipmentOrderingChoices,
   OptionsDocument,

--- a/apps/ui/modules/util.ts
+++ b/apps/ui/modules/util.ts
@@ -6,11 +6,8 @@ import {
   fromUIDate,
 } from "common/src/common/util";
 import { isBrowser } from "./const";
-import {
-  formatMinutes,
-  timeToMinutes,
-  type LocalizationLanguages,
-} from "common/src/helpers";
+import { formatMinutes, timeToMinutes } from "common/src/helpers";
+import { type LocalizationLanguages } from "common/src/urlBuilder";
 import { ReadonlyURLSearchParams } from "next/navigation";
 
 export { formatDuration } from "common/src/common/util";

--- a/packages/common/src/browserHelpers.ts
+++ b/packages/common/src/browserHelpers.ts
@@ -1,6 +1,11 @@
 import { z } from "zod";
 import { isBrowser } from "./helpers";
-import { getSignOutUrl, getSignInUrl } from "./urlBuilder";
+import {
+  getSignOutUrl,
+  getSignInUrl,
+  type LocalizationLanguages,
+  type UserTypeChoice,
+} from "./urlBuilder";
 import { getCookie } from "typescript-cookie";
 
 // TODO add wrapper a that blocks importing on nodejs
@@ -16,15 +21,29 @@ function cleanupUrlParam(url: unknown): string | undefined {
 // Redirect the user to the sign in dialog and return to returnUrl (or
 // current url if none is provided) after sign in
 /// Thows if called on the server
-export function signIn(apiBaseUrl: string, returnUrl?: unknown) {
+export function signIn({
+  apiBaseUrl,
+  language,
+  client,
+  returnUrl,
+}: {
+  apiBaseUrl: string;
+  language: LocalizationLanguages;
+  client: UserTypeChoice;
+  returnUrl?: unknown;
+}) {
   if (!isBrowser) {
     throw new Error("signIn can only be called in the browser");
   }
   const returnUrlParam = cleanupUrlParam(returnUrl);
   // encode otherwise backend will drop the query params
-  const returnTo = encodeURIComponent(returnUrlParam ?? window.location.href);
-  const url = getSignInUrl(apiBaseUrl, returnTo);
-  window.location.href = url;
+  const returnTo = returnUrlParam ?? window.location.href;
+  window.location.href = getSignInUrl({
+    apiBaseUrl,
+    language,
+    callBackUrl: returnTo,
+    client,
+  });
 }
 
 function removeTrailingSlash(url: string): string {

--- a/packages/common/src/calendar/Calendar.tsx
+++ b/packages/common/src/calendar/Calendar.tsx
@@ -20,7 +20,7 @@ import withDragAndDrop from "react-big-calendar/lib/addons/dragAndDrop";
 import "react-big-calendar/lib/css/react-big-calendar.css";
 import "react-big-calendar/lib/addons/dragAndDrop/styles.css";
 import { parseDate } from "../common/util";
-import { LocalizationLanguages } from "../helpers";
+import type { LocalizationLanguages } from "../urlBuilder";
 
 export type CalendarEvent<T> = {
   title?: string;

--- a/packages/common/src/components/statuses/ApplicationStatusLabel.tsx
+++ b/packages/common/src/components/statuses/ApplicationStatusLabel.tsx
@@ -12,8 +12,7 @@ import { ApplicationStatusChoice, type Maybe } from "../../../gql/gql-types";
 import { type StatusLabelType } from "../../tags";
 import StatusLabel from "../StatusLabel";
 import { useTranslation } from "next-i18next";
-
-export type UserTypeChoice = "customer" | "admin";
+import type { UserTypeChoice } from "../../urlBuilder";
 
 function getAdminApplicationStatusLabelProps(status: ApplicationStatusChoice): {
   type: StatusLabelType;

--- a/packages/common/src/helpers.ts
+++ b/packages/common/src/helpers.ts
@@ -8,6 +8,7 @@ import {
 import { type OptionInProps } from "hds-react";
 import { pixel } from "./const";
 import { type TFunction } from "i18next";
+import { type LocalizationLanguages } from "./urlBuilder";
 
 /// Enforce readonly on all nested properties
 /// only single level deep i.e. {a: {b: {c: string}}} -> {readonly a: {b: {c: string}}}
@@ -82,8 +83,6 @@ export const fromMondayFirstUnsafe = (day: number) => {
 
 export const fromMondayFirst = (day: 0 | 1 | 2 | 3 | 4 | 5 | 6) =>
   day === 6 ? 0 : day + 1;
-
-export type LocalizationLanguages = "fi" | "sv" | "en";
 
 export function getLocalizationLang(code?: string): LocalizationLanguages {
   if (code?.startsWith("fi")) {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Sets `ui` to "customer"/"admin" depending on who is logging in
- Sets `lang` as "fi"/"sv"/"en" based on the customer language selection
- Leaves `lang` unset for admin login, to allow for possible browser settings

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3565](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3565)
- [TILA-3566](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3566)
- [TILA-3567](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3567)
- [TILA-3566](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3566)
- [TILA-3569](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3569)

[TILA-3565]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3566]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3567]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3566]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3569]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ