### PR TITLE
fix: Use correct translation path for `USER_NOT_INTERNAL_USER`

### DIFF
--- a/apps/ui/public/locales/en/errors.json
+++ b/apps/ui/public/locales/en/errors.json
@@ -57,7 +57,6 @@
     "RESERVATION_UNIT_NOT_RESERVABLE": "The item cannot be booked.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "You can only make a seasonal booking application for this item.",
     "UNKNOWN": "An error occurred.",
-    "USER_NOT_INTERNAL_USER": "Making a booking is not allowed.",
     "validation": {
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "The applicant must be 18 years old.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Applicant type is missing.",
@@ -72,6 +71,7 @@
       "RESERVATION_UNITS_MAX_DURATION_EXCEEDED": "The booking time is too long.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "The person making the reservation must be 18 years old",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "You have the maximum number of bookings for this space.",
+      "USER_NOT_INTERNAL_USER": "Making a booking is not allowed.",
       "generic_validation_error": "An error occurred.",
       "invalid": "Invalid value."
     }

--- a/apps/ui/public/locales/fi/errors.json
+++ b/apps/ui/public/locales/fi/errors.json
@@ -56,7 +56,6 @@
     "RESERVATION_UNIT_NOT_RESERVABLE": "Kohde ei ole varattavissa.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Tähän kohteeseen voit tehdä vain kausivaraushakemuksen.",
     "UNKNOWN": "Tapahtui virhe.",
-    "USER_NOT_INTERNAL_USER": "Varauksen tekeminen ei ole sallittu.",
     "validation": {
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "Hakijan on oltava täysi-ikäinen.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Hakijan tyyppi puuttuu.",
@@ -74,6 +73,7 @@
       "RESERVATION_UNITS_MAX_DURATION_EXCEEDED": "Liian pitkä varausaika.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Varaajan on oltava täysi-ikäinen.",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Sinulla on maksimi määrä varauksia tässä kohteessa.",
+      "USER_NOT_INTERNAL_USER": "Varauksen tekeminen ei ole sallittu.",
       "generic_validation_error": "Tapahtui virhe.",
       "invalid": "Virheellinen arvo."
     }

--- a/apps/ui/public/locales/sv/errors.json
+++ b/apps/ui/public/locales/sv/errors.json
@@ -57,7 +57,6 @@
     "RESERVATION_UNIT_NOT_RESERVABLE": "Objektet går inte att boka.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Du kan bara göra en ansökan om säsongsbokning för detta objekt.",
     "UNKNOWN": "Ett fel uppstod.",
-    "USER_NOT_INTERNAL_USER": "Det är inte tillåtet att göra en bokning.",
     "validation": {
       "APPLICATION_ADULT_RESERVEE_REQUIRED": "Sökanden måste vara myndig.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Sökandens typ saknas.",
@@ -72,6 +71,7 @@
       "RESERVATION_UNITS_MAX_DURATION_EXCEEDED": "För lång bokningstid.",
       "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Personen som gör bokningen måste vara myndig.",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Du har det maximala antalet bokningar för detta objekt.",
+      "USER_NOT_INTERNAL_USER": "Det är inte tillåtet att göra en bokning.",
       "generic_validation_error": "Ett fel uppstod.",
       "invalid": "Ogiltigt värde."
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Use correct translation path for `USER_NOT_INTERNAL_USER`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4199](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4199)


[TILA-4199]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ