### PR TITLE
Speed up customer reservation unit page

### DIFF
--- a/apps/ui/components/reservation-unit/RelatedUnits.tsx
+++ b/apps/ui/components/reservation-unit/RelatedUnits.tsx
@@ -4,30 +4,47 @@ import { useTranslation } from "next-i18next";
 import { useMedia } from "react-use";
 import { H3 } from "common/styled";
 import { breakpoints } from "common/src/const";
-import type { RelatedUnitCardFieldsFragment } from "@gql/gql-types";
+import { useRelatedReservationUnitsQuery, type RelatedUnitCardFieldsFragment } from "@gql/gql-types";
 import Carousel from "../Carousel";
 import { getActivePricing, getPriceString } from "@/modules/reservationUnit";
 import Card from "common/src/components/Card";
 import { ButtonLikeLink } from "common/src/components/ButtonLikeLink";
-import { getImageSource, getMainImage } from "common/src/helpers";
+import { filterNonNullable, getImageSource, getMainImage } from "common/src/helpers";
 import { convertLanguageCode, getTranslationSafe } from "common/src/common/util";
 import { getReservationUnitPath } from "@/modules/urls";
 import { gql } from "@apollo/client";
 
 type RelatedUnitsProps = {
-  units: RelatedUnitCardFieldsFragment[];
+  thisReservationUnitPk: number;
+  unitPk: number;
   className?: string;
   style?: React.CSSProperties;
 };
 
-export function RelatedUnits({ units, style, className }: RelatedUnitsProps): JSX.Element | null {
+/// Below the fold content so use a fetch inside this
+export function RelatedUnits({
+  thisReservationUnitPk,
+  unitPk,
+  style,
+  className,
+}: RelatedUnitsProps): JSX.Element | null {
   const { t } = useTranslation();
   const isMobile = useMedia(`(max-width: ${breakpoints.m})`, false);
   const isWideMobile = useMedia(`(max-width: ${breakpoints.l})`, false);
 
-  if (units.length === 0) {
+  const { data } = useRelatedReservationUnitsQuery({
+    variables: {
+      unit: [unitPk],
+    },
+  });
+  const relatedReservationUnits: RelatedUnitCardFieldsFragment[] = filterNonNullable(
+    data?.reservationUnits?.edges?.map((n) => n?.node)
+  ).filter((n) => n?.pk !== thisReservationUnitPk);
+
+  if (relatedReservationUnits.length === 0) {
     return null;
   }
+
   return (
     <div style={style} className={className}>
       <H3 as="h2" id="related-reservation-units">
@@ -41,7 +58,7 @@ export function RelatedUnits({ units, style, className }: RelatedUnitsProps): JS
         cellSpacing={24}
         frameAriaLabel={t("reservationUnit:relatedReservationUnits")}
       >
-        {units.map((ru) => (
+        {relatedReservationUnits.map((ru) => (
           <RelatedUnitCard key={ru.pk} reservationUnit={ru} />
         ))}
       </Carousel>

--- a/apps/ui/components/reservation-unit/ReservationUnitMoreDetails.tsx
+++ b/apps/ui/components/reservation-unit/ReservationUnitMoreDetails.tsx
@@ -4,7 +4,6 @@ import {
   type ApplicationRoundTimeSlotFieldsFragment,
   type NoticeWhenReservingFragment,
   type ReservationUnitMoreDetailsFragment,
-  type TermsOfUseFieldsFragment,
   TimeSlotType,
   type PricingFieldsFragment,
 } from "@gql/gql-types";
@@ -28,20 +27,21 @@ import styled from "styled-components";
 import { formatters as getFormatters } from "common";
 import { breakpoints } from "common/src/const";
 import { AddressSection } from "./AddressSection";
+import { useGenericTermsOfUse } from "common/src/hooks";
 
 /// Below the fold content
 /// TODO use a client side fetch instead of passing data from SSR (requires more refactors)
 export function ReservationUnitMoreDetails({
   reservationUnit,
-  termsOfUse,
   isReservable,
 }: Readonly<{
   reservationUnit: ReservationUnitMoreDetailsFragment;
-  termsOfUse: TermsOfUseFieldsFragment | null;
   isReservable: boolean;
 }>) {
   const { t, i18n } = useTranslation();
   const lang = convertLanguageCode(i18n.language);
+
+  const termsOfUse = useGenericTermsOfUse();
 
   const activeApplicationRounds = reservationUnit.applicationRounds;
   const showApplicationRoundTimeSlots = activeApplicationRounds.length > 0;

--- a/apps/ui/components/reservation-unit/ReservationUnitMoreDetails.tsx
+++ b/apps/ui/components/reservation-unit/ReservationUnitMoreDetails.tsx
@@ -1,0 +1,277 @@
+import React, { useMemo } from "react";
+import { Trans, useTranslation } from "next-i18next";
+import {
+  type ApplicationRoundTimeSlotFieldsFragment,
+  type NoticeWhenReservingFragment,
+  type ReservationUnitMoreDetailsFragment,
+  type TermsOfUseFieldsFragment,
+  TimeSlotType,
+  type PricingFieldsFragment,
+} from "@gql/gql-types";
+import { Map as MapComponent } from "@/components/Map";
+import { getFuturePricing, getPriceString, getReservationUnitName } from "@/modules/reservationUnit";
+import { JustForMobile } from "@/modules/style/layout";
+import { Accordion } from "hds-react";
+import { gql } from "@apollo/client";
+import {
+  filterNonNullable,
+  formatListToCSV,
+  formatTimeRange,
+  isPriceFree,
+  timeToMinutes,
+  toNumber,
+} from "common/src/helpers";
+import { convertLanguageCode, getTranslationSafe, toUIDate } from "common/src/common/util";
+import { ReservationInfoSection } from "./ReservationInfoSection";
+import { Sanitize } from "common/src/components/Sanitize";
+import styled from "styled-components";
+import { formatters as getFormatters } from "common";
+import { breakpoints } from "common/src/const";
+import { AddressSection } from "./AddressSection";
+
+/// Below the fold content
+/// TODO use a client side fetch instead of passing data from SSR (requires more refactors)
+export function ReservationUnitMoreDetails({
+  reservationUnit,
+  termsOfUse,
+  isReservable,
+}: Readonly<{
+  reservationUnit: ReservationUnitMoreDetailsFragment;
+  termsOfUse: TermsOfUseFieldsFragment | null;
+  isReservable: boolean;
+}>) {
+  const { t, i18n } = useTranslation();
+  const lang = convertLanguageCode(i18n.language);
+
+  const activeApplicationRounds = reservationUnit.applicationRounds;
+  const showApplicationRoundTimeSlots = activeApplicationRounds.length > 0;
+  const applicationRoundTimeSlots = reservationUnit.applicationRoundTimeSlots;
+  const shouldDisplayPricingTerms = useMemo(() => {
+    const pricings = filterNonNullable(reservationUnit?.pricings);
+    if (pricings.length === 0) {
+      return false;
+    }
+    const isPaid = pricings.some((pricing) => !isPriceFree(pricing));
+    return reservationUnit?.canApplyFreeOfCharge && isPaid;
+  }, [reservationUnit?.canApplyFreeOfCharge, reservationUnit?.pricings]);
+
+  const paymentTermsContent = reservationUnit.paymentTerms
+    ? getTranslationSafe(reservationUnit.paymentTerms, "text", lang)
+    : undefined;
+  const cancellationTermsContent = reservationUnit.cancellationTerms
+    ? getTranslationSafe(reservationUnit.cancellationTerms, "text", lang)
+    : undefined;
+  const pricingTermsContent = reservationUnit.pricingTerms
+    ? getTranslationSafe(reservationUnit.pricingTerms, "text", lang)
+    : undefined;
+  const serviceSpecificTermsContent = reservationUnit.serviceSpecificTerms
+    ? getTranslationSafe(reservationUnit.serviceSpecificTerms, "text", lang)
+    : undefined;
+
+  return (
+    <>
+      <ReservationInfoSection reservationUnit={reservationUnit} reservationUnitIsReservable={isReservable} />
+      <NoticeWhenReservingSection reservationUnit={reservationUnit} />
+      {showApplicationRoundTimeSlots && (
+        <Accordion headingLevel={2} heading={t("reservationUnit:recurringHeading")} closeButton={false}>
+          <p>{t("reservationUnit:recurringBody")}</p>
+          {applicationRoundTimeSlots.map((day) => (
+            <ApplicationRoundScheduleDay key={day.weekday} {...day} />
+          ))}
+        </Accordion>
+      )}
+      {reservationUnit.unit?.tprekId && (
+        <Accordion closeButton={false} heading={t("common:location")} initiallyOpen>
+          <JustForMobile customBreakpoint={breakpoints.l}>
+            <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
+          </JustForMobile>
+          <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
+        </Accordion>
+      )}
+      {(paymentTermsContent || cancellationTermsContent) && (
+        <Accordion
+          heading={t(`reservationUnit:${paymentTermsContent ? "paymentAndCancellationTerms" : "cancellationTerms"}`)}
+          closeButton={false}
+          data-testid="reservation-unit__payment-and-cancellation-terms"
+        >
+          {paymentTermsContent && <Sanitize html={paymentTermsContent} />}
+          <Sanitize html={cancellationTermsContent ?? ""} />
+        </Accordion>
+      )}
+      {shouldDisplayPricingTerms && pricingTermsContent && (
+        <Accordion
+          heading={t("reservationUnit:pricingTerms")}
+          closeButton={false}
+          data-testid="reservation-unit__pricing-terms"
+        >
+          <Sanitize html={pricingTermsContent} />
+        </Accordion>
+      )}
+      <Accordion
+        heading={t("reservationUnit:termsOfUse")}
+        closeButton={false}
+        data-testid="reservation-unit__terms-of-use"
+      >
+        {serviceSpecificTermsContent && <Sanitize html={serviceSpecificTermsContent} />}
+        <Sanitize html={getTranslationSafe(termsOfUse ?? {}, "text", lang)} />
+      </Accordion>
+    </>
+  );
+}
+function NoticeWhenReservingSection({
+  reservationUnit,
+}: {
+  reservationUnit: NoticeWhenReservingFragment;
+}): JSX.Element | null {
+  const { t, i18n } = useTranslation();
+  const lang = convertLanguageCode(i18n.language);
+  const notesWhenReserving = getTranslationSafe(reservationUnit, "notesWhenApplying", lang);
+
+  const appRounds = reservationUnit.applicationRounds;
+  const futurePricing = getFuturePricing(reservationUnit, appRounds);
+
+  if (!futurePricing && !notesWhenReserving) {
+    return null;
+  }
+  return (
+    <Accordion
+      heading={t("reservationUnit:terms")}
+      headingLevel={2}
+      closeButton={false}
+      data-testid="reservation-unit__reservation-notice"
+    >
+      {futurePricing && <PriceChangeNotice futurePricing={futurePricing} />}
+      {notesWhenReserving && <Sanitize html={notesWhenReserving} />}
+    </Accordion>
+  );
+}
+
+function PriceChangeNotice({ futurePricing }: { futurePricing: PricingFieldsFragment }): JSX.Element {
+  const { t, i18n } = useTranslation();
+
+  const isPaid = !isPriceFree(futurePricing);
+  const taxPercentage = toNumber(futurePricing.taxPercentage.value) ?? 0;
+  const begins = new Date(futurePricing.begins);
+  const priceString = getPriceString({
+    t,
+    pricing: futurePricing,
+  }).toLocaleLowerCase();
+  const showTaxNotice = isPaid && taxPercentage > 0;
+  const formatters = getFormatters(i18n.language);
+
+  return (
+    <p style={{ marginTop: 0 }}>
+      <Trans
+        i18nKey="reservationUnit:futurePricingNotice"
+        defaults="Huomioi <bold>hinnoittelumuutos {{date}} alkaen. Uusi hinta on {{price}}</bold>."
+        values={{
+          date: toUIDate(begins),
+          price: priceString,
+        }}
+        components={{ bold: <strong /> }}
+      />
+      {showTaxNotice && (
+        <strong>
+          {t("reservationUnit:futurePriceNoticeTax", {
+            tax: formatters.strippedDecimal?.format(taxPercentage),
+          })}
+        </strong>
+      )}
+      .
+    </p>
+  );
+}
+
+const StyledApplicationRoundScheduleDay = styled.p`
+  span:first-child {
+    display: inline-block;
+    font-weight: bold;
+    width: 9ch;
+    margin-right: var(--spacing-s);
+  }
+`;
+
+function formatTimeSlot(slot: TimeSlotType): string {
+  const { begin, end } = slot;
+  if (!begin || !end) {
+    return "";
+  }
+  const beginTime = timeToMinutes(begin);
+  const endTime = timeToMinutes(end);
+  const endTimeChecked = endTime === 0 ? 24 * 60 : endTime;
+  return formatTimeRange(beginTime, endTimeChecked, true);
+}
+
+// Returns an element for a weekday in the application round timetable, with up to two timespans
+function ApplicationRoundScheduleDay(props: ApplicationRoundTimeSlotFieldsFragment) {
+  const { t } = useTranslation();
+  const { weekday, isClosed } = props;
+  const reservableTimes = filterNonNullable(props.reservableTimes);
+  return (
+    <StyledApplicationRoundScheduleDay>
+      <span data-testid="application-round-time-slot__weekday">{t(`common:weekdayLongEnum.${weekday}`)}</span>{" "}
+      {isClosed ? (
+        <span data-testid="application-round-time-slot__value">-</span>
+      ) : (
+        reservableTimes.length > 0 && (
+          <span data-testid="application-round-time-slot__value">
+            {formatListToCSV(
+              t,
+              reservableTimes.map((slot) => formatTimeSlot(slot))
+            )}
+          </span>
+        )
+      )}
+    </StyledApplicationRoundScheduleDay>
+  );
+}
+
+export const APPLICATION_ROUND_TIME_SLOT_FRAGMENT = gql`
+  fragment ApplicationRoundTimeSlotFields on ApplicationRoundTimeSlotNode {
+    id
+    weekday
+    isClosed
+    reservableTimes {
+      begin
+      end
+    }
+  }
+`;
+
+export const NOTICE_WHEN_RESERVING_FRAGMENT = gql`
+  fragment NoticeWhenReserving on ReservationUnitNode {
+    notesWhenApplyingEn
+    notesWhenApplyingFi
+    notesWhenApplyingSv
+    ...PriceReservationUnitFields
+    applicationRounds(filter: { ongoing: true }) {
+      id
+      reservationPeriodBeginDate
+      reservationPeriodEndDate
+    }
+  }
+`;
+
+export const RESERVATION_UNIT_MODE_DETAILS_FRAGMENT = gql`
+  fragment ReservationUnitMoreDetails on ReservationUnitNode {
+    nameFi
+    nameEn
+    nameSv
+    applicationRoundTimeSlots {
+      ...ApplicationRoundTimeSlotFields
+    }
+    ...MetadataSets
+    ...TermsOfUse
+    ...ReservationQuotaReached
+    canApplyFreeOfCharge
+    ...NoticeWhenReserving
+    ...ReservationInfoSection
+    pricings {
+      id
+      highestPrice
+    }
+    unit {
+      ...AddressFields
+    }
+  }
+`;

--- a/apps/ui/hooks/useCurrentUser.ts
+++ b/apps/ui/hooks/useCurrentUser.ts
@@ -21,15 +21,21 @@ export function useCurrentUser(): {
   };
 }
 
-export const CURRENT_USER = gql`
+export const CURRENT_USER_FRAGMENT = gql`
+  fragment CurrentUserFields on UserNode {
+    id
+    pk
+    firstName
+    lastName
+    email
+    isAdAuthenticated
+  }
+`;
+
+export const CURRENT_USER_QUERY = gql`
   query CurrentUser {
     currentUser {
-      id
-      pk
-      firstName
-      lastName
-      email
-      isAdAuthenticated
+      ...CurrentUserFields
     }
   }
 `;

--- a/apps/ui/modules/serverUtils.ts
+++ b/apps/ui/modules/serverUtils.ts
@@ -45,11 +45,11 @@ export async function getGenericTerms(apolloClient: ApolloClient<unknown>): Prom
     query: TermsOfUseDocument,
     variables: {
       termsType: TermsOfUseTypeChoices.GenericTerms,
+      pk: genericTermsVariant.BOOKING,
     },
   });
 
-  // TODO missing backend filtering
-  const tos = tosData?.allTermsOfUse.find((node) => node?.pk === genericTermsVariant.BOOKING) ?? null;
+  const tos = tosData.allTermsOfUse.find(() => true) ?? null;
 
   // NOTE there is no error reporting in the Pages even though this is required data
   // so Pages / Components might return null if tos is missing

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -651,10 +651,14 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
 
   const isPostLogin = query.isPostLogin === "true";
 
+  const startTime = performance.now();
   // recheck login status in case user cancelled the login
   const { data: userData } = await apolloClient.query<CurrentUserQuery>({
     query: CurrentUserDocument,
   });
+  let innerEndTime = performance.now();
+  // oxlint-disable-next-line no-console
+  console.log("Fetch Current user took:", innerEndTime - startTime, "ms");
   let mutationErrors: ApiError[] | null = null;
   if (pk != null && pk > 0 && isPostLogin && userData?.currentUser != null) {
     const beginsAt = ignoreMaybeArray(query.begin);
@@ -696,6 +700,8 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     const startDate = today;
     const endDate = addYears(today, 2);
 
+    let innerStartTime = performance.now();
+    // This takes 400ms+ on local server
     const { data: reservationUnitData } = await apolloClient.query<
       ReservationUnitPageQuery,
       ReservationUnitPageQueryVariables
@@ -707,6 +713,9 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         endDate: toApiDate(endDate) ?? "",
       },
     });
+    innerEndTime = performance.now();
+    // oxlint-disable-next-line no-console
+    console.log("Fetch reservationUnit took:", innerEndTime - innerStartTime, "ms");
 
     const reservationUnit = getNode(reservationUnitData);
 
@@ -724,8 +733,14 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       return notFound;
     }
 
+    innerStartTime = performance.now();
+    // This takes 50-60 ms on local server
     const bookingTerms = await getGenericTerms(apolloClient);
+    innerEndTime = performance.now();
+    // oxlint-disable-next-line no-console
+    console.log("Fetch terms took:", innerEndTime - innerStartTime, "ms");
 
+    innerStartTime = performance.now();
     let relatedReservationUnits: RelatedUnitCardFieldsFragment[] = [];
     if (reservationUnit?.unit?.pk) {
       const { data: relatedData } = await apolloClient.query<
@@ -741,11 +756,18 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         (n) => n?.pk !== reservationUnit?.pk
       );
     }
+    innerEndTime = performance.now();
+    // oxlint-disable-next-line no-console
+    console.log("Fetch related units took:", innerEndTime - innerStartTime, "ms");
 
     const queryParams = new URLSearchParams(query as Record<string, string>);
     const searchDate = queryParams.get("date") ?? null;
     const searchTime = queryParams.get("time") ?? null;
     const searchDuration = toNumber(ignoreMaybeArray(queryParams.get("duration")));
+
+    const endTime = performance.now();
+    // oxlint-disable-next-line no-console
+    console.log("SSR fetches took in total:", endTime - startTime, "ms");
 
     return {
       props: {

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -19,8 +19,6 @@ import {
   CreateReservationDocument,
   type CreateReservationMutation,
   type CreateReservationMutationVariables,
-  CurrentUserDocument,
-  type CurrentUserQuery,
   type ReservationCreateMutation,
   ReservationUnitPageDocument,
   type ReservationUnitPageQuery,
@@ -440,43 +438,32 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     const beginsAt = ignoreMaybeArray(query.begin);
     const endsAt = ignoreMaybeArray(query.end);
     if (isPostLogin && beginsAt != null && endsAt != null) {
-      // recheck login status in case user cancelled the login
-      // TODO this might be superflous, we could just catch API errors instead
-      const { data: userData } = await apolloClient.query<CurrentUserQuery>({
-        query: CurrentUserDocument,
-      });
-      let innerEndTime = performance.now();
-      // oxlint-disable-next-line no-console
-      console.log("Fetch Current user took:", innerEndTime - startTime, "ms");
+      const input: ReservationCreateMutation = {
+        beginsAt,
+        endsAt,
+        reservationUnit: pk,
+      };
 
-      if (userData.currentUser != null) {
-        const input: ReservationCreateMutation = {
-          beginsAt,
-          endsAt,
-          reservationUnit: pk,
+      try {
+        const res = await apolloClient.mutate<CreateReservationMutation, CreateReservationMutationVariables>({
+          mutation: CreateReservationDocument,
+          variables: {
+            input,
+          },
+        });
+        const { pk: reservationPk } = res.data?.createReservation ?? {};
+        return {
+          redirect: {
+            destination: getReservationInProgressPath(pk, reservationPk),
+            permanent: false,
+          },
+          props: {
+            notFound: true, // required for type narrowing
+          },
         };
-
-        try {
-          const res = await apolloClient.mutate<CreateReservationMutation, CreateReservationMutationVariables>({
-            mutation: CreateReservationDocument,
-            variables: {
-              input,
-            },
-          });
-          const { pk: reservationPk } = res.data?.createReservation ?? {};
-          return {
-            redirect: {
-              destination: getReservationInProgressPath(pk, reservationPk),
-              permanent: false,
-            },
-            props: {
-              notFound: true, // required for type narrowing
-            },
-          };
-        } catch (error) {
-          // Format errors so we can JSON.stringify them and toast them on client
-          mutationErrors = getApiErrors(error);
-        }
+      } catch (error) {
+        // Format errors so we can JSON.stringify them and toast them on client
+        mutationErrors = getApiErrors(error);
       }
     }
 

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useState } from "react";
 import type { GetServerSidePropsContext } from "next";
-import { Trans, useTranslation } from "next-i18next";
+import { useTranslation } from "next-i18next";
 import { useRouter } from "next/router";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 import styled from "styled-components";
@@ -13,48 +13,31 @@ import {
   toApiDate,
   toUIDate,
 } from "common/src/common/util";
-import { formatters as getFormatters } from "common";
 import { Flex, H4 } from "common/styled";
 import { breakpoints } from "common/src/const";
 import {
-  type ApplicationRoundTimeSlotFieldsFragment,
   CreateReservationDocument,
   type CreateReservationMutation,
   type CreateReservationMutationVariables,
   CurrentUserDocument,
   type CurrentUserQuery,
-  type PricingFieldsFragment,
   type ReservationCreateMutation,
   ReservationUnitPageDocument,
   type ReservationUnitPageQuery,
   type ReservationUnitPageQueryVariables,
-  type TimeSlotType,
   useCreateReservationMutation,
 } from "@gql/gql-types";
-import {
-  createNodeId,
-  filterNonNullable,
-  formatListToCSV,
-  formatTimeRange,
-  getNode,
-  ignoreMaybeArray,
-  isPriceFree,
-  timeToMinutes,
-  toNumber,
-} from "common/src/helpers";
+import { createNodeId, filterNonNullable, getNode, ignoreMaybeArray, toNumber } from "common/src/helpers";
 import { Sanitize } from "common/src/components/Sanitize";
 import { createApolloClient } from "@/modules/apolloClient";
-import { Map as MapComponent } from "@/components/Map";
 import { getPostLoginUrl } from "@/modules/util";
 import {
-  getFuturePricing,
-  getPriceString,
   getReservationUnitName,
   getTimeString,
   isReservationUnitPublished,
   isReservationUnitReservable,
 } from "@/modules/reservationUnit";
-import { JustForDesktop, JustForMobile } from "@/modules/style/layout";
+import { JustForDesktop } from "@/modules/style/layout";
 import {
   convertFormToFocustimeSlot,
   createDateTime,
@@ -69,7 +52,6 @@ import {
   EquipmentList,
   Head,
   RelatedUnits,
-  ReservationInfoSection,
   ReservationUnitCalendarSection,
 } from "@/components/reservation-unit";
 import { getCommonServerSideProps, getGenericTerms } from "@/modules/serverUtils";
@@ -80,7 +62,7 @@ import { LoginFragment } from "@/components/LoginFragment";
 import { SubmitButton } from "@/styled/util";
 import { ReservationUnitPageWrapper } from "@/styled/reservation";
 import { getReservationInProgressPath, getSingleSearchPath } from "@/modules/urls";
-import { Accordion, ButtonVariant, LoadingSpinner } from "hds-react";
+import { ButtonVariant, LoadingSpinner } from "hds-react";
 import { Breadcrumb } from "@/components/common/Breadcrumb";
 import { useDisplayError } from "common/src/hooks";
 import {
@@ -95,63 +77,7 @@ import { type ApiError, getApiErrors } from "common/src/apolloUtils";
 import { formatErrorMessage } from "common/src/hooks/useDisplayError";
 import { errorToast } from "common/src/components/toast";
 import { QuickReservation } from "@/components/QuickReservation";
-
-const StyledApplicationRoundScheduleDay = styled.p`
-  span:first-child {
-    display: inline-block;
-    font-weight: bold;
-    width: 9ch;
-    margin-right: var(--spacing-s);
-  }
-`;
-
-function formatTimeSlot(slot: TimeSlotType): string {
-  const { begin, end } = slot;
-  if (!begin || !end) {
-    return "";
-  }
-  const beginTime = timeToMinutes(begin);
-  const endTime = timeToMinutes(end);
-  const endTimeChecked = endTime === 0 ? 24 * 60 : endTime;
-  return formatTimeRange(beginTime, endTimeChecked, true);
-}
-
-export const APPLICATION_ROUND_TIME_SLOT_FRAGMENT = gql`
-  fragment ApplicationRoundTimeSlotFields on ApplicationRoundTimeSlotNode {
-    id
-    weekday
-    isClosed
-    reservableTimes {
-      begin
-      end
-    }
-  }
-`;
-
-// Returns an element for a weekday in the application round timetable, with up to two timespans
-function ApplicationRoundScheduleDay(props: ApplicationRoundTimeSlotFieldsFragment) {
-  const { t } = useTranslation();
-  const { weekday, isClosed } = props;
-  const reservableTimes = filterNonNullable(props.reservableTimes);
-  return (
-    <StyledApplicationRoundScheduleDay>
-      <span data-testid="application-round-time-slot__weekday">{t(`common:weekdayLongEnum.${weekday}`)}</span>{" "}
-      {isClosed ? (
-        <span data-testid="application-round-time-slot__value">-</span>
-      ) : (
-        reservableTimes.length > 0 && (
-          <span data-testid="application-round-time-slot__value">
-            {formatListToCSV(
-              t,
-              reservableTimes.map((slot) => formatTimeSlot(slot))
-            )}
-          </span>
-        )
-      )}
-    </StyledApplicationRoundScheduleDay>
-  );
-}
-
+import { ReservationUnitMoreDetails } from "@/components/reservation-unit/ReservationUnitMoreDetails";
 function SubmitFragment({
   apiBaseUrl,
   focusSlot,
@@ -338,19 +264,6 @@ function ReservationUnit({
     blockingReservations,
   ]);
 
-  const showApplicationRoundTimeSlots = activeApplicationRounds.length > 0;
-
-  const { applicationRoundTimeSlots } = reservationUnit;
-
-  const shouldDisplayPricingTerms = useMemo(() => {
-    const pricings = filterNonNullable(reservationUnit.pricings);
-    if (pricings.length === 0) {
-      return false;
-    }
-    const isPaid = pricings.some((pricing) => !isPriceFree(pricing));
-    return reservationUnit.canApplyFreeOfCharge && isPaid;
-  }, [reservationUnit.canApplyFreeOfCharge, reservationUnit.pricings]);
-
   const [createReservationMutation] = useCreateReservationMutation();
 
   const createReservation = async (input: ReservationCreateMutation): Promise<void> => {
@@ -379,19 +292,6 @@ function ReservationUnit({
     // eslint-disable-next-line no-console
     console.warn("not reservable because: ", reason);
   }
-
-  const paymentTermsContent = reservationUnit.paymentTerms
-    ? getTranslationSafe(reservationUnit.paymentTerms, "text", lang)
-    : undefined;
-  const cancellationTermsContent = reservationUnit.cancellationTerms
-    ? getTranslationSafe(reservationUnit.cancellationTerms, "text", lang)
-    : undefined;
-  const pricingTermsContent = reservationUnit.pricingTerms
-    ? getTranslationSafe(reservationUnit.pricingTerms, "text", lang)
-    : undefined;
-  const serviceSpecificTermsContent = reservationUnit.serviceSpecificTerms
-    ? getTranslationSafe(reservationUnit.serviceSpecificTerms, "text", lang)
-    : undefined;
 
   const equipment = filterNonNullable(reservationUnit.equipments);
 
@@ -430,6 +330,10 @@ function ReservationUnit({
       ) : undefined,
     [reservationUnit.canApplyFreeOfCharge]
   );
+
+  const pricingTermsContent = reservationUnit.pricingTerms
+    ? getTranslationSafe(reservationUnit.pricingTerms, "text", lang)
+    : undefined;
 
   return (
     <ReservationUnitPageWrapper>
@@ -477,54 +381,11 @@ function ReservationUnit({
             submitReservation={submitReservation}
           />
         )}
-        <ReservationInfoSection
+        <ReservationUnitMoreDetails
           reservationUnit={reservationUnit}
-          reservationUnitIsReservable={reservationUnitIsReservable}
+          termsOfUse={termsOfUse.genericTerms}
+          isReservable={reservationUnitIsReservable}
         />
-        <NoticeWhenReservingSection reservationUnit={reservationUnit} />
-        {showApplicationRoundTimeSlots && (
-          <Accordion headingLevel={2} heading={t("reservationUnit:recurringHeading")} closeButton={false}>
-            <p>{t("reservationUnit:recurringBody")}</p>
-            {applicationRoundTimeSlots.map((day) => (
-              <ApplicationRoundScheduleDay key={day.weekday} {...day} />
-            ))}
-          </Accordion>
-        )}
-        {reservationUnit.unit?.tprekId && (
-          <Accordion closeButton={false} heading={t("common:location")} initiallyOpen>
-            <JustForMobile customBreakpoint={breakpoints.l}>
-              <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
-            </JustForMobile>
-            <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
-          </Accordion>
-        )}
-        {(paymentTermsContent || cancellationTermsContent) && (
-          <Accordion
-            heading={t(`reservationUnit:${paymentTermsContent ? "paymentAndCancellationTerms" : "cancellationTerms"}`)}
-            closeButton={false}
-            data-testid="reservation-unit__payment-and-cancellation-terms"
-          >
-            {paymentTermsContent && <Sanitize html={paymentTermsContent} />}
-            <Sanitize html={cancellationTermsContent ?? ""} />
-          </Accordion>
-        )}
-        {shouldDisplayPricingTerms && pricingTermsContent && (
-          <Accordion
-            heading={t("reservationUnit:pricingTerms")}
-            closeButton={false}
-            data-testid="reservation-unit__pricing-terms"
-          >
-            <Sanitize html={pricingTermsContent} />
-          </Accordion>
-        )}
-        <Accordion
-          heading={t("reservationUnit:termsOfUse")}
-          closeButton={false}
-          data-testid="reservation-unit__terms-of-use"
-        >
-          {serviceSpecificTermsContent && <Sanitize html={serviceSpecificTermsContent} />}
-          <Sanitize html={getTranslationSafe(termsOfUse.genericTerms ?? {}, "text", lang)} />
-        </Accordion>
       </PageContentWrapper>
       <InfoDialog
         id="pricing-terms"
@@ -553,70 +414,6 @@ function ReservationUnitWrapped(props: PropsNarrowed) {
       <Breadcrumb routes={routes} />
       <ReservationUnit {...props} />
     </>
-  );
-}
-
-function NoticeWhenReservingSection({
-  reservationUnit,
-}: {
-  reservationUnit: PropsNarrowed["reservationUnit"];
-}): JSX.Element | null {
-  const { t, i18n } = useTranslation();
-  const lang = convertLanguageCode(i18n.language);
-  const notesWhenReserving = getTranslationSafe(reservationUnit, "notesWhenApplying", lang);
-
-  const appRounds = reservationUnit.applicationRounds;
-  const futurePricing = getFuturePricing(reservationUnit, appRounds);
-
-  if (!futurePricing && !notesWhenReserving) {
-    return null;
-  }
-  return (
-    <Accordion
-      heading={t("reservationUnit:terms")}
-      headingLevel={2}
-      closeButton={false}
-      data-testid="reservation-unit__reservation-notice"
-    >
-      {futurePricing && <PriceChangeNotice futurePricing={futurePricing} />}
-      {notesWhenReserving && <Sanitize html={notesWhenReserving} />}
-    </Accordion>
-  );
-}
-
-function PriceChangeNotice({ futurePricing }: { futurePricing: PricingFieldsFragment }): JSX.Element {
-  const { t, i18n } = useTranslation();
-
-  const isPaid = !isPriceFree(futurePricing);
-  const taxPercentage = toNumber(futurePricing.taxPercentage.value) ?? 0;
-  const begins = new Date(futurePricing.begins);
-  const priceString = getPriceString({
-    t,
-    pricing: futurePricing,
-  }).toLocaleLowerCase();
-  const showTaxNotice = isPaid && taxPercentage > 0;
-  const formatters = getFormatters(i18n.language);
-
-  return (
-    <p style={{ marginTop: 0 }}>
-      <Trans
-        i18nKey="reservationUnit:futurePricingNotice"
-        defaults="Huomioi <bold>hinnoittelumuutos {{date}} alkaen. Uusi hinta on {{price}}</bold>."
-        values={{
-          date: toUIDate(begins),
-          price: priceString,
-        }}
-        components={{ bold: <strong /> }}
-      />
-      {showTaxNotice && (
-        <strong>
-          {t("reservationUnit:futurePriceNoticeTax", {
-            tax: formatters.strippedDecimal?.format(taxPercentage),
-          })}
-        </strong>
-      )}
-      .
-    </p>
   );
 }
 
@@ -771,29 +568,18 @@ export const RESERVATION_UNIT_PAGE_QUERY = gql`
       ... on ReservationUnitNode {
         id
         pk
-        nameFi
-        nameEn
-        nameSv
         ...AvailableTimesReservationUnitFields
         ...NotReservableFields
         ...ReservationTimePickerFields
         ...MetadataSets
         ...ReservationUnitHead
-        unit {
-          ...AddressFields
-        }
+        ...ReservationUnitMoreDetails
         extUuid
-        ...TermsOfUse
         isDraft
-        applicationRoundTimeSlots {
-          ...ApplicationRoundTimeSlotFields
-        }
         descriptionFi
         descriptionEn
         descriptionSv
         canApplyFreeOfCharge
-        ...ReservationInfoSection
-        ...ReservationQuotaReached
         publishingState
         equipments {
           id

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -431,53 +431,55 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     notFound: true,
   };
 
+  const startTime = performance.now();
+
   const isPostLogin = query.isPostLogin === "true";
 
-  const startTime = performance.now();
-  // recheck login status in case user cancelled the login
-  const { data: userData } = await apolloClient.query<CurrentUserQuery>({
-    query: CurrentUserDocument,
-  });
-  let innerEndTime = performance.now();
-  // oxlint-disable-next-line no-console
-  console.log("Fetch Current user took:", innerEndTime - startTime, "ms");
   let mutationErrors: ApiError[] | null = null;
-  if (pk != null && pk > 0 && isPostLogin && userData?.currentUser != null) {
+  if (pk != null && pk > 0) {
     const beginsAt = ignoreMaybeArray(query.begin);
     const endsAt = ignoreMaybeArray(query.end);
+    if (isPostLogin && beginsAt != null && endsAt != null) {
+      // recheck login status in case user cancelled the login
+      // TODO this might be superflous, we could just catch API errors instead
+      const { data: userData } = await apolloClient.query<CurrentUserQuery>({
+        query: CurrentUserDocument,
+      });
+      let innerEndTime = performance.now();
+      // oxlint-disable-next-line no-console
+      console.log("Fetch Current user took:", innerEndTime - startTime, "ms");
 
-    if (beginsAt != null && endsAt != null) {
-      const input: ReservationCreateMutation = {
-        beginsAt,
-        endsAt,
-        reservationUnit: pk,
-      };
-
-      try {
-        const res = await apolloClient.mutate<CreateReservationMutation, CreateReservationMutationVariables>({
-          mutation: CreateReservationDocument,
-          variables: {
-            input,
-          },
-        });
-        const { pk: reservationPk } = res.data?.createReservation ?? {};
-        return {
-          redirect: {
-            destination: getReservationInProgressPath(pk, reservationPk),
-            permanent: false,
-          },
-          props: {
-            notFound: true, // required for type narrowing
-          },
+      if (userData.currentUser != null) {
+        const input: ReservationCreateMutation = {
+          beginsAt,
+          endsAt,
+          reservationUnit: pk,
         };
-      } catch (error) {
-        // Format errors so we can JSON.stringify them and toast them on client
-        mutationErrors = getApiErrors(error);
+
+        try {
+          const res = await apolloClient.mutate<CreateReservationMutation, CreateReservationMutationVariables>({
+            mutation: CreateReservationDocument,
+            variables: {
+              input,
+            },
+          });
+          const { pk: reservationPk } = res.data?.createReservation ?? {};
+          return {
+            redirect: {
+              destination: getReservationInProgressPath(pk, reservationPk),
+              permanent: false,
+            },
+            props: {
+              notFound: true, // required for type narrowing
+            },
+          };
+        } catch (error) {
+          // Format errors so we can JSON.stringify them and toast them on client
+          mutationErrors = getApiErrors(error);
+        }
       }
     }
-  }
 
-  if (pk != null && pk > 0) {
     const today = new Date();
     const startDate = today;
     const endDate = addYears(today, 2);
@@ -495,7 +497,7 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         endDate: toApiDate(endDate) ?? "",
       },
     });
-    innerEndTime = performance.now();
+    let innerEndTime = performance.now();
     // oxlint-disable-next-line no-console
     console.log("Fetch reservationUnit took:", innerEndTime - innerStartTime, "ms");
 

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -24,10 +24,6 @@ import {
   CurrentUserDocument,
   type CurrentUserQuery,
   type PricingFieldsFragment,
-  RelatedReservationUnitsDocument,
-  type RelatedReservationUnitsQuery,
-  type RelatedReservationUnitsQueryVariables,
-  type RelatedUnitCardFieldsFragment,
   type ReservationCreateMutation,
   ReservationUnitPageDocument,
   type ReservationUnitPageQuery,
@@ -223,12 +219,9 @@ const StyledRelatedUnits = styled(RelatedUnits)`
 
 function ReservationUnit({
   reservationUnit,
-  relatedReservationUnits,
   termsOfUse,
   apiBaseUrl,
-  searchDuration,
-  searchDate,
-  searchTime,
+  queryParams: { searchDuration, searchDate, searchTime },
   mutationErrors,
 }: Readonly<PropsNarrowed>): JSX.Element | null {
   const { t, i18n } = useTranslation();
@@ -387,8 +380,6 @@ function ReservationUnit({
     console.warn("not reservable because: ", reason);
   }
 
-  const shouldDisplayBottomWrapper = relatedReservationUnits?.length > 0;
-
   const paymentTermsContent = reservationUnit.paymentTerms
     ? getTranslationSafe(reservationUnit.paymentTerms, "text", lang)
     : undefined;
@@ -542,8 +533,7 @@ function ReservationUnit({
         isOpen={isPricingTermsDialogOpen}
         onClose={() => setIsPricingTermsDialogOpen(false)}
       />
-      {/* TODO this breaks the layout when inside a grid (the RelatedUnits) */}
-      {shouldDisplayBottomWrapper && <StyledRelatedUnits units={relatedReservationUnits} />}
+      <StyledRelatedUnits thisReservationUnitPk={reservationUnit.pk} unitPk={reservationUnit.unit.pk} />
     </ReservationUnitPageWrapper>
   );
 }
@@ -740,26 +730,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
     // oxlint-disable-next-line no-console
     console.log("Fetch terms took:", innerEndTime - innerStartTime, "ms");
 
-    innerStartTime = performance.now();
-    let relatedReservationUnits: RelatedUnitCardFieldsFragment[] = [];
-    if (reservationUnit?.unit?.pk) {
-      const { data: relatedData } = await apolloClient.query<
-        RelatedReservationUnitsQuery,
-        RelatedReservationUnitsQueryVariables
-      >({
-        query: RelatedReservationUnitsDocument,
-        variables: {
-          unit: [reservationUnit.unit.pk],
-        },
-      });
-      relatedReservationUnits = filterNonNullable(relatedData?.reservationUnits?.edges?.map((n) => n?.node)).filter(
-        (n) => n?.pk !== reservationUnit?.pk
-      );
-    }
-    innerEndTime = performance.now();
-    // oxlint-disable-next-line no-console
-    console.log("Fetch related units took:", innerEndTime - innerStartTime, "ms");
-
     const queryParams = new URLSearchParams(query as Record<string, string>);
     const searchDate = queryParams.get("date") ?? null;
     const searchTime = queryParams.get("time") ?? null;
@@ -774,11 +744,12 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         ...commonProps,
         ...(await serverSideTranslations(locale ?? "fi")),
         reservationUnit,
-        relatedReservationUnits,
         termsOfUse: { genericTerms: bookingTerms },
-        searchDuration,
-        searchDate,
-        searchTime,
+        queryParams: {
+          searchDuration,
+          searchDate,
+          searchTime,
+        },
         mutationErrors,
       },
     };

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -54,7 +54,7 @@ import {
   RelatedUnits,
   ReservationUnitCalendarSection,
 } from "@/components/reservation-unit";
-import { getCommonServerSideProps, getGenericTerms } from "@/modules/serverUtils";
+import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { useForm, type UseFormReturn } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PendingReservationFormSchema, type PendingReservationFormType } from "@/components/reservation-unit/schema";
@@ -145,7 +145,6 @@ const StyledRelatedUnits = styled(RelatedUnits)`
 
 function ReservationUnit({
   reservationUnit,
-  termsOfUse,
   apiBaseUrl,
   queryParams: { searchDuration, searchDate, searchTime },
   mutationErrors,
@@ -381,11 +380,7 @@ function ReservationUnit({
             submitReservation={submitReservation}
           />
         )}
-        <ReservationUnitMoreDetails
-          reservationUnit={reservationUnit}
-          termsOfUse={termsOfUse.genericTerms}
-          isReservable={reservationUnitIsReservable}
-        />
+        <ReservationUnitMoreDetails reservationUnit={reservationUnit} isReservable={reservationUnitIsReservable} />
       </PageContentWrapper>
       <InfoDialog
         id="pricing-terms"
@@ -520,13 +515,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
       return notFound;
     }
 
-    innerStartTime = performance.now();
-    // This takes 50-60 ms on local server
-    const bookingTerms = await getGenericTerms(apolloClient);
-    innerEndTime = performance.now();
-    // oxlint-disable-next-line no-console
-    console.log("Fetch terms took:", innerEndTime - innerStartTime, "ms");
-
     const queryParams = new URLSearchParams(query as Record<string, string>);
     const searchDate = queryParams.get("date") ?? null;
     const searchTime = queryParams.get("time") ?? null;
@@ -541,7 +529,6 @@ export async function getServerSideProps(ctx: GetServerSidePropsContext) {
         ...commonProps,
         ...(await serverSideTranslations(locale ?? "fi")),
         reservationUnit,
-        termsOfUse: { genericTerms: bookingTerms },
         queryParams: {
           searchDuration,
           searchDate,

--- a/apps/ui/pages/terms/[id].tsx
+++ b/apps/ui/pages/terms/[id].tsx
@@ -13,27 +13,31 @@ import { getCommonServerSideProps } from "@/modules/serverUtils";
 import { createApolloClient } from "@/modules/apolloClient";
 import { Sanitize } from "common/src/components/Sanitize";
 import { convertLanguageCode, getTranslationSafe } from "common/src/common/util";
+import { ignoreMaybeArray } from "common/src/helpers";
 
 type Props = Awaited<ReturnType<typeof getServerSideProps>>["props"];
+type PropsNarrowed = Exclude<Props, { notFound: boolean }>;
 
 export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   const { locale, params } = ctx;
   const commonProps = getCommonServerSideProps();
   const apolloClient = createApolloClient(commonProps.apiBaseUrl, ctx);
 
-  const genericTermsId = params?.id;
+  const genericTermsId = ignoreMaybeArray(params?.id);
   const { data } = await apolloClient.query<TermsOfUseQuery, TermsOfUseQueryVariables>({
     query: TermsOfUseDocument,
     variables: {
       termsType: TermsOfUseTypeChoices.GenericTerms,
+      pk: genericTermsId ?? "",
     },
   });
-  const genericTerms = data.allTermsOfUse?.find((n) => n?.pk === genericTermsId);
+
+  const genericTerms = data.allTermsOfUse.find(() => true);
   if (genericTerms == null) {
     return {
       props: {
         ...commonProps,
-        genericTerms: null,
+        notFound: true,
       },
       notFound: true,
     };
@@ -47,12 +51,8 @@ export const getServerSideProps = async (ctx: GetServerSidePropsContext) => {
   };
 };
 
-const GenericTerms = ({ genericTerms }: Props): JSX.Element => {
+function GenericTerms({ genericTerms }: PropsNarrowed): JSX.Element {
   const { i18n } = useTranslation();
-
-  if (genericTerms == null) {
-    return <div>404</div>;
-  }
 
   const lang = convertLanguageCode(i18n.language);
   const title = getTranslationSafe(genericTerms, "name", lang);
@@ -64,6 +64,6 @@ const GenericTerms = ({ genericTerms }: Props): JSX.Element => {
       <Sanitize html={text} />
     </>
   );
-};
+}
 
 export default GenericTerms;

--- a/apps/ui/public/locales/en/errors.json
+++ b/apps/ui/public/locales/en/errors.json
@@ -57,6 +57,7 @@
     "RESERVATION_UNIT_MIN_DURATION_NOT_EXCEEDED": "Please extend the booking time.",
     "RESERVATION_UNIT_NOT_RESERVABLE": "The item cannot be booked.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "You can only make a seasonal booking application for this item.",
+    "PERMISSION_DENIED": "Permission denied.",
     "UNKNOWN": "An error occurred.",
     "validation": {
       "APPLICATION_APPLICANT_TYPE_MISSING": "Applicant type is missing.",

--- a/apps/ui/public/locales/fi/errors.json
+++ b/apps/ui/public/locales/fi/errors.json
@@ -57,6 +57,7 @@
     "RESERVATION_UNIT_MIN_DURATION_NOT_EXCEEDED": "Pidennä varausaikaa.",
     "RESERVATION_UNIT_NOT_RESERVABLE": "Kohde ei ole varattavissa.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Tähän kohteeseen voit tehdä vain kausivaraushakemuksen.",
+    "PERMISSION_DENIED": "Ei oikeuksia.",
     "UNKNOWN": "Tapahtui virhe.",
     "validation": {
       "APPLICATION_APPLICANT_TYPE_MISSING": "Hakijan tyyppi puuttuu.",

--- a/apps/ui/public/locales/sv/errors.json
+++ b/apps/ui/public/locales/sv/errors.json
@@ -57,6 +57,7 @@
     "RESERVATION_UNIT_MIN_DURATION_NOT_EXCEEDED": "Förläng bokningstiden.",
     "RESERVATION_UNIT_NOT_RESERVABLE": "Objektet går inte att boka.",
     "RESERVATION_UNIT_TYPE_IS_SEASON": "Du kan bara göra en ansökan om säsongsbokning för detta objekt.",
+    "PERMISSION_DENIED": "Tillstånd nekad.",
     "UNKNOWN": "Ett fel uppstod.",
     "validation": {
       "APPLICATION_APPLICANT_TYPE_MISSING": "Sökandens typ saknas.",

--- a/packages/common/src/const.ts
+++ b/packages/common/src/const.ts
@@ -18,7 +18,7 @@ export const genericTermsVariant = {
   SERVICE: "service",
   PRIVACY: "privacy",
   ACCESSIBILITY: "accessibility",
-};
+} as const;
 
 export const RELATED_RESERVATION_STATES: ReservationStateChoice[] = [
   ReservationStateChoice.Created,

--- a/packages/common/src/hooks/useGenericTermsOfUse.ts
+++ b/packages/common/src/hooks/useGenericTermsOfUse.ts
@@ -1,5 +1,4 @@
 import { TermsOfUseTypeChoices, useTermsOfUseQuery } from "../../gql/gql-types";
-import { filterNonNullable } from "../helpers";
 import { genericTermsVariant } from "../const";
 import { gql } from "@apollo/client";
 
@@ -7,18 +6,20 @@ export function useGenericTermsOfUse() {
   const { data } = useTermsOfUseQuery({
     variables: {
       termsType: TermsOfUseTypeChoices.GenericTerms,
+      pk: genericTermsVariant.BOOKING,
     },
   });
 
-  return filterNonNullable(data?.allTermsOfUse).find((n) => n.pk === genericTermsVariant.BOOKING);
+  return data?.allTermsOfUse.find(() => true) ?? null;
 }
 
 export const TERMS_OF_USE_QUERY = gql`
   query TermsOfUse(
     # Filter
     $termsType: TermsOfUseTypeChoices
+    $pk: String!
   ) {
-    allTermsOfUse(filter: { termsType: $termsType }) {
+    allTermsOfUse(filter: { termsType: $termsType, pk: [$pk] }) {
       id
       ...TermsOfUseFields
     }


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Speed up reservation-unit page load times by removing extra queries from SSR.
- Refactor: move below the fold content on reservation-unit page to separate component.
- Refactor: replace frontend filtering with backend query filter in Terms queries.
- Refactor: make RelatedUnits client side only (it's below the fold). 

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: reservation-unit page, starting a reservation, "Login and Book".

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
