### PR TITLE
fix: Incorrect purpose in admin form options

### DIFF
--- a/apps/admin-ui/src/component/MetadataSetForm.tsx
+++ b/apps/admin-ui/src/component/MetadataSetForm.tsx
@@ -11,10 +11,10 @@ type Props = {
 };
 
 export const ReservationMetadataSetForm = ({ reservationUnit }: Props): JSX.Element => {
-  const { ageGroups, purposes } = useFilterOptions();
+  const { ageGroups, reservationPurposes } = useFilterOptions();
   const options = {
     ageGroup: ageGroups,
-    purpose: purposes,
+    purpose: reservationPurposes,
   };
 
   // TODO naming: generalFields = reservationFields (Varauksen tiedot)
@@ -34,10 +34,10 @@ export const ReservationMetadataSetForm = ({ reservationUnit }: Props): JSX.Elem
 // TODO this component can be wholly deprecated maybe? translations / options?
 export const ReserverMetadataSetForm = ({ reservationUnit }: Props): JSX.Element => {
   const { watch } = useFormContext<Reservation>();
-  const { ageGroups, purposes } = useFilterOptions();
+  const { ageGroups, reservationPurposes } = useFilterOptions();
   const options = {
     ageGroup: ageGroups,
-    purpose: purposes,
+    purpose: reservationPurposes,
   };
 
   // TODO naming: applicationFields = reserverFields (Varaajan tiedot)


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix: `reservationPurpose` options empty due to wrong variable name in `admin` reservation forms.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: new `admin` reservation should have `purpose` Select (and correct options).

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
