### PR TITLE
Notify user if their timezone deviates from expected

### DIFF
--- a/apps/admin-ui/public/locales/fi/notification.json
+++ b/apps/admin-ui/public/locales/fi/notification.json
@@ -72,5 +72,9 @@
     "activeUntil": "Voimassa asti",
     "targetGroup": "Kohderyhmä",
     "level": "Tyyppi"
+  },
+  "timeZoneDeviation": {
+    "title": "Käytät palvelua ulkomailta",
+    "body": "Varauskalenterin ajat näytetään paikallisessa aikavyöhykkeessä ({{timeZone}}). Huomioithan aikaeron varausta tehdessäsi."
   }
 }

--- a/apps/admin-ui/src/pages/my-units/[id]/index.tsx
+++ b/apps/admin-ui/src/pages/my-units/[id]/index.tsx
@@ -1,3 +1,4 @@
+import TimeZoneNotification from "common/src/components/TimeZoneNotification";
 import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { useTranslation } from "next-i18next";
@@ -115,6 +116,7 @@ export default function MyUnitsPage({ unit }: Pick<PropsNarrowed, "unit">): JSX.
   const address = formatAddress(unit, "");
   return (
     <>
+      <TimeZoneNotification />
       <TitleSection>
         <H1 $noMargin>{title}</H1>
         {address !== "" && <LocationOnlyOnDesktop>{address}</LocationOnlyOnDesktop>}

--- a/apps/admin-ui/src/pages/my-units/[id]/recurring/index.tsx
+++ b/apps/admin-ui/src/pages/my-units/[id]/recurring/index.tsx
@@ -1,3 +1,4 @@
+import TimeZoneNotification from "common/src/components/TimeZoneNotification";
 import React from "react";
 import { useTranslation } from "next-i18next";
 import { ReservationSeriesForm } from "@lib/my-units/[id]/recurring/ReservationSeriesForm";
@@ -34,6 +35,7 @@ export default function Page({ apiBaseUrl, unitPk, reservationUnits }: PropsNarr
       permission={UserPermissionChoice.CanCreateStaffReservations}
       unitPk={unitPk}
     >
+      <TimeZoneNotification />
       <LinkPrev />
       <H1 $noMargin>{t("myUnits:ReservationSeries.pageTitle")}</H1>
       {reservationUnitOptions.length > 0 ? (

--- a/apps/ui/pages/reservation-unit/[...params].tsx
+++ b/apps/ui/pages/reservation-unit/[...params].tsx
@@ -1,3 +1,4 @@
+import TimeZoneNotification from "common/src/components/TimeZoneNotification";
 import React, { useCallback, useMemo, useState } from "react";
 import styled from "styled-components";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
@@ -331,6 +332,7 @@ function NewReservation(props: PropsNarrowed): JSX.Element | null {
 
   return (
     <FormProvider {...form}>
+      <TimeZoneNotification />
       <ReservationPageWrapper>
         <StyledReservationInfoCard
           reservation={reservation}

--- a/apps/ui/pages/reservation-unit/[id].tsx
+++ b/apps/ui/pages/reservation-unit/[id].tsx
@@ -1,3 +1,4 @@
+import TimeZoneNotification from "common/src/components/TimeZoneNotification";
 import React, { useEffect, useMemo, useState } from "react";
 import type { GetServerSidePropsContext } from "next";
 import { Trans, useTranslation } from "next-i18next";
@@ -440,110 +441,115 @@ function ReservationUnit({
   );
 
   return (
-    <ReservationUnitPageWrapper>
-      <Head
-        reservationUnit={reservationUnit}
-        reservationUnitIsReservable={reservationUnitIsReservable}
-        subventionSuffix={subventionSuffix}
-      />
-      <div>
-        {reservationUnitIsReservable && (
-          <QuickReservation
-            reservationUnit={reservationUnit}
-            reservationForm={reservationForm}
-            durationOptions={durationOptions}
-            startingTimeOptions={startingTimeOptions}
-            nextAvailableTime={nextAvailableTime}
-            focusSlot={focusSlot}
-            submitReservation={submitReservation}
-            LoginAndSubmit={LoginAndSubmit}
-            subventionSuffix={subventionSuffix}
-          />
-        )}
-        <JustForDesktop customBreakpoint={breakpoints.l}>
-          <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
-        </JustForDesktop>
-      </div>
-      <PageContentWrapper>
-        <div data-testid="reservation-unit__description">
-          <H4 as="h2">{t("reservationUnit:description")}</H4>
-          <Sanitize html={getTranslationSafe(reservationUnit, "description", lang)} />
-        </div>
-        {equipment.length > 0 && (
-          <div data-testid="reservation-unit__equipment">
-            <H4 as="h2">{t("reservationUnit:equipment")}</H4>
-            <EquipmentList equipment={equipment} />
-          </div>
-        )}
-        {reservationUnitIsReservable && (
-          <ReservationUnitCalendarSection
-            reservationUnit={reservationUnit}
-            reservationForm={reservationForm}
-            startingTimeOptions={startingTimeOptions}
-            blockingReservations={blockingReservations}
-            loginAndSubmitButton={LoginAndSubmit}
-            submitReservation={submitReservation}
-          />
-        )}
-        <ReservationInfoSection
+    <>
+      <TimeZoneNotification />
+      <ReservationUnitPageWrapper>
+        <Head
           reservationUnit={reservationUnit}
           reservationUnitIsReservable={reservationUnitIsReservable}
+          subventionSuffix={subventionSuffix}
         />
-        <NoticeWhenReservingSection reservationUnit={reservationUnit} />
-        {showApplicationRoundTimeSlots && (
-          <Accordion headingLevel={2} heading={t("reservationUnit:recurringHeading")} closeButton={false}>
-            <p>{t("reservationUnit:recurringBody")}</p>
-            {applicationRoundTimeSlots.map((day) => (
-              <ApplicationRoundScheduleDay key={day.weekday} {...day} />
-            ))}
-          </Accordion>
-        )}
-        {reservationUnit.unit?.tprekId && (
-          <Accordion closeButton={false} heading={t("common:location")} initiallyOpen>
-            <JustForMobile customBreakpoint={breakpoints.l}>
-              <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
-            </JustForMobile>
-            <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
-          </Accordion>
-        )}
-        {(paymentTermsContent || cancellationTermsContent) && (
+        <div>
+          {reservationUnitIsReservable && (
+            <QuickReservation
+              reservationUnit={reservationUnit}
+              reservationForm={reservationForm}
+              durationOptions={durationOptions}
+              startingTimeOptions={startingTimeOptions}
+              nextAvailableTime={nextAvailableTime}
+              focusSlot={focusSlot}
+              submitReservation={submitReservation}
+              LoginAndSubmit={LoginAndSubmit}
+              subventionSuffix={subventionSuffix}
+            />
+          )}
+          <JustForDesktop customBreakpoint={breakpoints.l}>
+            <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
+          </JustForDesktop>
+        </div>
+        <PageContentWrapper>
+          <div data-testid="reservation-unit__description">
+            <H4 as="h2">{t("reservationUnit:description")}</H4>
+            <Sanitize html={getTranslationSafe(reservationUnit, "description", lang)} />
+          </div>
+          {equipment.length > 0 && (
+            <div data-testid="reservation-unit__equipment">
+              <H4 as="h2">{t("reservationUnit:equipment")}</H4>
+              <EquipmentList equipment={equipment} />
+            </div>
+          )}
+          {reservationUnitIsReservable && (
+            <ReservationUnitCalendarSection
+              reservationUnit={reservationUnit}
+              reservationForm={reservationForm}
+              startingTimeOptions={startingTimeOptions}
+              blockingReservations={blockingReservations}
+              loginAndSubmitButton={LoginAndSubmit}
+              submitReservation={submitReservation}
+            />
+          )}
+          <ReservationInfoSection
+            reservationUnit={reservationUnit}
+            reservationUnitIsReservable={reservationUnitIsReservable}
+          />
+          <NoticeWhenReservingSection reservationUnit={reservationUnit} />
+          {showApplicationRoundTimeSlots && (
+            <Accordion headingLevel={2} heading={t("reservationUnit:recurringHeading")} closeButton={false}>
+              <p>{t("reservationUnit:recurringBody")}</p>
+              {applicationRoundTimeSlots.map((day) => (
+                <ApplicationRoundScheduleDay key={day.weekday} {...day} />
+              ))}
+            </Accordion>
+          )}
+          {reservationUnit.unit?.tprekId && (
+            <Accordion closeButton={false} heading={t("common:location")} initiallyOpen>
+              <JustForMobile customBreakpoint={breakpoints.l}>
+                <AddressSection unit={reservationUnit.unit} title={getReservationUnitName(reservationUnit) ?? "-"} />
+              </JustForMobile>
+              <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
+            </Accordion>
+          )}
+          {(paymentTermsContent || cancellationTermsContent) && (
+            <Accordion
+              heading={t(
+                `reservationUnit:${paymentTermsContent ? "paymentAndCancellationTerms" : "cancellationTerms"}`
+              )}
+              closeButton={false}
+              data-testid="reservation-unit__payment-and-cancellation-terms"
+            >
+              {paymentTermsContent && <Sanitize html={paymentTermsContent} />}
+              <Sanitize html={cancellationTermsContent ?? ""} />
+            </Accordion>
+          )}
+          {shouldDisplayPricingTerms && pricingTermsContent && (
+            <Accordion
+              heading={t("reservationUnit:pricingTerms")}
+              closeButton={false}
+              data-testid="reservation-unit__pricing-terms"
+            >
+              <Sanitize html={pricingTermsContent} />
+            </Accordion>
+          )}
           <Accordion
-            heading={t(`reservationUnit:${paymentTermsContent ? "paymentAndCancellationTerms" : "cancellationTerms"}`)}
+            heading={t("reservationUnit:termsOfUse")}
             closeButton={false}
-            data-testid="reservation-unit__payment-and-cancellation-terms"
+            data-testid="reservation-unit__terms-of-use"
           >
-            {paymentTermsContent && <Sanitize html={paymentTermsContent} />}
-            <Sanitize html={cancellationTermsContent ?? ""} />
+            {serviceSpecificTermsContent && <Sanitize html={serviceSpecificTermsContent} />}
+            <Sanitize html={getTranslationSafe(termsOfUse.genericTerms ?? {}, "text", lang)} />
           </Accordion>
-        )}
-        {shouldDisplayPricingTerms && pricingTermsContent && (
-          <Accordion
-            heading={t("reservationUnit:pricingTerms")}
-            closeButton={false}
-            data-testid="reservation-unit__pricing-terms"
-          >
-            <Sanitize html={pricingTermsContent} />
-          </Accordion>
-        )}
-        <Accordion
-          heading={t("reservationUnit:termsOfUse")}
-          closeButton={false}
-          data-testid="reservation-unit__terms-of-use"
-        >
-          {serviceSpecificTermsContent && <Sanitize html={serviceSpecificTermsContent} />}
-          <Sanitize html={getTranslationSafe(termsOfUse.genericTerms ?? {}, "text", lang)} />
-        </Accordion>
-      </PageContentWrapper>
-      <InfoDialog
-        id="pricing-terms"
-        heading={t("reservationUnit:pricingTerms")}
-        text={pricingTermsContent ?? ""}
-        isOpen={isPricingTermsDialogOpen}
-        onClose={() => setIsPricingTermsDialogOpen(false)}
-      />
-      {/* TODO this breaks the layout when inside a grid (the RelatedUnits) */}
-      {shouldDisplayBottomWrapper && <StyledRelatedUnits units={relatedReservationUnits} />}
-    </ReservationUnitPageWrapper>
+        </PageContentWrapper>
+        <InfoDialog
+          id="pricing-terms"
+          heading={t("reservationUnit:pricingTerms")}
+          text={pricingTermsContent ?? ""}
+          isOpen={isPricingTermsDialogOpen}
+          onClose={() => setIsPricingTermsDialogOpen(false)}
+        />
+        {/* TODO this breaks the layout when inside a grid (the RelatedUnits) */}
+        {shouldDisplayBottomWrapper && <StyledRelatedUnits units={relatedReservationUnits} />}
+      </ReservationUnitPageWrapper>
+    </>
   );
 }
 

--- a/apps/ui/public/locales/en/notification.json
+++ b/apps/ui/public/locales/en/notification.json
@@ -11,5 +11,9 @@
     "title": "Your booking is incomplete",
     "body": "Your booking will be cancelled automatically, if it won’t be completed within 20 minutes.",
     "continueReservation": "Continue booking"
+  },
+  "timeZoneDeviation": {
+    "title": "You are using this service abroad:",
+    "body": "The times in the booking calendar are shown in the local timezone ({{timeZone}}). Please consider the time difference when making a booking."
   }
 }

--- a/apps/ui/public/locales/fi/notification.json
+++ b/apps/ui/public/locales/fi/notification.json
@@ -11,5 +11,9 @@
     "title": "Varauksesi on keskeneräinen",
     "body": "Varauksesi peruuntuu automaattisesti, jos et viimestele sitä 20 minuutin kuluessa.",
     "continueReservation": "Jatka varaamista"
+  },
+  "timeZoneDeviation": {
+    "title": "Käytät palvelua ulkomailta",
+    "body": "Varauskalenterin ajat näytetään paikallisessa aikavyöhykkeessä ({{timeZone}}). Huomioithan aikaeron varausta tehdessäsi."
   }
 }

--- a/apps/ui/public/locales/sv/notification.json
+++ b/apps/ui/public/locales/sv/notification.json
@@ -11,5 +11,9 @@
     "title": "Din bokning är inte klar",
     "body": "Din bokning är inte klar. Vänligen slutför bokningen inom 20 minuter.",
     "continueReservation": "Fortsätt bokningen"
+  },
+  "timeZoneDeviation": {
+    "title": "Du använder den här tjänsten utomlands:",
+    "body": "Tiderna i bokningskalendern visas i lokala tidszonen ({{timeZone}}). Vänligen ta hänsyn till tidsskillnaden när du gör en bokning."
   }
 }

--- a/packages/common/src/components/TimeZoneNotification.tsx
+++ b/packages/common/src/components/TimeZoneNotification.tsx
@@ -1,0 +1,17 @@
+import { Notification } from "hds-react";
+import { useTranslation } from "next-i18next";
+import { EXPECTED_TIMEZONE } from "../const";
+
+function TimeZoneNotification() {
+  const { t } = useTranslation();
+  if (Intl.DateTimeFormat().resolvedOptions().timeZone === EXPECTED_TIMEZONE) {
+    return null;
+  }
+  return (
+    <Notification label={t("notification:timeZoneDeviation.title")} type="info">
+      {t("notification:timeZoneDeviation.body", { timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone })}
+    </Notification>
+  );
+}
+
+export default TimeZoneNotification;

--- a/packages/common/src/const.ts
+++ b/packages/common/src/const.ts
@@ -36,3 +36,5 @@ export const breakpoints = {
 } as const;
 
 export const pixel = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
+
+export const EXPECTED_TIMEZONE = "Europe/Helsinki" as const;


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds `TimeZoneNotification` component to `common` (in case it would be used in `admin-ui` too, eventually)
- show the notification on the reservation unit page and in the reservation funnel, if the browser time zone isn't `Europe/Helsinki` as expected

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-3249](https://helsinkisolutionoffice.atlassian.net/browse/TILA-3249)


[TILA-3249]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-3249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ