### PR TITLE
Fix pink box missing after GQL field rename

### DIFF
--- a/apps/ui/components/reservation/EditStep0.tsx
+++ b/apps/ui/components/reservation/EditStep0.tsx
@@ -183,18 +183,18 @@ function EditStep0({
   });
 
   const lang = convertLanguageCode(i18n.language);
-  const termsOfUse = getTranslationSafe(reservationUnit, "termsOfUse", lang);
+  const notesWhenReserving = getTranslationSafe(reservationUnit, "notesWhenApplying", lang);
 
   return (
     <>
       <StyledReservationInfoCard reservation={reservation} bgColor="gold" disableImage />
       {/* TODO on mobile in the design this is after the calendar but before action buttons */}
-      {termsOfUse !== "" && (
+      {notesWhenReserving !== "" && (
         <PinkBox>
           <H4 as="h2" $marginTop="none">
             {t("reservations:reservationInfoBoxHeading")}
           </H4>
-          <Sanitize html={termsOfUse} />
+          <Sanitize html={notesWhenReserving} />
         </PinkBox>
       )}
       <StyledQuickReservation

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -311,7 +311,7 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
   }, [step, generalFields, reservation, reservationUnit]);
 
   const lang = convertLanguageCode(i18n.language);
-  const termsOfUse = getTranslationSafe(reservationUnit, "termsOfUse", lang);
+  const notesWhenReserving = getTranslationSafe(reservationUnit, "notesWhenApplying", lang);
 
   // TODO hacky should separate the submit handlers and form types
   const onSubmit = (values: Inputs) => {
@@ -336,12 +336,12 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
           bgColor="gold"
           shouldDisplayReservationUnitPrice={shouldDisplayReservationUnitPrice}
         />
-        {termsOfUse && (
+        {notesWhenReserving && (
           <PinkBox>
             <H4 as="h2" $marginTop="none">
               {t("reservations:reservationInfoBoxHeading")}
             </H4>
-            <Sanitize html={termsOfUse} />
+            <Sanitize html={notesWhenReserving} />
           </PinkBox>
         )}
         <TitleSection>

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -564,12 +564,12 @@ function NoticeWhenReservingSection({
 }): JSX.Element | null {
   const { t, i18n } = useTranslation();
   const lang = convertLanguageCode(i18n.language);
-  const termsOfUseContent = getTranslationSafe(reservationUnit, "termsOfUse", lang);
+  const notesWhenReserving = getTranslationSafe(reservationUnit, "notesWhenApplying", lang);
 
   const appRounds = reservationUnit.applicationRounds;
   const futurePricing = getFuturePricing(reservationUnit, appRounds);
 
-  if (!futurePricing && !termsOfUseContent) {
+  if (!futurePricing && !notesWhenReserving) {
     return null;
   }
   return (
@@ -580,7 +580,7 @@ function NoticeWhenReservingSection({
       data-testid="reservation-unit__reservation-notice"
     >
       {futurePricing && <PriceChangeNotice futurePricing={futurePricing} />}
-      {termsOfUseContent && <Sanitize html={termsOfUseContent} />}
+      {notesWhenReserving && <Sanitize html={notesWhenReserving} />}
     </Accordion>
   );
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix pink box "Huomio varatessa" missing from reservation funnel, edit reservation, and reservation unit pages after field rename from `termsOfUse` to `notesWhenApplying`.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: see the Jira ticket.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4138](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4138)

[TILA-4138]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ