### PR TITLE
TILA-4164: fix Sentry source maps upload

### DIFF
--- a/.github/workflows/upload_sentry_sourcemaps.yml
+++ b/.github/workflows/upload_sentry_sourcemaps.yml
@@ -42,7 +42,7 @@ jobs:
       - name: "Create release name"
         id: release
         run: >-
-          echo "release=$(
+          echo "release=tilavarauspalvelu-ui@$(
             echo ${{ github.ref_name || github.sha }} | tr '/' '-'
           )" >> $GITHUB_OUTPUT
       - name: Create Sentry release
@@ -80,7 +80,7 @@ jobs:
       - name: "Create release name"
         id: release
         run: >-
-          echo "release=$(
+          echo "release=tilavarauspalvelu-admin-ui@$(
             echo ${{ github.ref_name || github.sha }} | tr '/' '-'
           )" >> $GITHUB_OUTPUT
       - name: Create Sentry release


### PR DESCRIPTION
## 🛠️ Changelog
- The workflow [Upload frontend sentry sourcemaps](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/actions/workflows/upload_sentry_sourcemaps.yml) does create separate UI and Admin-UI releases for the `prod` environment with their source maps uploaded in Sentry: e.g. https://sentry.hel.fi/organizations/city-of-helsinki/releases/v1.36.0-ui/?project=17
- However, the sessions and events subsequently recorded no longer seem to match them, so the maps are of no use: e.g. https://sentry.hel.fi/organizations/city-of-helsinki/releases/tilavarauspalvelu-ui%40v1.36.0-ui/?project=17
- The reason appears to be that when the data is sent from browser the value is like `"release":"tilavarauspalvelu-ui@v1.36.0-ui"` (because of the [config](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/blob/8e3005d9e5f695359307b6efce394ef3c76da15e/apps/ui/sentry.server.config.ts#L16)) whereas the workflow definition sets it simply to the version number (for example [the last run](https://github.com/City-of-Helsinki/tilavarauspalvelu-core/actions/runs/16669118293/job/47181232333#step:11:1495)), without the frontend app name prefix (which Sentry interprets as the package name), so the user data does not match the releases created by the source maps upload.

## 🧪 Test plan
- Check in [sentry.hel.fi](https://sentry.hel.fi/organizations/city-of-helsinki/releases/?project=17&project=18&project=16&statsPeriod=7d) when the next production release is tagged and this workflow is run in Github Actions, that the new release slugs (urls) contain the frontend app names (i.e., as prefixes before e.g. `v1.36.0-ui`) and that under the *Project Release Details* the **package** name is no longer empty but contains the respective name (`tilavarauspalvelu-ui` or `tilavarauspalvelu-admin-ui`).
- After the release has been deployed to production from Azure DevOps pipe, check that the sessions and recorded events now target that release, instead of automatically creating another release.

## 🚧 Dependencies
- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4164](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4164)


[TILA-4164]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4164?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ