### PR TITLE
Fix payment url language

### DIFF
--- a/apps/ui/components/UnpaidReservationNotification.tsx
+++ b/apps/ui/components/UnpaidReservationNotification.tsx
@@ -16,7 +16,7 @@ import { useCurrentUser } from "@/hooks";
 import { getCheckoutUrl } from "@/modules/reservation";
 import { base64encode, filterNonNullable } from "common/src/helpers";
 import { gql, useApolloClient } from "@apollo/client";
-import { toApiDate } from "common/src/common/util";
+import { convertLanguageCode, toApiDate } from "common/src/common/util";
 import { errorToast, successToast } from "common/src/common/toast";
 import { getReservationInProgressPath } from "@/modules/urls";
 import { Button, ButtonSize, ButtonVariant, LoadingSpinner } from "hds-react";
@@ -162,7 +162,8 @@ export function InProgressReservationNotification() {
 
   const [deleteReservation, { loading: isDeleteLoading }] = useDeleteReservationMutation();
 
-  const checkoutUrl = getCheckoutUrl(unpaidReservation?.paymentOrder, i18n.language);
+  const lang = convertLanguageCode(i18n.language);
+  const checkoutUrl = getCheckoutUrl(unpaidReservation?.paymentOrder, lang);
 
   // Lazy minimal query to check if the reservation is still valid
   const [reservationQ] = useReservationStateLazyQuery({

--- a/apps/ui/modules/reservation.test.ts
+++ b/apps/ui/modules/reservation.test.ts
@@ -406,17 +406,20 @@ describe("getCheckoutUrl", () => {
   });
 
   test("returns undefined if checkoutUrl is not defined", () => {
-    expect(getCheckoutUrl({ ...order, checkoutUrl: null })).toBeUndefined();
+    expect(getCheckoutUrl({ ...order, checkoutUrl: null }, "fi")).toBeUndefined();
   });
 
   test("returns undefined if checkoutUrl is not an url", () => {
     // we are expecting console.errors => suppress
     vi.spyOn(console, "error").mockImplementation(vi.fn());
     expect(
-      getCheckoutUrl({
-        ...order,
-        checkoutUrl: "checkout.url?user=1111-2222-3333-4444",
-      })
+      getCheckoutUrl(
+        {
+          ...order,
+          checkoutUrl: "checkout.url?user=1111-2222-3333-4444",
+        },
+        "fi"
+      )
     ).toBeUndefined();
   });
 });

--- a/apps/ui/modules/reservation.ts
+++ b/apps/ui/modules/reservation.ts
@@ -470,7 +470,7 @@ export function getPaymentUrl(
     reservation.paymentOrder.status === OrderStatus.Draft &&
     reservation.paymentOrder.checkoutUrl
   ) {
-    return getCheckoutUrl(reservation.paymentOrder);
+    return getCheckoutUrl(reservation.paymentOrder, lang);
   }
 
   return undefined;
@@ -502,7 +502,7 @@ function getCheckoutRedirectUrl(pk: number, lang: LocalizationLanguages, apiBase
 /// left because requires refactoring old users to include more ReservationNode parameters
 export function getCheckoutUrl(
   order: Pick<PaymentOrderNode, "checkoutUrl"> | undefined | null,
-  lang = "fi"
+  lang: LocalizationLanguages
 ): string | undefined {
   const { checkoutUrl } = order ?? {};
 

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -279,7 +279,8 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
         router.push(getReservationPath(pk, undefined, "requires_handling"));
       } else if (state === ReservationStateChoice.WaitingForPayment) {
         const { order } = data?.confirmReservation ?? {};
-        const checkoutUrl = getCheckoutUrl(order, i18n.language);
+        const lang = convertLanguageCode(i18n.language);
+        const checkoutUrl = getCheckoutUrl(order, lang);
         if (!checkoutUrl) {
           throw new Error("No checkout url found");
         }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix direct payment url not including `lang` parameter for webstore so always default to FI.
- Fix handled payment failure return url not including `lang` prefix so it returned to default FI page.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing.

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4158](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4158)


[TILA-4158]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ