### PR TITLE
fix: redirect to reservation page on handled payment cancellation

### DIFF
--- a/apps/ui/components/reservation/PaymentNotification.tsx
+++ b/apps/ui/components/reservation/PaymentNotification.tsx
@@ -1,6 +1,7 @@
 import {
   ReservationCancelReasonChoice,
   type ReservationPaymentUrlFragment,
+  type ReservationPriceFieldsFragment,
   ReservationStateChoice,
 } from "@gql/gql-types";
 import { Notification } from "hds-react";
@@ -15,7 +16,7 @@ import { breakpoints } from "common/src/const";
 import { getPaymentUrl } from "@/modules/reservation";
 
 type PaymentNotificationProps = {
-  reservation: ReservationPaymentUrlFragment;
+  reservation: ReservationPaymentUrlFragment & Pick<ReservationPriceFieldsFragment, "price">;
   appliedPricing: {
     highestPrice: string;
     taxPercentage: string;
@@ -49,7 +50,7 @@ export const PaymentNotification = ({
   const { t, i18n } = useTranslation();
   const formatters = useMemo(() => getFormatters(i18n.language), [i18n.language]);
   const formatter = formatters["currencyWithDecimals"];
-  const price = formatter?.format(parseFloat(appliedPricing?.highestPrice ?? "") ?? 0);
+  const price = formatter?.format(parseFloat(reservation.price ?? "") ?? 0);
   const taxPercentage = formatters.strippedDecimal?.format(parseFloat(appliedPricing?.taxPercentage ?? "")) ?? "0";
 
   const deadline =


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- use the delete reservation mutation only for reservations which are in `WaitingForPayment` state, redirect to the reservation page as default

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4152](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4152)


[TILA-4152]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ