### PR TITLE
Make terms of use on application round required in Django admin

### DIFF
--- a/backend/tilavarauspalvelu/admin/application_round/admin.py
+++ b/backend/tilavarauspalvelu/admin/application_round/admin.py
@@ -9,7 +9,7 @@ from django.contrib.admin import helpers
 from django.template.response import TemplateResponse
 from django.utils.translation import gettext_lazy as _
 from lookup_property import L
-from modeltranslation.admin import TranslationAdmin
+from modeltranslation.admin import TabbedTranslationAdmin
 
 from tilavarauspalvelu.admin.application_round.form import ApplicationRoundAdminForm
 from tilavarauspalvelu.enums import ApplicationRoundStatusChoice
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 
 
 @admin.register(ApplicationRound)
-class ApplicationRoundAdmin(ExtraButtonsMixin, TranslationAdmin):
+class ApplicationRoundAdmin(ExtraButtonsMixin, TabbedTranslationAdmin):
     # Functions
     actions = ["reset_application_rounds"]
 

--- a/backend/tilavarauspalvelu/admin/application_round/form.py
+++ b/backend/tilavarauspalvelu/admin/application_round/form.py
@@ -42,6 +42,7 @@ class ApplicationRoundAdminForm(forms.ModelForm):
         self.base_fields["terms_of_use"].queryset = TermsOfUse.objects.filter(
             terms_type=TermsOfUseTypeChoices.RECURRING
         )
+        self.base_fields["terms_of_use"].required = True
         super().__init__(*args, **kwargs)
 
     class Meta:


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- If not set, users cannot send applications. Require them in admin form
- Use `TabbedTranslationAdmin` for application round view

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
