### PR TITLE
Fix: restore icon to toasts after updating toastify

### DIFF
--- a/packages/common/src/components/toast.tsx
+++ b/packages/common/src/components/toast.tsx
@@ -54,22 +54,7 @@ const Container = styled(TC)`
     left: var(--spacing-s);
     transform: translateY(-50%);
     z-index: 1;
-    display: none;
-  }
-  [class^="Toastify__toast-body"] {
-    border-radius: 0;
-
-    /* HDS doesn't render the icon if the toast doesn't have a label, so we
-    show the toastify icon instead, and make room for it with padding */
-    &:not(:has([class*="Notification-module_label"])) {
-      [class^="Toastify__toast-icon"] {
-        display: block;
-      }
-      [class*="Notification-module_notification"] {
-        padding-left: var(--spacing-2-xl);
-        padding-right: var(--spacing-2-xl);
-      }
-    }
+    display: block;
   }
   [class^="Toastify__close-button"] {
     position: absolute;
@@ -99,7 +84,7 @@ const HDSNotification = styled(Notification)`
     border-width: 0;
   }
   [class^="Notification-module_content"] {
-    padding-top: 8px;
+    padding: 8px var(--spacing-l) 0;
     white-space: pre-line;
   }
   .progress-bar {


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- migrate to toast 11:
  - show the icon
  - reposition it within the updated structure (`.Toastify__toast-body` doesn't exist anymore)

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4261](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4261)


[TILA-4261]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ