### PR TITLE
Fix series and section `update_access_code_is_active` logic

### DIFF
--- a/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_update_access_code_is_active.py
+++ b/backend/tests/test_integrations/test_keyless_entry/test_pindora_service/test_update_access_code_is_active.py
@@ -8,6 +8,7 @@ import pytest
 from tilavarauspalvelu.enums import AccessType, ReservationStateChoice, ReservationTypeChoice
 from tilavarauspalvelu.integrations.keyless_entry import PindoraService
 from tilavarauspalvelu.integrations.keyless_entry.exceptions import PindoraNotFoundError
+from tilavarauspalvelu.integrations.keyless_entry.typing import PindoraAccessCodeModifyResponse
 from utils.date_utils import local_datetime
 
 from tests.factories import ApplicationSectionFactory, ReservationFactory, ReservationSeriesFactory, UserFactory
@@ -135,6 +136,13 @@ def test_update_access_code_is_active__reservation__not_found():
     assert reservation.access_code_generated_at is None
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -154,11 +162,45 @@ def test_update_access_code_is_active__series__active_when_should_be_inactive():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is True
     assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == series
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__series__active_when_should_be_inactive__already_inactive_in_pindora():
+    series = ReservationSeriesFactory.create()
+    ReservationFactory.create(
+        reservation_unit=series.reservation_unit,
+        reservation_series=series,
+        begins_at=local_datetime(2024, 1, 1, 12),
+        ends_at=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -178,10 +220,18 @@ def test_update_access_code_is_active__series__active_when_should_be_active():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -201,11 +251,45 @@ def test_update_access_code_is_active__series__inactive_when_should_be_active():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is True
     assert PindoraService.activate_access_code.call_args.kwargs["obj"] == series
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__series__inactive_when_should_be_active__already_active_in_pindora():
+    series = ReservationSeriesFactory.create()
+    ReservationFactory.create(
+        reservation_unit=series.reservation_unit,
+        reservation_series=series,
+        begins_at=local_datetime(2024, 1, 1, 12),
+        ends_at=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.NORMAL,
+        access_code_is_active=False,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -225,10 +309,12 @@ def test_update_access_code_is_active__series__inactive_when_should_be_inactive(
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("not found"))
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -248,15 +334,22 @@ def test_update_access_code_is_active__series__not_found():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
-    assert PindoraService.deactivate_access_code.called is True
-    assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == series
+    assert PindoraService.deactivate_access_code.called is False
 
     reservation.refresh_from_db()
     assert reservation.access_code_is_active is False
     assert reservation.access_code_generated_at is None
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -281,11 +374,50 @@ def test_update_access_code_is_active__seasonal_booking__active_when_should_be_i
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is True
     assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == section
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__seasonal_booking__active_when_should_be_inactive__already_inactive_in_pindora():
+    user = UserFactory.create()
+    section = ApplicationSectionFactory.create(
+        application__user=user,
+    )
+    series = ReservationSeriesFactory.create(allocated_time_slot__reservation_unit_option__application_section=section)
+    ReservationFactory.create(
+        user=user,
+        reservation_unit=series.reservation_unit,
+        reservation_series=series,
+        begins_at=local_datetime(2024, 1, 1, 12),
+        ends_at=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.BLOCKED,
+        access_code_is_active=True,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -310,10 +442,18 @@ def test_update_access_code_is_active__seasonal_booking__active_when_should_be_a
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=False,
+    ),
+)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -338,11 +478,50 @@ def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is True
     assert PindoraService.activate_access_code.call_args.kwargs["obj"] == section
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(
+    PindoraService.reschedule_access_code,
+    return_value=PindoraAccessCodeModifyResponse(
+        access_code_generated_at=local_datetime(2024, 1, 1),
+        access_code_is_active=True,
+    ),
+)
+@patch_method(PindoraService.activate_access_code)
+@patch_method(PindoraService.deactivate_access_code)
+@freezegun.freeze_time(local_datetime(2024, 1, 1))
+def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be_active__already_active_in_pindora():
+    user = UserFactory.create()
+    section = ApplicationSectionFactory.create(
+        application__user=user,
+    )
+    series = ReservationSeriesFactory.create(allocated_time_slot__reservation_unit_option__application_section=section)
+    ReservationFactory.create(
+        user=user,
+        reservation_unit=series.reservation_unit,
+        reservation_series=series,
+        begins_at=local_datetime(2024, 1, 1, 12),
+        ends_at=local_datetime(2024, 1, 1, 13),
+        access_type=AccessType.ACCESS_CODE,
+        state=ReservationStateChoice.CONFIRMED,
+        type=ReservationTypeChoice.NORMAL,
+        access_code_is_active=False,
+        access_code_generated_at=local_datetime(2024, 1, 1),
+    )
+
+    PindoraService.update_access_code_is_active()
+
+    # Rescheduling will change the access code is active, but we mock it here so it doesn't happen
+    assert PindoraService.reschedule_access_code.called is True
+    assert PindoraService.activate_access_code.called is False
+    assert PindoraService.deactivate_access_code.called is False
+
+
+@patch_method(PindoraService.reschedule_access_code)
 @patch_method(PindoraService.activate_access_code)
 @patch_method(PindoraService.deactivate_access_code)
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -367,10 +546,12 @@ def test_update_access_code_is_active__seasonal_booking__inactive_when_should_be
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is False
     assert PindoraService.activate_access_code.called is False
     assert PindoraService.deactivate_access_code.called is False
 
 
+@patch_method(PindoraService.reschedule_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.activate_access_code, side_effect=PindoraNotFoundError("not found"))
 @patch_method(PindoraService.deactivate_access_code, side_effect=PindoraNotFoundError("not found"))
 @freezegun.freeze_time(local_datetime(2024, 1, 1))
@@ -395,9 +576,9 @@ def test_update_access_code_is_active__seasonal_booking__not_found():
 
     PindoraService.update_access_code_is_active()
 
+    assert PindoraService.reschedule_access_code.called is True
     assert PindoraService.activate_access_code.called is False
-    assert PindoraService.deactivate_access_code.called is True
-    assert PindoraService.deactivate_access_code.call_args.kwargs["obj"] == section
+    assert PindoraService.deactivate_access_code.called is False
 
     reservation.refresh_from_db()
     assert reservation.access_code_is_active is False

--- a/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
+++ b/backend/tilavarauspalvelu/integrations/keyless_entry/service.py
@@ -443,9 +443,11 @@ class PindoraService:
         )
 
         for reservation in reservations:
+            should_be_active = reservation.access_code_should_be_active
+
             try:
                 try:
-                    cls.create_access_code(obj=reservation, is_active=reservation.access_code_should_be_active)
+                    cls.create_access_code(obj=reservation, is_active=should_be_active)
 
                 # If reservation already exists, fetch it and update instead.
                 except PindoraConflictError:
@@ -457,7 +459,7 @@ class PindoraService:
 
                 # User needs to be informed that their reservation now has an access code,
                 # since we previously thought there was no access code.
-                if reservation.access_code_should_be_active:
+                if should_be_active:
                     EmailService.send_reservation_access_type_changed_email(reservation=reservation)
 
             except ExternalServiceError as error:
@@ -474,20 +476,20 @@ class PindoraService:
         )
 
         for series in all_series:
-            is_active: bool = series.should_have_active_access_code  # type: ignore[attr-defined]
+            should_be_active = series.should_have_active_access_code
 
             try:
                 try:
-                    cls.create_access_code(obj=series, is_active=is_active)
+                    cls.create_access_code(obj=series, is_active=should_be_active)
 
                 # If series already exists, reschedule and activate/deactivate instead.
                 except PindoraConflictError:
                     response = cls.reschedule_access_code(obj=series)
 
-                    if is_active and not response["access_code_is_active"]:
+                    if should_be_active and not response["access_code_is_active"]:
                         cls.activate_access_code(obj=series)
 
-                    elif not is_active and response["access_code_is_active"]:
+                    elif not should_be_active and response["access_code_is_active"]:
                         cls.deactivate_access_code(obj=series)
 
             except ExternalServiceError as error:
@@ -499,25 +501,25 @@ class PindoraService:
         sections: Iterable[ApplicationSection] = ApplicationSection.objects.requiring_access_code()
 
         for section in sections:
-            is_active: bool = section.should_have_active_access_code  # type: ignore[attr-defined]
+            should_be_active = section.should_have_active_access_code
 
             try:
                 try:
-                    cls.create_access_code(obj=section, is_active=is_active)
+                    cls.create_access_code(obj=section, is_active=should_be_active)
 
                 # If seasonal booking already exists, reschedule and activate/deactivate instead.
                 except PindoraConflictError:
                     response = cls.reschedule_access_code(obj=section)
 
-                    if is_active and not response["access_code_is_active"]:
+                    if should_be_active and not response["access_code_is_active"]:
                         cls.activate_access_code(obj=section)
 
-                    elif not is_active and response["access_code_is_active"]:
+                    elif not should_be_active and response["access_code_is_active"]:
                         cls.deactivate_access_code(obj=section)
 
                     # User needs to be informed that their seasonal booking now has an access code,
                     # since we previously thought there was no access code.
-                    if is_active:
+                    if should_be_active:
                         EmailService.send_seasonal_booking_access_type_changed_email(section)
 
             except ExternalServiceError as error:
@@ -530,9 +532,11 @@ class PindoraService:
         )
 
         for reservation in reservations:
+            should_be_active = reservation.access_code_should_be_active
+
             try:
                 try:
-                    if reservation.access_code_should_be_active:
+                    if should_be_active:
                         cls.activate_access_code(obj=reservation)
 
                         # User needs to be informed that their reservation now has an access code,
@@ -561,11 +565,25 @@ class PindoraService:
         )
 
         for series in all_series:
+            should_be_active = series.should_have_active_access_code
+
             try:
                 try:
-                    if series.should_have_active_access_code:
+                    # We need to reschedule the series first, as one reason why the series might have
+                    # reservations with incorrect access code active status is that the access type
+                    # for the reservation units in the series has changed. Usually this means that
+                    # access type changes in the middle of the series to something other than
+                    # access code. This means that the access code is still active, but its no longer
+                    # valid for all reservations in the series. Rescheduling updates the series'
+                    # access code validity periods, fixing the issue.
+                    response = cls.reschedule_access_code(obj=series)
+
+                    # Only activate if was not already active
+                    if should_be_active and not response["access_code_is_active"]:
                         cls.activate_access_code(obj=series)
-                    else:
+
+                    # Only deactivate if was not already inactive
+                    elif not should_be_active and response["access_code_is_active"]:
                         cls.deactivate_access_code(obj=series)
 
                 # If we think an access code has been generated, but it's not found in Pindora,
@@ -581,16 +599,23 @@ class PindoraService:
         sections: Iterable[ApplicationSection] = ApplicationSection.objects.has_incorrect_access_code_is_active()
 
         for section in sections:
+            should_be_active = section.should_have_active_access_code
+
             try:
                 try:
-                    if section.should_have_active_access_code:
+                    # See explanation in '_update_access_code_is_active_for_reservations'
+                    response = cls.reschedule_access_code(obj=section)
+
+                    # Only activate if was not already active
+                    if should_be_active and not response["access_code_is_active"]:
                         cls.activate_access_code(obj=section)
 
                         # User needs to be informed that their seasonal booking now has an access code,
                         # since inactive access codes are not shown to users.
                         EmailService.send_seasonal_booking_access_type_changed_email(section)
 
-                    else:
+                    # Only deactivate if was not already inactive
+                    elif not should_be_active and response["access_code_is_active"]:
                         cls.deactivate_access_code(obj=section)
 
                 # If we think an access code has been generated, but it's not found in Pindora,


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Update Pindora client logic for access code is active to reschedule first

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
