### PR TITLE
Fix language saving broken due to enum rename

### DIFF
--- a/apps/ui/middleware.ts
+++ b/apps/ui/middleware.ts
@@ -316,7 +316,7 @@ async function maybeSaveUserLanguage(req: NextRequest, user: User | null): Promi
 
     const query: QqlQuery = {
       query: `
-        mutation SaveUserLanguage($preferredLanguage: PreferredLanguage!) {
+        mutation SaveUserLanguage($preferredLanguage: Language!) {
           updateCurrentUser(
             input:{
               preferredLanguage: $preferredLanguage


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Fix users current language isn't saved (for use in emails etc.) because GraphQL enum was renamed.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Manual testing: check that user language is saved when changed on the frontend (can be checked from django admin).

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4262](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4262)

[TILA-4262]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ