### PR TITLE
Fix handled payment polling

### DIFF
--- a/apps/ui/hooks/useToastIfQueryParam.ts
+++ b/apps/ui/hooks/useToastIfQueryParam.ts
@@ -7,10 +7,12 @@ export function useToastIfQueryParam({
   key,
   message,
   type = "success",
+  title,
 }: {
   key: string | string[];
   message: string | (() => string);
-  type?: "success" | "error";
+  type?: "success" | "error" | "alert";
+  title?: string | (() => string);
 }) {
   const router = useRouter();
   const { t } = useTranslation();
@@ -43,11 +45,13 @@ export function useToastIfQueryParam({
     };
     const q = router.query;
 
+    const titleText = title ? (typeof title === "string" ? title : title()) : undefined;
     const text = typeof message === "string" ? message : message();
     const handle = () => {
       toast({
         text,
         type,
+        label: titleText,
       });
       removeTimeUpdatedParam();
     };

--- a/apps/ui/modules/urls.ts
+++ b/apps/ui/modules/urls.ts
@@ -63,7 +63,7 @@ export function getApplicationSectionPath(
 }
 
 type ReservationPages = "cancel" | "edit";
-export type ReservationNotifications = "requires_handling" | "confirmed" | "paid";
+export type ReservationNotifications = "requires_handling" | "confirmed" | "paid" | "polling_timeout";
 export function getReservationPath(
   pk: Maybe<number> | undefined,
   page?: ReservationPages | undefined,

--- a/apps/ui/pages/reservations/[id]/index.tsx
+++ b/apps/ui/pages/reservations/[id]/index.tsx
@@ -202,6 +202,13 @@ function Reservation({
   });
 
   useToastIfQueryParam({
+    key: "polling_timeout",
+    title: t("reservations:notifications.polling_timeout.title"),
+    message: t("reservations:notifications.polling_timeout.body"),
+    type: "alert",
+  });
+
+  useToastIfQueryParam({
     key: "error_code",
     message:
       params.get("error_code") === "RESERVATION_NOT_CONFIRMED" ||

--- a/apps/ui/public/locales/en/reservations.json
+++ b/apps/ui/public/locales/en/reservations.json
@@ -155,6 +155,10 @@
     "paid": {
       "title": "Your booking has been paid",
       "body": ""
+    },
+    "polling_timeout": {
+      "title": "The status of the payment related to the booking could not be verified.",
+      "body": "Please recheck the status of the booking at this page after 10 minutes. If the status still has not changed by then, please contact the customer service."
     }
   }
 }

--- a/apps/ui/public/locales/fi/reservations.json
+++ b/apps/ui/public/locales/fi/reservations.json
@@ -151,6 +151,10 @@
     "paid": {
       "title": "Varauksesi on maksettu.",
       "body": ""
+    },
+    "polling_timeout": {
+      "title": "Varaukseen liittyvän maksun tilaa ei voitu vahvistaa.",
+      "body": "Tarkista varauksen tila tältä sivulta 10 minuutin päästä uudelleen ja ellei maksu vieläkään ole vahvistunut, ole yhteydessä asiakaspalveluun."
     }
   }
 }

--- a/apps/ui/public/locales/sv/reservations.json
+++ b/apps/ui/public/locales/sv/reservations.json
@@ -155,6 +155,10 @@
     "paid": {
       "title": "Din bokning är betald",
       "body": ""
+    },
+    "polling_timeout": {
+      "title": "Betalningsstatusen för bokningen kunde inte verifieras.",
+      "body": "Kontrollera bokningsstatusen på den här sidan efter 10 minuter. Om statusen har ännu heller inte ändrats, vänligen kontakta kundtjänsten."
     }
   }
 }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Redirects the user to the reservation page when returning from a successful online payment, Instead of keeping them waiting for the change in payment status from the backend which we're expecting
- Shows a "Payment status not verified" toast, informing the user of the situation
- Adds `alert` type toasts to `useToastIfQueryParam()`-hook
- Adds optional title/heading text to the `useToastIfQueryParam()`-hook's contents


## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4133](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4133)


[TILA-4133]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ