### PR TITLE
Fix reservationsMaxDaysBefore validation in Admin UI

### DIFF
--- a/apps/admin-ui/src/lib/reservation-units/[pk]/form.ts
+++ b/apps/admin-ui/src/lib/reservation-units/[pk]/form.ts
@@ -556,7 +556,7 @@ export const ReservationUnitEditSchema = z
           path: ["reservationsMinDaysBefore"],
         });
       }
-      if (v.reservationsMaxDaysBefore == null) {
+      if (v.reservationsMaxDaysBefore == null || v.reservationsMaxDaysBefore === 0) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: "Required",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix reservationsMaxDaysBefore validation not raising an issue when trying to publish a reservation unit with the field not filled due to it defaulting to `0`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4062](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4062)


[TILA-4062]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ