### PR TITLE
fix: use onClick to open the a11y terms, to get the url correct

### DIFF
--- a/apps/admin-ui/src/component/MainLander.tsx
+++ b/apps/admin-ui/src/component/MainLander.tsx
@@ -82,8 +82,9 @@ export function MainLander({ apiBaseUrl }: Readonly<{ apiBaseUrl: string }>): Re
         <IconButton
           label={t("navigation:a11yTerms")}
           icon={<IconLinkExternal />}
-          href={getAccessibilityTermsUrl()}
-          openInNewTab
+          onClick={() => window.open(getAccessibilityTermsUrl(), "_blank", "noopener noreferrer")}
+          aria-label={t("navigation:a11yTerms")}
+          aria-roledescription="link"
         />
       </Content>
     </>

--- a/apps/admin-ui/src/component/Navigation.tsx
+++ b/apps/admin-ui/src/component/Navigation.tsx
@@ -302,6 +302,7 @@ export function Navigation({ apiBaseUrl }: Props) {
               }
               onClick={() => window.open(getAccessibilityTermsUrl(), "_blank", "noopener noreferrer")}
               aria-label={t("navigation:a11yTerms")}
+              aria-roledescription="link"
             />
             <Header.ActionBarButton
               label={


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- uses `onClick` to open the a11y terms from `MainLander`, since SSR doesn't have `window.location.origin`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-](https://helsinkisolutionoffice.atlassian.net/browse/TILA-)
