### PR TITLE
Fix translation of underage reservee

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -172,6 +172,12 @@
         "prefer-rest-params": "error",
         "prefer-spread": "error"
       }
+    },
+    {
+      "files": ["**/next-env.d.ts"],
+      "rules": {
+        "triple-slash-reference": "off"
+      }
     }
   ]
 }

--- a/apps/admin-ui/next-env.d.ts
+++ b/apps/admin-ui/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/ui/next-env.d.ts
+++ b/apps/ui/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/apps/ui/public/locales/en/errors.json
+++ b/apps/ui/public/locales/en/errors.json
@@ -41,6 +41,7 @@
   },
   "general_error": "Undefined error.",
   "api": {
+    "APPLICATION_ADULT_RESERVEE_REQUIRED": "The applicant must be 18 years old.",
     "CHANGES_NOT_ALLOWED": "You cannot make changes to the booking.",
     "CREATE_PERMISSION_DENIED": "No permission to create.",
     "MAX_NUMBER_OF_ACTIVE_RESERVATIONS_EXCEEDED": "You have exceeded the maximum number of bookings.",
@@ -49,6 +50,7 @@
     "RESERVATION_NOT_WITHIN_ALLOWED_TIME_RANGE": "Please check the booking time.",
     "RESERVATION_OVERLAP": "There are duplicate bookings.",
     "RESERVATION_TIME_DOES_NOT_MATCH_ALLOWED_INTERVAL": "Please check the booking time.",
+    "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "The person making the reservation must be 18 years old",
     "RESERVATION_UNIT_IN_OPEN_ROUND": "You can make a seasonal booking application for this item.",
     "RESERVATION_UNIT_IS_NOT_OPEN": "The item is closed at the moment.",
     "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "Please shorten the booking time.",
@@ -57,7 +59,6 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "You can only make a seasonal booking application for this item.",
     "UNKNOWN": "An error occurred.",
     "validation": {
-      "APPLICATION_ADULT_RESERVEE_REQUIRED": "The applicant must be 18 years old.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Applicant type is missing.",
       "APPLICATION_BILLING_ADDRESS_MISSING": "Billing address is missing.",
       "APPLICATION_CONTACT_PERSON_MISSING": "Contact person is missing.",
@@ -70,7 +71,6 @@
       "CANCEL_REASON_DOES_NOT_EXIST": "Cancel reason does not exist",
       "OVERLAPPING_RESERVATIONS": "There are duplicate bookings.",
       "RESERVATION_CANCELLATION_NOT_ALLOWED": "Cancellation is not allowed.",
-      "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "The person making the reservation must be 18 years old",
       "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "The booking time is too long.",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "You have the maximum number of bookings for this space.",
       "USER_NOT_INTERNAL_USER": "Making a booking is not allowed.",

--- a/apps/ui/public/locales/fi/errors.json
+++ b/apps/ui/public/locales/fi/errors.json
@@ -41,6 +41,7 @@
   },
   "general_error": "Tapahtui määrittämätön virhe.",
   "api": {
+    "APPLICATION_ADULT_RESERVEE_REQUIRED": "Hakijan on oltava täysi-ikäinen.",
     "CHANGES_NOT_ALLOWED": "Muutoksia ei sallita.",
     "CREATE_PERMISSION_DENIED": "Ei lupaa luoda.",
     "MAX_NUMBER_OF_ACTIVE_RESERVATIONS_EXCEEDED": "Varausten enimmäismäärä on ylittynyt.",
@@ -49,6 +50,7 @@
     "RESERVATION_NOT_WITHIN_ALLOWED_TIME_RANGE": "Tarkista varausaika.",
     "RESERVATION_OVERLAP": "Päällekkäisiä varauksia.",
     "RESERVATION_TIME_DOES_NOT_MATCH_ALLOWED_INTERVAL": "Tarkista varausaika.",
+    "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Varaajan on oltava täysi-ikäinen.",
     "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "Lyhennä varausaikaa.",
     "RESERVATION_UNIT_IN_OPEN_ROUND": "Voit tehdä kausivaraushakemuksen tähän kohteeseen.",
     "RESERVATION_UNIT_IS_NOT_OPEN": "Kohde on tällä hetkellä suljettu.",
@@ -57,7 +59,6 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Tähän kohteeseen voit tehdä vain kausivaraushakemuksen.",
     "UNKNOWN": "Tapahtui virhe.",
     "validation": {
-      "APPLICATION_ADULT_RESERVEE_REQUIRED": "Hakijan on oltava täysi-ikäinen.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Hakijan tyyppi puuttuu.",
       "APPLICATION_BILLING_ADDRESS_MISSING": "Laskutusosoite puuttuu.",
       "APPLICATION_CONTACT_PERSON_MISSING": "Yhteyshenkilö puuttuu.",
@@ -71,7 +72,6 @@
       "OVERLAPPING_RESERVATIONS": "Päällekkäisiä varauksia.",
       "RESERVATION_CANCELLATION_NOT_ALLOWED": "Peruutus ei ole sallittu.",
       "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "Liian pitkä varausaika.",
-      "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Varaajan on oltava täysi-ikäinen.",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Sinulla on maksimi määrä varauksia tässä kohteessa.",
       "USER_NOT_INTERNAL_USER": "Varauksen tekeminen ei ole sallittu.",
       "generic_validation_error": "Tapahtui virhe.",

--- a/apps/ui/public/locales/sv/errors.json
+++ b/apps/ui/public/locales/sv/errors.json
@@ -41,6 +41,7 @@
   },
   "general_error": "Odefinierat fel.",
   "api": {
+    "APPLICATION_ADULT_RESERVEE_REQUIRED": "Sökanden måste vara myndig.",
     "CHANGES_NOT_ALLOWED": "Du kan inte göra ändringar.",
     "CREATE_PERMISSION_DENIED": "Ingen behörighet att skapa.",
     "MAX_NUMBER_OF_ACTIVE_RESERVATIONS_EXCEEDED": "Det maximala antalet bokningar har överskridits.",
@@ -49,6 +50,7 @@
     "RESERVATION_NOT_WITHIN_ALLOWED_TIME_RANGE": "Kontrollera bokningstiden.",
     "RESERVATION_OVERLAP": "Överlappande bokningar.",
     "RESERVATION_TIME_DOES_NOT_MATCH_ALLOWED_INTERVAL": "Kontrollera bokningstiden.",
+    "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Personen som gör bokningen måste vara myndig.",
     "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "Förkorta bokningstiden.",
     "RESERVATION_UNIT_IN_OPEN_ROUND": "Du kan ansöka om en säsongsbokning för detta objekt.",
     "RESERVATION_UNIT_IS_NOT_OPEN": "Objektet är för närvarande stängt.",
@@ -57,7 +59,6 @@
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Du kan bara göra en ansökan om säsongsbokning för detta objekt.",
     "UNKNOWN": "Ett fel uppstod.",
     "validation": {
-      "APPLICATION_ADULT_RESERVEE_REQUIRED": "Sökanden måste vara myndig.",
       "APPLICATION_APPLICANT_TYPE_MISSING": "Sökandens typ saknas.",
       "APPLICATION_BILLING_ADDRESS_MISSING": "Faktureringsadress saknas.",
       "APPLICATION_CONTACT_PERSON_MISSING": "Kontaktperson saknas.",
@@ -71,7 +72,6 @@
       "OVERLAPPING_RESERVATIONS": "Överlappande bokningar.",
       "RESERVATION_CANCELLATION_NOT_ALLOWED": "Avbokning är inte tillåten.",
       "RESERVATION_UNIT_MAX_DURATION_EXCEEDED": "För lång bokningstid.",
-      "RESERVATION_UNIT_ADULT_RESERVEE_REQUIRED": "Personen som gör bokningen måste vara myndig.",
       "RESERVATION_UNIT_MAX_NUMBER_OF_RESERVATIONS_EXCEEDED": "Du har det maximala antalet bokningar för detta objekt.",
       "USER_NOT_INTERNAL_USER": "Det är inte tillåtet att göra en bokning.",
       "generic_validation_error": "Ett fel uppstod.",


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix adult reservee error required translations.
- Bump NextJs types to match the current installed version.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
