### PR TITLE
Fix series and section `update_access_code_is_active` logic

### DIFF
--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_update_access_code_is_active.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_update_access_code_is_active.py
@@ -8,6 +8,7 @@ import pytest
 from tilavarauspalvelu.enums import AccessType, ReservationStateChoice, ReservationTypeChoice
 from tilavarauspalvelu.integrations.keyless_entry import PindoraService
 from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraNotFoundError
+from tilavarauspalvelu.integrations.keyless_entry.typing import PindoraAccessCodeModifyResponse
 from utils.date_utils import local_datetime
 
 from tests.factories import ApplicationSectionFactory, RecurringReservationFactory, ReservationFactory, UserFactory
@@ -135,6 +136,13 @@ def test_update_access_code_is_active__reservation__not_found():
     assert reservation.access_code_generated_at is None
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -154,11 +162,45 @@ def test_update_access_code_is_active__series__active_when_should_be_inactive():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is True
     assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == series
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__series__active_when_should_be_inactive__already_inactive_in_pindora():
+    series = RecurringReservationFactory.create()
+    ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 12),
+        end=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -178,10 +220,18 @@ def test_update_access_code_is_active__series__active_when_should_be_active():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -201,11 +251,45 @@ def test_update_access_code_is_active__series__inactive_when_should_be_active():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is True
     assert PindoraService.activate_access_code.call_args.kwargs["obj"] == series
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__series__inactive_when_should_be_active__already_active_in_pindora():
+    series = RecurringReservationFactory.create()
+    ReservationFactory.create(
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 12),
+        end=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.NORMAL,
+        access_code_is_active=False,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -225,10 +309,12 @@ def test_update_access_code_is_active__series__inactive_when_should_be_inactive(
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("not found"))
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -248,15 +334,22 @@ def test_update_access_code_is_active__series__not_found():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
-    assert PindoraService.deactivate_access_code.called is True
-    assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == series
+    assert PindoraService.deactivate_access_code.called is False
 
     reservation.refresh_from_db()
     assert reservation.access_code_is_active is False
     assert reservation.access_code_generated_at is None
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -283,11 +376,52 @@ def test_update_access_code_is_active__seasonal_booking__active_when_should_be_i
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is True
     assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == section
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__seasonal_booking__active_when_should_be_inactive__already_inactive_in_pindora():
+    user = UserFactory.create()
+    section = ApplicationSectionFactory.create(
+        application__user=user,
+    )
+    series = RecurringReservationFactory.create(
+        allocated_time_slot__reservation_unit_option__application_section=section
+    )
+    ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 12),
+        end=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -314,10 +448,18 @@ def test_update_access_code_is_active__seasonal_booking__active_when_should_be_a
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -344,11 +486,52 @@ def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is True
     assert PindoraService.activate_access_code.call_args.kwargs["obj"] == section
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be_active__already_active_in_pindora():
+    user = UserFactory.create()
+    section = ApplicationSectionFactory.create(
+        application__user=user,
+    )
+    series = RecurringReservationFactory.create(
+        allocated_time_slot__reservation_unit_option__application_section=section
+    )
+    ReservationFactory.create(
+        user=user,
+        reservation_units=[series.reservation_unit],
+        recurring_reservation=series,
+        begin=local_datetime(2024, 1, 1, 12),
+        end=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.NORMAL,
+        access_code_is_active=False,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -375,10 +558,12 @@ def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("not found"))
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -405,9 +590,9 @@ def test_update_access_code_is_active__seasonal_booking__not_found():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
-    assert PindoraService.deactivate_access_code.called is True
-    assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == section
+    assert PindoraService.deactivate_access_code.called is False
 
     reservation.refresh_from_db()
     assert reservation.access_code_is_active is False


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Run reschedule in access code active status update to cover situations where access type changes from access code to something else in the middle of a series. In this case, some validity times should be removed, but the core remains active, so no email should be sent.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
