### PR TITLE
Use onlyWithManagePermission filter when querying for reservation units

### DIFF
--- a/apps/admin-ui/src/lib/reservation-units/ReservationUnitsDataLoader.tsx
+++ b/apps/admin-ui/src/lib/reservation-units/ReservationUnitsDataLoader.tsx
@@ -136,7 +136,7 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
         maxPersonsLte: $maxPersonsLte
         minPersonsGte: $maxPersonsGte
         minPersonsLte: $maxPersonsLte
-        onlyWithPermission: true
+        onlyWithManagePermission: true
         publishingState: $publishingState
         reservationUnitType: $reservationUnitType
         surfaceAreaGte: $surfaceAreaGte


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Changes the permission filter from `onlyWithPermission` to `onlyWithManagePermission`

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- requires the changes made in `add-manage-perm-res-unit-filter` branch in order to support the `onlyWithManagePermission`filter

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4196](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4196)


[TILA-4196]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ