### PR TITLE
Adds two straggler commits from the undine-back-to-graphene switch

### DIFF
--- a/apps/admin-ui/src/lib/reservation-units/ReservationUnitsDataLoader.tsx
+++ b/apps/admin-ui/src/lib/reservation-units/ReservationUnitsDataLoader.tsx
@@ -156,7 +156,7 @@ export const SEARCH_RESERVATION_UNITS_QUERY = gql`
       unitGroup: $unitGroup
       reservationUnitType: $reservationUnitType
       publishingState: $publishingState
-      onlyWithPermission: true
+      onlyWithManagePermission: true
     ) {
       edges {
         node {

--- a/apps/ui/modules/search.ts
+++ b/apps/ui/modules/search.ts
@@ -180,6 +180,17 @@ export function translateOption(
   };
 }
 
+function getUnitsOrderBy(lang: LocalizationLanguages) {
+  switch (lang) {
+    case "sv":
+      return UnitOrderingChoices.NameSvAsc;
+    case "en":
+      return UnitOrderingChoices.NameEnAsc;
+    default:
+      return UnitOrderingChoices.NameFiAsc;
+  }
+}
+
 export async function getSearchOptions(
   apolloClient: ApolloClient<unknown>,
   page: "seasonal" | "direct",
@@ -191,7 +202,7 @@ export async function getSearchOptions(
     variables: {
       reservationUnitTypesOrderBy: ReservationUnitTypeOrderingChoices.RankAsc,
       purposesOrderBy: PurposeOrderingChoices.RankAsc,
-      unitsOrderBy: UnitOrderingChoices.NameFiAsc,
+      unitsOrderBy: getUnitsOrderBy(lang),
       equipmentsOrderBy: EquipmentOrderingChoices.CategoryRankAsc,
       ...(page === "direct" ? { onlyDirectBookable: true } : {}),
       ...(page === "seasonal" ? { onlySeasonalBookable: true } : {}),


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- adds the remaining two old commits from before the undine removal:
  - uses `onlyWithManagePermission`-filter when listing reservation units for admin
  - takes the selected language into account when sorting the items in the search page unit dropdown

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4245](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4245)


[TILA-4245]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ