### PR TITLE
Fix Hauki resource update too long URI

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -364,6 +364,7 @@ class Common(Environment):
     HAUKI_SECRET = values.StringValue()
     HAUKI_API_KEY = values.StringValue()
     HAUKI_DAYS_TO_FETCH = 730  # 2 years
+    HAUKI_RESOURCE_BATCH_SIZE = values.IntegerValue(default=500)
 
     # --- Verkkokauppa settings --------------------------------------------------------------------------------------
 
@@ -519,7 +520,7 @@ class Common(Environment):
     EXPORT_AUTHORIZATION_TOKEN = values.StringValue()
 
     GRAPHENE_DJANGO_EXTENSIONS = {
-      "EXPERIMENTAL_REMOVE_TRANSLATION_BASE_FIELDS": True,
+        "EXPERIMENTAL_REMOVE_TRANSLATION_BASE_FIELDS": True,
     }
 
     # Allows faking membership to certain AD groups for testing automatic role assignment

--- a/backend/tests/factories/__init__.py
+++ b/backend/tests/factories/__init__.py
@@ -13,6 +13,7 @@ from .city import CityFactory
 from .equipment import EquipmentFactory
 from .equipment_category import EquipmentCategoryFactory
 from .general_role import GeneralRoleFactory
+from .hauki import HaukiAPIResourceFactory, HaukiAPIResourceListResponseFactory
 from .location import LocationFactory
 from .organisation import OrganisationFactory
 from .origin_hauki_resource import OriginHaukiResourceFactory
@@ -65,6 +66,8 @@ __all__ = [
     "EquipmentCategoryFactory",
     "EquipmentFactory",
     "GeneralRoleFactory",
+    "HaukiAPIResourceFactory",
+    "HaukiAPIResourceListResponseFactory",
     "LocationFactory",
     "OrderCustomerFactory",
     "OrderFactory",

--- a/backend/tests/factories/hauki.py
+++ b/backend/tests/factories/hauki.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import factory
+
+from tilavarauspalvelu.integrations.opening_hours.hauki_api_types import (
+    HaukiAPIOrigin,
+    HaukiAPIResource,
+    HaukiAPIResourceListResponse,
+    HaukiDataSource,
+    HaukiTranslatedField,
+)
+
+from ._base import GenericListFactory, ValidatedGenericFactory
+
+__all__ = [
+    "HaukiAPIOriginFactory",
+    "HaukiAPIResourceFactory",
+    "HaukiAPIResourceListResponseFactory",
+    "HaukiDataSourceFactory",
+    "HaukiTranslatedFieldFactory",
+]
+
+
+class HaukiTranslatedFieldFactory(ValidatedGenericFactory[HaukiTranslatedField]):
+    class Meta:
+        model = HaukiTranslatedField
+
+    fi = "fi"
+    sv = "sv"
+    en = "en"
+
+
+class HaukiDataSourceFactory(ValidatedGenericFactory[HaukiDataSource]):
+    class Meta:
+        model = HaukiDataSource
+
+    id = ""
+    name = factory.SubFactory(HaukiTranslatedFieldFactory)
+
+
+class HaukiAPIOriginFactory(ValidatedGenericFactory[HaukiAPIOrigin]):
+    class Meta:
+        model = HaukiAPIOrigin
+
+    origin_id = ""
+    data_source = factory.SubFactory(HaukiDataSourceFactory)
+
+
+class HaukiAPIResourceFactory(ValidatedGenericFactory[HaukiAPIResource]):
+    class Meta:
+        model = HaukiAPIResource
+
+    id = factory.Sequence(lambda n: n)
+    name = factory.SubFactory(HaukiTranslatedFieldFactory)
+    description = factory.SubFactory(HaukiTranslatedFieldFactory)
+    address = factory.SubFactory(HaukiTranslatedFieldFactory)
+    resource_type = ""
+    children: list[int] = []
+    parents: list[int] = []
+    organization = "org"
+    origins = GenericListFactory(HaukiAPIOriginFactory)
+    last_modified_by = None
+    created = "2021-11-10T16:49:49.025469+02:00"
+    modified = "2023-09-13T06:04:34.051926+03:00"
+    extra_data: dict[str, str] = {}
+    is_public = True
+    timezone = "Europe/Helsinki"
+    date_periods_hash = ""
+    date_periods_as_text = ""
+
+
+class HaukiAPIResourceListResponseFactory(ValidatedGenericFactory[HaukiAPIResourceListResponse]):
+    class Meta:
+        model = HaukiAPIResourceListResponse
+
+    count = 0
+    next = None
+    previous = None
+    results = GenericListFactory(HaukiAPIResourceFactory)

--- a/backend/tests/test_integrations/test_hauki/test_hauki_api_client.py
+++ b/backend/tests/test_integrations/test_hauki/test_hauki_api_client.py
@@ -1,35 +1,66 @@
 from __future__ import annotations
 
+from copy import deepcopy
+
 from tilavarauspalvelu.integrations.opening_hours.hauki_api_client import HaukiAPIClient
 
+from tests.factories import HaukiAPIResourceListResponseFactory
 from tests.helpers import ResponseMock, patch_method
 
 
-@patch_method(HaukiAPIClient.get_resources, return_value={"results": ["foo"]})
+@patch_method(HaukiAPIClient.get)
 def test__HaukiAPIClient__get_resources_all_pages__single_page():
+    data = HaukiAPIResourceListResponseFactory.create()
+
+    HaukiAPIClient.get.return_value = ResponseMock(status_code=200, json_data=deepcopy(data))
+
     fetched_hauki_resources = HaukiAPIClient.get_resources_all_pages(hauki_resource_ids=[1])
 
-    assert HaukiAPIClient.get_resources.call_count == 1
-    assert fetched_hauki_resources == ["foo"]
+    assert HaukiAPIClient.get.call_count == 1
+    assert fetched_hauki_resources == data["results"]
 
 
-@patch_method(
-    HaukiAPIClient.get,
-    side_effect=[
-        ResponseMock(status_code=200, json_data={"results": ["foo"], "next": "page2"}),
-        ResponseMock(status_code=200, json_data={"results": ["bar"], "next": None}),
-    ],
-)
+@patch_method(HaukiAPIClient.get)
 def test__HaukiAPIClient__get_resources_all_pages__multiple_pages():
+    page_1 = HaukiAPIResourceListResponseFactory.create(next="example.com/page2")
+    page_2 = HaukiAPIResourceListResponseFactory.create()
+
+    HaukiAPIClient.get.side_effect = [
+        ResponseMock(status_code=200, json_data=deepcopy(page_1)),
+        ResponseMock(status_code=200, json_data=deepcopy(page_2)),
+    ]
+
     fetched_hauki_resources = HaukiAPIClient.get_resources_all_pages(hauki_resource_ids=[1])
 
     assert HaukiAPIClient.get.call_count == 2
-    assert fetched_hauki_resources == ["foo", "bar"]
+    assert fetched_hauki_resources == page_1["results"] + page_2["results"]
 
 
-@patch_method(HaukiAPIClient.get_resources, return_value={"results": []})
+@patch_method(HaukiAPIClient.get)
 def test__HaukiAPIClient__get_resources_all_pages__nothing_returned():
+    data = HaukiAPIResourceListResponseFactory.create(results=[])
+
+    HaukiAPIClient.get.return_value = ResponseMock(status_code=200, json_data=deepcopy(data))
+
     fetched_hauki_resources = HaukiAPIClient.get_resources_all_pages(hauki_resource_ids=[1])
 
-    assert HaukiAPIClient.get_resources.call_count == 1
+    assert HaukiAPIClient.get.call_count == 1
     assert fetched_hauki_resources == []
+
+
+@patch_method(HaukiAPIClient.get)
+def test__HaukiAPIClient__get_resources_all_pages__multiple_batches(settings):
+    settings.HAUKI_RESOURCE_BATCH_SIZE = 1
+
+    resource_1 = HaukiAPIResourceListResponseFactory.create()
+    resource_2 = HaukiAPIResourceListResponseFactory.create()
+
+    HaukiAPIClient.get.side_effect = [
+        ResponseMock(status_code=200, json_data=deepcopy(resource_1)),
+        ResponseMock(status_code=200, json_data=deepcopy(resource_2)),
+    ]
+
+    fetched_hauki_resources = HaukiAPIClient.get_resources_all_pages(hauki_resource_ids=[1, 2])
+
+    assert HaukiAPIClient.get.call_count == 2
+    assert fetched_hauki_resources == resource_1["results"] + resource_2["results"]

--- a/backend/tests/test_integrations/test_hauki/test_hauki_resource_hash_updater.py
+++ b/backend/tests/test_integrations/test_hauki/test_hauki_resource_hash_updater.py
@@ -47,7 +47,7 @@ def test__HaukiResourceHashUpdater__init__pass_empty_list():
     assert hash_updater.hauki_resource_ids == []
 
 
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__no_initial_hash():
     origin_hauki_resource: OriginHaukiResource = OriginHaukiResourceFactory.create(
@@ -56,7 +56,7 @@ def test__HaukiResourceHashUpdater__no_initial_hash():
         latest_fetched_date=None,
     )
 
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
 
     hash_updater = HaukiResourceHashUpdater()
     hash_updater.run()
@@ -68,7 +68,7 @@ def test__HaukiResourceHashUpdater__no_initial_hash():
 
 
 @freezegun.freeze_time("2020-01-01 08:00:00")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__handle_existing_reservable_time_spans():
     origin_hauki_resource: OriginHaukiResource = OriginHaukiResourceFactory.create(
@@ -77,7 +77,7 @@ def test__HaukiResourceHashUpdater__handle_existing_reservable_time_spans():
         latest_fetched_date=datetime.date(2019, 12, 31),  # in the past
     )
 
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "UPDATED"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "UPDATED"}]}
 
     # In the past: Should be kept as is
     rts1 = ReservableTimeSpanFactory.create(
@@ -122,13 +122,13 @@ def test__HaukiResourceHashUpdater__handle_existing_reservable_time_spans():
 
 
 @freezegun.freeze_time("2020-01-01")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_changed():
     hauki_resource = OriginHaukiResourceFactory.create(id=999, opening_hours_hash="OLD", latest_fetched_date=None)
 
     # Hash is changed so it should be updated
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "UPDATED"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "UPDATED"}]}
 
     hash_updater = HaukiResourceHashUpdater()
     hash_updater.run()
@@ -138,13 +138,13 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_changed(
 
 
 @freezegun.freeze_time("2020-01-01")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchanged__no_latest_fetched_date():
     hauki_resource = OriginHaukiResourceFactory.create(id=999, opening_hours_hash="OLD", latest_fetched_date=None)
 
     # Hash not changed, but has no latest_fetched_date so it should be updated
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
 
     hash_updater = HaukiResourceHashUpdater()
     hash_updater.run()
@@ -154,7 +154,7 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchange
 
 
 @freezegun.freeze_time("2020-01-01")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchanged__latest_fetched_date_is_stale():
     hauki_resource = OriginHaukiResourceFactory.create(
@@ -162,7 +162,7 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchange
     )
 
     # Hash not changed, but latest_fetched_date is early enough to warrant an update
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
 
     hash_updater = HaukiResourceHashUpdater()
     hash_updater.run()
@@ -172,7 +172,7 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchange
 
 
 @freezegun.freeze_time("2020-01-01")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchanged__latest_fetched_date_is_up_to_date():
     cutoff_date = local_date() + datetime.timedelta(days=settings.HAUKI_DAYS_TO_FETCH + 1)  # Late enough to not update
@@ -180,7 +180,7 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchange
     OriginHaukiResourceFactory.create(id=999, opening_hours_hash="OLD", latest_fetched_date=cutoff_date)
 
     # Hash not changed and latest_fetched_date late enough to not warrant an update
-    HaukiAPIClient.get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
+    HaukiAPIClient._get_resources.return_value = {"results": [{"id": 999, "date_periods_hash": "OLD"}]}
 
     hash_updater = HaukiResourceHashUpdater()
     hash_updater.run()
@@ -190,13 +190,13 @@ def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_unchange
 
 
 @freezegun.freeze_time("2020-01-01")
-@patch_method(HaukiAPIClient.get_resources)
+@patch_method(HaukiAPIClient._get_resources)
 @patch_method(ReservableTimeSpanClient.run, return_value=[])
 def test__HaukiResourceHashUpdater__process_single_hauki_resource__hash_updated__never_any_opening_hours_hash():
     hauki_resource = OriginHaukiResourceFactory.create(id=999, opening_hours_hash="OLD", latest_fetched_date=None)
 
     # Hash is updated, but is known to not have hours
-    HaukiAPIClient.get_resources.return_value = {
+    HaukiAPIClient._get_resources.return_value = {
         "results": [{"id": 999, "date_periods_hash": NEVER_ANY_OPENING_HOURS_HASH}]
     }
 

--- a/backend/tilavarauspalvelu/integrations/opening_hours/hauki_api_types.py
+++ b/backend/tilavarauspalvelu/integrations/opening_hours/hauki_api_types.py
@@ -16,13 +16,14 @@ class HaukiTranslatedField(TypedDict):
     en: str | None
 
 
-class HaukiAPIOrigin(TypedDict):
-    class DataSource(TypedDict):
-        id: str
-        name: HaukiTranslatedField
+class HaukiDataSource(TypedDict):
+    id: str
+    name: HaukiTranslatedField
 
+
+class HaukiAPIOrigin(TypedDict):
     origin_id: str
-    data_source: DataSource
+    data_source: HaukiDataSource
 
 
 ############
@@ -62,28 +63,30 @@ class HaukiAPIResourceListResponse(TypedDict):
 ###############
 
 
+class HaukiTimeSpan(TypedDict):
+    id: int
+    group: int
+    name: HaukiTranslatedField
+    description: HaukiTranslatedField
+    start_time: str | None  # Time, e.g. "08:00:00"
+    end_time: str | None  # Time, e.g. "09:00:00"
+    end_time_on_next_day: bool
+    full_day: bool
+    weekdays: list[int]
+    resource_state: HaukiResourceState
+    created: str  # Timestamp, e.g. "2023-09-06T09:14:12.834385+03:00"
+    modified: str  # Timestamp, e.g. "2023-09-06T09:14:12.834385+03:00"
+
+
+class HaukiTimeSpanGroup(TypedDict):
+    id: int
+    period: int
+    time_spans: list[HaukiTimeSpan]
+    rules: list[Any]
+    is_removed: bool
+
+
 class HaukiAPIDatePeriod(TypedDict):
-    class TimeSpanGroup(TypedDict):
-        class TimeSpan(TypedDict):
-            id: int
-            group: int
-            name: HaukiTranslatedField
-            description: HaukiTranslatedField
-            start_time: str | None  # Time, e.g. "08:00:00"
-            end_time: str | None  # Time, e.g. "09:00:00"
-            end_time_on_next_day: bool
-            full_day: bool
-            weekdays: list[int]
-            resource_state: HaukiResourceState
-            created: str  # Timestamp, e.g. "2023-09-06T09:14:12.834385+03:00"
-            modified: str  # Timestamp, e.g. "2023-09-06T09:14:12.834385+03:00"
-
-        id: int
-        period: int
-        time_spans: list[TimeSpan]
-        rules: list[Any]
-        is_removed: bool
-
     id: int  # date period id
     resource: int  # resource id
     name: HaukiTranslatedField
@@ -97,7 +100,7 @@ class HaukiAPIDatePeriod(TypedDict):
     origins: list[HaukiAPIOrigin]
     created: str  # Timestamp, e.g. "2023-09-06T09:14:12.671531+03:00"
     modified: str  # Timestamp, e.g. "2023-09-06T09:14:12.671531+03:00"
-    time_span_groups: list[TimeSpanGroup]
+    time_span_groups: list[HaukiTimeSpanGroup]
 
 
 #################

--- a/backend/tilavarauspalvelu/integrations/opening_hours/hauki_resource_hash_updater.py
+++ b/backend/tilavarauspalvelu/integrations/opening_hours/hauki_resource_hash_updater.py
@@ -25,13 +25,13 @@ class HaukiResourceHashUpdater:
     total_time_spans_created: int
 
     def __init__(self, hauki_resource_ids: list[int] | None = None) -> None:
+        # Initialise the list of resource ids if it is not provided
+        if hauki_resource_ids is None:
+            hauki_resource_ids = list(OriginHaukiResource.objects.values_list("id", flat=True))
+
         self.hauki_resource_ids = hauki_resource_ids
         self.resources_updated = []
         self.total_time_spans_created = 0
-
-        # Initialise the list of resource ids if it is not provided
-        if self.hauki_resource_ids is None:
-            self.hauki_resource_ids = OriginHaukiResource.objects.values_list("id", flat=True)
 
     def run(self, *, force_refetch: bool = False) -> None:
         fetched_hauki_resources = HaukiAPIClient.get_resources_all_pages(hauki_resource_ids=self.hauki_resource_ids)


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fixes Hauki resource update requesting too many resources at once, and going over Hauki's URI length limit. Adds a `HAUKI_RESOURCE_BATCH_SIZE` setting for configuring how many resources should be fetched in a batch.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4075](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4075)


[TILA-4075]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4075?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ