### PR TITLE
Fix duplicate reservations returned from GQL

### DIFF
--- a/backend/tilavarauspalvelu/admin/unit/admin.py
+++ b/backend/tilavarauspalvelu/admin/unit/admin.py
@@ -11,7 +11,7 @@ from modeltranslation.admin import TabbedTranslationAdmin
 
 from tilavarauspalvelu.integrations.sentry import SentryLogger
 from tilavarauspalvelu.integrations.tprek.tprek_unit_importer import TprekUnitImporter
-from tilavarauspalvelu.models import Unit
+from tilavarauspalvelu.models import Unit, UnitGroup
 
 from .form import UnitAdminForm
 
@@ -19,6 +19,19 @@ if TYPE_CHECKING:
     from django.db.models import QuerySet
 
     from tilavarauspalvelu.typing import WSGIRequest
+
+
+class UnitGroupInlineAdmin(admin.TabularInline):
+    model = UnitGroup.units.through
+    fk_name = "unit"
+    fields = ["unitgroup"]
+    readonly_fields = fields
+
+    def has_add_permission(self, request, obj=None) -> bool:
+        return False
+
+    def has_delete_permission(self, request, obj=None) -> bool:
+        return False
 
 
 @admin.register(Unit)
@@ -114,6 +127,9 @@ class UnitAdmin(SortableAdminMixin, ExtraButtonsMixin, TabbedTranslationAdmin):
     readonly_fields = [
         "tprek_last_modified",
     ]
+    inlines = [
+        UnitGroupInlineAdmin,
+    ]
 
     def get_queryset(self, request: WSGIRequest) -> QuerySet[Unit]:
         return (
@@ -123,6 +139,9 @@ class UnitAdmin(SortableAdminMixin, ExtraButtonsMixin, TabbedTranslationAdmin):
                 "origin_hauki_resource",
                 "payment_merchant",
                 "payment_accounting",
+            )
+            .prefetch_related(
+                "unit_groups",
             )
         )
 

--- a/backend/tilavarauspalvelu/api/graphql/types/reservation/filtersets.py
+++ b/backend/tilavarauspalvelu/api/graphql/types/reservation/filtersets.py
@@ -118,7 +118,7 @@ class ReservationFilterSet(ModelFilterSet):
                     | Q(reservation_unit__unit__unit_groups__in=reserver_g_ids)
                 )
             )
-        )
+        ).distinct()
 
     def filter_by_only_with_handling_permission(self, qs: QuerySet, name: str, value: bool) -> QuerySet:
         if not value:
@@ -141,7 +141,7 @@ class ReservationFilterSet(ModelFilterSet):
         return qs.filter(
             Q(reservation_unit__unit__in=u_ids)  #
             | Q(reservation_unit__unit__unit_groups__in=g_ids)
-        )
+        ).distinct()
 
     @staticmethod
     def filter_by_requested(qs: QuerySet, name, value: str) -> QuerySet:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix duplicate reservations returned from GQL caused by missing `.distinct()`s and a unit belonging to multiple unit groups
- Add UnitGroups on Unit Django Admin page (Previously there was no way to

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4179](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4179)


[TILA-4179]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ