### PR TITLE
WIP: reduce client side options queries in my-units page

### DIFF
--- a/apps/admin-ui/src/lib/my-units/[id]/UnitReservations.tsx
+++ b/apps/admin-ui/src/lib/my-units/[id]/UnitReservations.tsx
@@ -15,8 +15,7 @@ import { MultiSelectFilter } from "@/component/QueryParamFilters";
 import { DayNavigation } from "@/component/QueryParamFilters/DayNavigation";
 import { useSearchParams } from "next/navigation";
 import { useSetSearchParams } from "@/hooks/useSetSearchParams";
-import { translateTag } from "@/modules/search";
-import { useFilterOptions } from "@/hooks/useFilterOptions";
+import { TagOptionsList, translateTag } from "@/modules/search";
 import { type ReservationUnitOption } from "@/hooks/useUnitResources";
 
 const LegendContainer = styled.div`
@@ -33,13 +32,14 @@ interface UnitReservationsProps {
   unitPk: number;
   reservationUnitOptions: ReadonlyArray<ReservationUnitOption>;
   canCreateReservations: boolean;
+  tagOptions: TagOptionsList;
 }
 
 function UnitReservationsInner({
   unitPk,
   reservationUnitOptions,
   canCreateReservations,
-}: UnitReservationsProps): JSX.Element {
+}: Omit<UnitReservationsProps, "tagOptions">): JSX.Element {
   const searchParams = useSearchParams();
   const { t } = useTranslation();
   const { reservationUnitTypeFilter } = useGetFilterSearchParams();
@@ -76,10 +76,8 @@ function UnitReservationsInner({
   );
 }
 
-export function UnitReservations(props: UnitReservationsProps): JSX.Element {
+export function UnitReservations({ tagOptions, ...props }: UnitReservationsProps): JSX.Element {
   const { t } = useTranslation();
-
-  const options = useFilterOptions();
 
   const searchParams = useSearchParams();
   const setSearchParams = useSetSearchParams();
@@ -107,10 +105,10 @@ export function UnitReservations(props: UnitReservationsProps): JSX.Element {
             zIndex: "var(--tilavaraus-admin-stack-select-over-calendar)",
           }}
           name="reservationUnitType"
-          options={options.reservationUnitTypes}
+          options={tagOptions.reservationUnitTypes}
         />
       </AutoGrid>
-      <SearchTags hide={hideTags} translateTag={translateTag(t, options)} />
+      <SearchTags hide={hideTags} translateTag={translateTag(t, tagOptions)} />
       <HR />
       <Flex $gap="none" $direction="row" $justifyContent="space-between" $alignItems="center">
         <Button size={ButtonSize.Small} variant={ButtonVariant.Secondary} onClick={handleTodayClick}>

--- a/apps/admin-ui/src/pages/my-units/[id]/index.tsx
+++ b/apps/admin-ui/src/pages/my-units/[id]/index.tsx
@@ -8,6 +8,9 @@ import { formatAddress } from "@/common/util";
 import { getReservationSeriesUrl } from "@/common/urls";
 import { createNodeId, ignoreMaybeArray, toNumber } from "common/src/helpers";
 import {
+  FilterOptionsDocument,
+  type FilterOptionsQuery,
+  type FilterOptionsQueryVariables,
   UnitViewDocument,
   type UnitViewQuery,
   type UnitViewQueryVariables,
@@ -28,6 +31,7 @@ import { fromUIDate } from "common/src/common/util";
 import { addMinutes } from "date-fns";
 import { createClient } from "@/common/apolloClient";
 import { hasPermission } from "@/modules/permissionHelper";
+import { getFilterOptions } from "@/hooks/useFilterOptions";
 
 const LocationOnlyOnDesktop = styled.p`
   display: none;
@@ -41,9 +45,11 @@ const TabPanel = styled(Tabs.TabPanel)`
   padding-block: var(--spacing-m);
 `;
 
-export default function MyUnitsPage({ unit }: Pick<PropsNarrowed, "unit">): JSX.Element {
+export default function MyUnitsPage({ unit, optionsData }: Pick<PropsNarrowed, "unit" | "optionsData">): JSX.Element {
   const { t } = useTranslation();
   const { setModalContent } = useModal();
+
+  const options = getFilterOptions(t, optionsData);
 
   const createReservationBtnRef = useRef<HTMLButtonElement>(null);
   const { user } = useSession();
@@ -144,6 +150,7 @@ export default function MyUnitsPage({ unit }: Pick<PropsNarrowed, "unit">): JSX.
               reservationUnitOptions={reservationUnitOptions}
               unitPk={unit.pk ?? 0}
               canCreateReservations={canCreateReservations}
+              tagOptions={options}
             />
           </TabPanel>
           <TabPanel>
@@ -177,13 +184,23 @@ export async function getServerSideProps({ req, locale, query }: GetServerSidePr
   if (pk == null || pk <= 0) {
     return NOT_FOUND_SSR_VALUE;
   }
-
+  const start = performance.now();
   const commonProps = await getCommonServerSideProps();
   const apolloClient = createClient(commonProps.apiBaseUrl ?? "", req);
   const { data } = await apolloClient.query<UnitViewQuery, UnitViewQueryVariables>({
     query: UnitViewDocument,
     variables: { id: createNodeId("UnitNode", pk) },
   });
+  const intermediate = performance.now();
+  // oxlint-disable-next-line no-console
+  console.log(`Get unit took: ${intermediate - start} ms`);
+
+  const { data: optionsData } = await apolloClient.query<FilterOptionsQuery, FilterOptionsQueryVariables>({
+    query: FilterOptionsDocument,
+  });
+  const end = performance.now();
+  // oxlint-disable-next-line no-console
+  console.log(`Get otions took: ${end - intermediate} ms`);
 
   const { unit } = data;
   if (unit == null) {
@@ -193,6 +210,7 @@ export async function getServerSideProps({ req, locale, query }: GetServerSidePr
   return {
     props: {
       unit,
+      optionsData,
       ...commonProps,
       ...(await serverSideTranslations(locale ?? "fi")),
     },


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

Client side does a new query every time user changes a date (or any other query param). This moves the options query to SSR so it's only executed once per page load.

WIP: don't serialize async requests to backend.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- None
