### PR TITLE
Add due date&payment status

### DIFF
--- a/apps/admin-ui/src/common/fragments.tsx
+++ b/apps/admin-ui/src/common/fragments.tsx
@@ -83,6 +83,7 @@ export const RESERVATION_COMMON_FRAGMENT = gql`
     paymentOrder {
       id
       status
+      handledPaymentDueBy
     }
     user {
       id

--- a/apps/admin-ui/src/component/DenyDialog.tsx
+++ b/apps/admin-ui/src/component/DenyDialog.tsx
@@ -68,13 +68,13 @@ function convertToReturnState(
   >
 ): ReturnAllowedState {
   const { price, paymentOrder, begin } = reservation;
-  const order = paymentOrder[0] ?? null;
+
   const paid = {
     price: toNumber(price) ?? 0,
-    orderStatus: order?.status ?? null,
-    orderUuid: order?.orderUuid ?? null,
-    refundUuid: order?.refundUuid ?? null,
-    begin: begin,
+    orderStatus: paymentOrder?.status ?? null,
+    orderUuid: paymentOrder?.orderUuid ?? null,
+    refundUuid: paymentOrder?.refundUuid ?? null,
+    begin,
   };
 
   if (paid.refundUuid != null) {

--- a/apps/admin-ui/src/i18n/index.ts
+++ b/apps/admin-ui/src/i18n/index.ts
@@ -52,7 +52,9 @@ i18n.addResourceBundle("fi", "common", {
   cancel: "Peruuta",
   remove: "Poista",
   scrollToTop: "Siirry ylös",
+  helsinkiCity: ["Helsingin kaupunki"],
 });
+i18n.addResourceBundle("fi", "navigation", { navigation: "Päävalikko" });
 i18n.addResourceBundle("en", "common", {
   day: "Day",
   week: "Week",

--- a/apps/admin-ui/src/i18n/messages.ts
+++ b/apps/admin-ui/src/i18n/messages.ts
@@ -1948,6 +1948,7 @@ const translations: ITranslations = {
     showBirthDate: ["Näytä"],
     alreadyEnded: ["Päättynyt"],
     keylessEntryHeader: ["Avaimeton kulku"],
+    dueByParenthesis: ["(määräaika {{date}})"],
     DenyDialog: {
       reject: ["Hylkää varaus"],
       denyReason: ["Hylkäyksen syy"],

--- a/apps/admin-ui/src/spa/reservations/ReservationsTable.tsx
+++ b/apps/admin-ui/src/spa/reservations/ReservationsTable.tsx
@@ -144,14 +144,13 @@ const getColConfig = (t: TFunction): ReservationTableColumn[] => [
     key: "orderStatus",
     isSortable: true,
     transform: ({ paymentOrder }: ReservationTableElementFragment) => {
-      const order = paymentOrder?.[0];
-      if (!order) {
+      if (!paymentOrder) {
         return "-";
       }
-      const labelType = getPaymentStatusLabelType(order.status);
+      const labelType = getPaymentStatusLabelType(paymentOrder.status);
       return (
         <StatusLabel type={labelType} icon={<IconEuroSign />} slim>
-          {t(`Payment.status.${order.status}`)}
+          {t(`Payment.status.${paymentOrder.status}`)}
         </StatusLabel>
       );
     },

--- a/apps/admin-ui/src/spa/reservations/[id]/ApprovalButtons.test.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ApprovalButtons.test.tsx
@@ -36,7 +36,7 @@ function createInput({
     state,
     begin: end.toISOString(),
     end: end.toISOString(),
-    paymentOrder: [],
+    paymentOrder: null,
     recurringReservation: null,
     reservationUnits: [],
     price: null,

--- a/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/ReservationTitleSection.tsx
@@ -92,8 +92,9 @@ const ReservationTitleSection = forwardRef<HTMLDivElement, Props>(
         ?.applicationSection?.pk;
     const applicationLink = getApplicationUrl(applicationPk, sectionPk);
 
-    const order = reservation.paymentOrder[0];
-    const paymentStatusLabelType = getStatusLabelType(order?.status);
+    const paymentStatusLabelType = getStatusLabelType(
+      reservation.paymentOrder?.status
+    );
     const reservationState = getReservationStateLabelProps(reservation.state);
 
     return (
@@ -101,13 +102,13 @@ const ReservationTitleSection = forwardRef<HTMLDivElement, Props>(
         <TitleSection $noMargin={noMargin} ref={ref}>
           <H1 $noMargin>{overrideTitle ?? getName(reservation, t)}</H1>
           <Flex $direction="row" $alignItems="center">
-            {order?.status != null && (
+            {reservation.paymentOrder?.status != null && (
               <StatusLabel
                 type={paymentStatusLabelType}
                 data-testid="reservation_title_section__order_status"
                 icon={<IconEuroSign aria-hidden="true" />}
               >
-                {t(`Payment.status.${order?.status}`)}
+                {t(`Payment.status.${reservation.paymentOrder?.status}`)}
               </StatusLabel>
             )}
             {reservation.state && (

--- a/apps/admin-ui/src/spa/reservations/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/index.tsx
@@ -275,7 +275,6 @@ function ReservationPricingDetailsAccordion({
   reservation: ReservationType;
 }>) {
   const { t } = useTranslation();
-  const order = reservation.paymentOrder.find(() => true);
 
   return (
     <Accordion
@@ -287,7 +286,9 @@ function ReservationPricingDetailsAccordion({
           {reservation.price && reservationPrice(reservation, t)}
         </DataWrapper>
         <DataWrapper label={t("RequestedReservation.paymentState")}>
-          {order?.status == null ? "-" : t(`Payment.status.${order?.status}`)}
+          {reservation.paymentOrder?.status == null
+            ? "-"
+            : t(`Payment.status.${reservation.paymentOrder?.status}`)}
         </DataWrapper>
         <DataWrapper label={t("RequestedReservation.applyingForFreeOfCharge")}>
           {t(

--- a/apps/admin-ui/src/spa/reservations/[id]/index.tsx
+++ b/apps/admin-ui/src/spa/reservations/[id]/index.tsx
@@ -33,6 +33,7 @@ import { Accordion, DataWrapper } from "./components";
 import { ReservationKeylessEntry } from "./ReservationKeylessEntrySection";
 import { TimeBlockSection } from "./ReservationTimeBlockSection";
 import { ReservationReserveeDetailsSection } from "@/spa/reservations/[id]/ReservationReserveeDetailsSection";
+import { toUIDateTime } from "common/src/common/util";
 
 type ReservationType = NonNullable<ReservationPageQuery["reservation"]>;
 
@@ -125,6 +126,14 @@ function ReservationSummary({
       {!isFree && (
         <DataWrapper isSummary label={t("RequestedReservation.price")}>
           {`${reservationPrice(reservation, t)}${
+            reservation.paymentOrder?.handledPaymentDueBy
+              ? ` ${t("RequestedReservation.dueByParenthesis", {
+                  date: toUIDateTime(
+                    new Date(reservation.paymentOrder?.handledPaymentDueBy)
+                  ),
+                })}`
+              : ""
+          }${
             reservation.applyingForFreeOfCharge
               ? `, ${t("RequestedReservation.appliesSubvention")}`
               : ""

--- a/apps/admin-ui/src/spa/reservations/hooks/__test__/mocks.ts
+++ b/apps/admin-ui/src/spa/reservations/hooks/__test__/mocks.ts
@@ -81,7 +81,7 @@ function createReservation({
   return {
     bufferTimeAfter: 0,
     bufferTimeBefore: 0,
-    paymentOrder: [],
+    paymentOrder: null,
     reservationUnits: [],
     type: ReservationTypeChoice.Behalf,
     handlingDetails: null,

--- a/apps/ui/components/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/UnpaidReservationNotification.tsx
@@ -50,8 +50,7 @@ function ReservationNotification({
   disabled?: boolean;
   isLoading?: boolean;
 }) {
-  const order = reservation.paymentOrder.find(() => true);
-  const startRemainingMinutes = order?.expiresInMinutes;
+  const startRemainingMinutes = reservation.paymentOrder?.expiresInMinutes;
   const [remainingMinutes, setRemainingMinutes] = useState(
     startRemainingMinutes
   );
@@ -175,8 +174,10 @@ export function InProgressReservationNotification() {
   const [deleteReservation, { loading: isDeleteLoading }] =
     useDeleteReservationMutation();
 
-  const order = unpaidReservation?.paymentOrder[0];
-  const checkoutUrl = getCheckoutUrl(order, i18n.language);
+  const checkoutUrl = getCheckoutUrl(
+    unpaidReservation?.paymentOrder,
+    i18n.language
+  );
 
   // Lazy minimal query to check if the reservation is still valid
   const [reservationQ] = useReservationStateLazyQuery({

--- a/apps/ui/modules/reservation.test.ts
+++ b/apps/ui/modules/reservation.test.ts
@@ -266,12 +266,10 @@ function createReservationOrderStatusFragment({
   return {
     id: base64encode("ReservationNode:1"),
     state,
-    paymentOrder: [
-      {
-        id: base64encode("PaymentOrderNode:1"),
-        status: orderStatus,
-      },
-    ],
+    paymentOrder: {
+      id: base64encode("PaymentOrderNode:1"),
+      status: orderStatus,
+    },
   };
 }
 

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -223,7 +223,7 @@ export function getNormalizedReservationOrderStatus(
   }
 
   if (shouldShowOrderStatus(reservation.state)) {
-    return reservation.paymentOrder[0]?.status ?? null;
+    return reservation.paymentOrder?.status ?? null;
   }
 
   return null;

--- a/apps/ui/pages/reservations/[id]/confirmation.tsx
+++ b/apps/ui/pages/reservations/[id]/confirmation.tsx
@@ -122,7 +122,6 @@ function Actions({
   >;
 }) {
   const { t, i18n } = useTranslation();
-  const order = reservation.paymentOrder.find(() => true);
 
   // Reservation can be in either RequiresHandling or Confirmed state on this page
   if (reservation.state !== ReservationStateChoice.Confirmed) {
@@ -141,11 +140,14 @@ function Actions({
         {t("reservations:saveToCalendar")}
         <IconCalendar />
       </ButtonLikeExternalLink>
-      {order?.receiptUrl && (
+      {reservation.paymentOrder?.receiptUrl && (
         <Button
           data-testid="reservation__confirmation--button__receipt-link"
           onClick={() =>
-            window.open(`${order.receiptUrl}&lang=${i18n.language}`, "_blank")
+            window.open(
+              `${reservation.paymentOrder?.receiptUrl}&lang=${i18n.language}`,
+              "_blank"
+            )
           }
           variant={ButtonVariant.Secondary}
           iconEnd={<IconLinkExternal />}

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -319,7 +319,6 @@ function Reservation({
   const pindoraInfo = accessCodeData?.reservation?.pindoraInfo ?? null;
 
   // NOTE typescript can't type array off index
-  const order = reservation.paymentOrder.find(() => true);
   const reservationUnit = reservation.reservationUnits.find(() => true);
 
   const modifyTimeReason = getWhyReservationCantBeChanged(reservation);
@@ -352,7 +351,7 @@ function Reservation({
   const isCancellable = isReservationCancellable(reservation);
 
   const lang = convertLanguageCode(i18n.language);
-  const checkoutUrl = getCheckoutUrl(order, lang);
+  const checkoutUrl = getCheckoutUrl(reservation.paymentOrder, lang);
 
   const hasCheckoutUrl = !!checkoutUrl;
   const isWaitingForPayment =
@@ -369,10 +368,10 @@ function Reservation({
   ] as const;
 
   const hasReceipt =
-    order?.receiptUrl &&
-    (order.status === OrderStatus.Paid ||
-      order.status === OrderStatus.Refunded ||
-      order.status === OrderStatus.PaidByInvoice);
+    reservation.paymentOrder?.receiptUrl &&
+    (reservation.paymentOrder?.status === OrderStatus.Paid ||
+      reservation.paymentOrder?.status === OrderStatus.Refunded ||
+      reservation.paymentOrder?.status === OrderStatus.PaidByInvoice);
 
   return (
     <>
@@ -443,7 +442,7 @@ function Reservation({
               <ButtonLikeExternalLink
                 size="large"
                 data-testid="reservation__confirmation--button__receipt-link"
-                href={`${order.receiptUrl}&lang=${lang}`}
+                href={`${reservation.paymentOrder?.receiptUrl}&lang=${lang}`}
                 target="_blank"
               >
                 {t("reservations:downloadReceipt")}

--- a/packages/common/src/common/util.ts
+++ b/packages/common/src/common/util.ts
@@ -121,6 +121,22 @@ export function toUIDate(date: Date | null, formatStr = "d.M.yyyy"): string {
   }
 }
 
+// Returns a string in "d.M.yyyy klo hh:mm" format from a Date object
+// TODO returning undefined would be preferably (specificity) but breaks the users of this function
+export function toUIDateTime(
+  date: Date | null,
+  formatStr = "d.M.yyyy"
+): string {
+  if (!date || !isValidDate(date)) {
+    return "";
+  }
+  try {
+    return `${format(date, formatStr, { locale: fi })} klo ${format(date, "hh:mm", { locale: fi })}`;
+  } catch (_) {
+    return "";
+  }
+}
+
 export const chunkArray = <T>(array: T[], size: number): T[][] => {
   const result = [];
   let index = 0;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Adds due date display to admin reservation view
- makes `reservation.paymentOrder` a singular object in stead of an array (0-n -> 0-1)
- fixes two annoying i18n errors showing up on the admin side, due to missing translation keys

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4028](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4028)
- [TILA-4033](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4033)
- [TILA-3811](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3811)


[TILA-4028]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-4033]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TILA-3811]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ