### PR TITLE
Mock Verkkokauppa: Use payment action to set reservation as CONFIRMED

### DIFF
--- a/backend/tilavarauspalvelu/models/payment_order/actions.py
+++ b/backend/tilavarauspalvelu/models/payment_order/actions.py
@@ -119,6 +119,10 @@ class PaymentOrderActions:
         return OrderStatus.DRAFT
 
     def complete_payment(self) -> None:
+        """
+        Update reservation state to CONFIRMED if the payment order is paid.
+        Activate Pindora access code and send confirmation emails if applicable.
+        """
         if self.payment_order.status not in OrderStatus.paid_in_webshop:
             return
 


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Use PaymentOrder actions to set reservation as CONFIRMED, which also activates Pindora access code and sends emails if applicable

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4130](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4130)


[TILA-4130]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ