### PR TITLE
Fix applicant type not translated correctly

### DIFF
--- a/apps/admin-ui/src/i18n/locales/fi/reservationApplication.json
+++ b/apps/admin-ui/src/i18n/locales/fi/reservationApplication.json
@@ -24,9 +24,9 @@
   "clientReservationCantBeChanged": "Asiakkaan tekemä varaus",
   "reserveeTypes": {
     "labels": {
-      "nonprofit": "järjestön, ryhmän tai yhteisön puolesta",
-      "company": "yrityksen puolesta",
-      "individual": "yksityishenkilönä"
+      "NONPROFIT": "Järjestön, ryhmän tai yhteisön puolesta",
+      "COMPANY": "Yrityksen puolesta",
+      "INDIVIDUAL": "Yksityishenkilönä"
     }
   },
   "label": {

--- a/apps/ui/components/application/ApplicationCard.tsx
+++ b/apps/ui/components/application/ApplicationCard.tsx
@@ -8,7 +8,6 @@ import {
   type ApplicationNameFragment,
   ApplicationStatusChoice,
   type Maybe,
-  ReserveeType,
   useCancelApplicationMutation,
 } from "@gql/gql-types";
 import { formatDateTime } from "@/modules/util";
@@ -27,21 +26,24 @@ const StyledButton = styled(Button)`
   }
 `;
 
-function getApplicant(application: ApplicationNameFragment, t: TFunction): string {
-  if (application.applicantType === ReserveeType.Individual) {
-    return t("applicationCard:person");
-  }
+function formatApplicant(
+  t: TFunction,
+  application: Pick<ApplicationNameFragment, "organisationName" | "applicantType" | "contactPersonFirstName">
+): string {
+  const type = formatApplicantType(t, application);
   if (application.organisationName) {
-    return t("applicationCard:organisation", {
-      type: t(`applicationCard:applicantType.${application.applicantType?.toLocaleLowerCase()}`),
-      name: application.organisationName || t("applicationCard:noName"),
-    });
-  }
-  if (application.contactPersonFirstName) {
-    return t("applicationCard:person");
+    return `${type}: ${application.organisationName}`;
   }
 
-  return "";
+  return type;
+}
+
+function formatApplicantType(t: TFunction, application: Pick<ApplicationNameFragment, "applicantType">): string {
+  const { applicantType } = application;
+  if (!applicantType) {
+    return "";
+  }
+  return t(`reservationApplication:reserveeTypes.labels.${applicantType}`);
 }
 
 function isEditable(status: Maybe<ApplicationStatusChoice> | undefined): boolean {
@@ -120,7 +122,7 @@ export function ApplicationCard({ application, actionCallback }: Props): JSX.Ele
     <Card
       heading={getApplicationRoundName(application.applicationRound, lang)}
       headingLevel={3}
-      text={getApplicant(application, t)}
+      text={formatApplicant(t, application)}
       tags={tags}
       buttons={buttons}
     >

--- a/apps/ui/components/reservation/SummaryFields.tsx
+++ b/apps/ui/components/reservation/SummaryFields.tsx
@@ -5,7 +5,6 @@ import { type ReservationNode, ReserveeType } from "@/gql/gql-types";
 import { containsField, type FieldName } from "common/src/metaFieldsHelpers";
 import { AutoGrid, H4 } from "common/styled";
 import { type MetaFieldsFragment } from "common/gql/gql-types";
-import { capitalize } from "common/src/helpers";
 import { ParagraphAlt, PreviewLabel, PreviewValue } from "./styles";
 import { LabelValuePair } from "./LabelValuePair";
 import { extendMetaFieldOptions } from "common/src/reservation-form/MetaFields";
@@ -104,7 +103,7 @@ export function ApplicationFields({
             <ParagraphAlt $isWide>
               <PreviewLabel>{t("reservationApplication:reserveeTypePrefix")}</PreviewLabel>
               <PreviewValue data-testid="reservation__reserveeType">
-                {capitalize(t(`reservationApplication:reserveeTypes.labels.${reserveeType.toLowerCase()}`))}
+                {t(`reservationApplication:reserveeTypes.labels.${reserveeType}`)}
               </PreviewValue>
             </ParagraphAlt>
           )}

--- a/apps/ui/public/locales/en/applicationCard.json
+++ b/apps/ui/public/locales/en/applicationCard.json
@@ -6,13 +6,5 @@
   "edit": "Edit",
   "cancel": "Cancel",
   "view": "View",
-  "reservations": "Bookings",
-  "saved": "Last saved:",
-  "person": "Application created: as a private person",
-  "organisation": "Application created: {{type}}, {{name}}",
-  "applicantType": {
-    "community": "association",
-    "association": "registered association",
-    "company": "company"
-  }
+  "saved": "Last saved:"
 }

--- a/apps/ui/public/locales/en/reservationApplication.json
+++ b/apps/ui/public/locales/en/reservationApplication.json
@@ -6,9 +6,9 @@
   "reserveeTypePrefix": "I am creating the application...",
   "reserveeTypes": {
     "labels": {
-      "nonprofit": "on behalf of an association or community",
-      "company": "on behalf of the company",
-      "individual": "as a private person"
+      "NONPROFIT": "On behalf of an association or community",
+      "COMPANY": "On behalf of the company",
+      "INDIVIDUAL": "As a private person"
     }
   },
   "label": {

--- a/apps/ui/public/locales/fi/applicationCard.json
+++ b/apps/ui/public/locales/fi/applicationCard.json
@@ -6,13 +6,5 @@
   "edit": "Muokkaa",
   "cancel": "Peru",
   "view": "Näytä",
-  "reservations": "Varaukset",
-  "saved": "Viimeksi tallennettu:",
-  "person": "Hakemus luotu: yksityishenkilönä",
-  "organisation": "Hakemus luotu: {{type}}, {{name}}",
-  "applicantType": {
-    "community": "yhdistykselle",
-    "association": "rekisteröidylle yhdistykselle",
-    "company": "yritykselle"
-  }
+  "saved": "Viimeksi tallennettu:"
 }

--- a/apps/ui/public/locales/fi/reservationApplication.json
+++ b/apps/ui/public/locales/fi/reservationApplication.json
@@ -6,9 +6,9 @@
   "reserveeTypePrefix": "Varaan",
   "reserveeTypes": {
     "labels": {
-      "nonprofit": "Järjestön tai muun yhteisön puolesta",
-      "company": "yrityksen puolesta",
-      "individual": "yksityishenkilönä"
+      "NONPROFIT": "Järjestön tai muun yhteisön puolesta",
+      "COMPANY": "Yrityksen puolesta",
+      "INDIVIDUAL": "Yksityishenkilönä"
     }
   },
   "label": {

--- a/apps/ui/public/locales/sv/applicationCard.json
+++ b/apps/ui/public/locales/sv/applicationCard.json
@@ -6,13 +6,5 @@
   "edit": "Redigera",
   "cancel": "Ångra",
   "view": "Visa",
-  "reservations": "Bokningar",
-  "saved": "Senast sparad:",
-  "person": "Ansökan skapad: som privatperson",
-  "organisation": "Ansökan skapad: {{type}}, {{name}}",
-  "applicantType": {
-    "community": "förening",
-    "association": "för en registrerad förening",
-    "company": "företag"
-  }
+  "saved": "Senast sparad:"
 }

--- a/apps/ui/public/locales/sv/reservationApplication.json
+++ b/apps/ui/public/locales/sv/reservationApplication.json
@@ -6,9 +6,9 @@
   "reserveeTypePrefix": "Skapa ansökan…",
   "reserveeTypes": {
     "labels": {
-      "nonprofit": "för en organisation, grupp eller samfund",
-      "company": "för ett företag",
-      "individual": "som privatkund"
+      "NONPROFIT": "För en organisation, grupp eller samfund",
+      "COMPANY": "För ett företag",
+      "INDIVIDUAL": "Som privatkund"
     }
   },
   "label": {

--- a/packages/common/src/reservation-form/MetaFields.tsx
+++ b/packages/common/src/reservation-form/MetaFields.tsx
@@ -12,7 +12,7 @@ import { IconGroup, IconUser } from "hds-react";
 import React, { Fragment } from "react";
 import styled from "styled-components";
 import { Controller, useFormContext } from "react-hook-form";
-import { useTranslation } from "next-i18next";
+import { useTranslation, type TFunction } from "next-i18next";
 import { camelCase } from "lodash-es";
 import { MetadataSetsFragment, MunicipalityChoice, ReserveeType } from "../../gql/gql-types";
 import { ReservationFormField } from "./ReservationFormField";
@@ -22,8 +22,7 @@ import { AutoGrid, fontMedium, fontRegular, H4, H5 } from "../../styled";
 import type { OptionsRecord } from "../../types/common";
 import IconPremises from "../icons/IconPremises";
 import { containsField } from "../metaFieldsHelpers";
-import { capitalize, filterNonNullable } from "../helpers";
-import { TFunction } from "i18next";
+import { filterNonNullable } from "../helpers";
 
 type CommonProps = {
   options: Omit<OptionsRecord, "municipality">;
@@ -250,14 +249,13 @@ function CustomerTypeChoiceSelector() {
               .map(({ id, icon }) => ({
                 choice: id,
                 icon,
-                name: id.toLocaleLowerCase(),
+                name: id,
               }))
               .map(({ choice, icon, name }) => (
                 <RadioButtonWithImage
                   key={choice}
                   id={`reserveeType__${name}`}
-                  // TODO use the enum translation key
-                  label={capitalize(t(`reservationApplication:reserveeTypes.labels.${name}`))}
+                  label={t(`reservationApplication:reserveeTypes.labels.${name}`)}
                   onClick={() => onChange(choice)}
                   icon={icon}
                   checked={value === choice}


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix invalid organisation (reservee type) translation in Application Cards `customer`.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: application card correct reservee type translations.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None