### PR TITLE
fix: user could click next or modify data during mutation

### DIFF
--- a/frontend/apps/customer/src/components/application/funnel/Page1.tsx
+++ b/frontend/apps/customer/src/components/application/funnel/Page1.tsx
@@ -13,10 +13,11 @@ import type { ApplicationPage1FormValues } from "./form";
 
 type Page1Props = Readonly<{
   applicationRound: Readonly<ApplicationRoundForApplicationFragment>;
+  isSaving: boolean;
   options: Readonly<OptionsListT>;
 }>;
 
-export function Page1({ applicationRound, options }: Page1Props): JSX.Element | null {
+export function Page1({ applicationRound, isSaving, options }: Page1Props): JSX.Element | null {
   const { t } = useTranslation();
 
   // get the user selected defaults for reservationUnits field
@@ -55,6 +56,7 @@ export function Page1({ applicationRound, options }: Page1Props): JSX.Element | 
           id="addApplicationEvent"
           variant={ButtonVariant.Secondary}
           iconStart={<IconPlus />}
+          disabled={isSaving}
           onClick={handleAddNewApplicationEvent}
           size={ButtonSize.Small}
         >
@@ -64,7 +66,7 @@ export function Page1({ applicationRound, options }: Page1Props): JSX.Element | 
           id="button__application--next"
           iconEnd={<IconArrowRight />}
           size={ButtonSize.Small}
-          disabled={submitDisabled}
+          disabled={submitDisabled || isSaving}
           type="submit"
         >
           {t("common:next")}

--- a/frontend/apps/customer/src/pages/applications/[id]/page1.tsx
+++ b/frontend/apps/customer/src/pages/applications/[id]/page1.tsx
@@ -28,7 +28,7 @@ import type { ApplicationPage1Query, ApplicationPage1QueryVariables } from "@gql
 function Page1({ application, options: optionsOrig }: Pick<PropsNarrowed, "application" | "options">): JSX.Element {
   const router = useRouter();
   const dislayError = useDisplayError();
-  const [mutate] = useUpdateApplicationMutation();
+  const [mutate, { loading: isSaving }] = useUpdateApplicationMutation();
 
   const saveAndNavigate = async (values: ApplicationPage1FormValues) => {
     try {
@@ -72,7 +72,7 @@ function Page1({ application, options: optionsOrig }: Pick<PropsNarrowed, "appli
     <FormProvider {...form}>
       <Flex as="form" noValidate onSubmit={handleSubmit(onSubmit)}>
         <ApplicationFunnelWrapper page="page1" application={application}>
-          <Page1Impl applicationRound={applicationRound} options={options} />
+          <Page1Impl applicationRound={applicationRound} isSaving={isSaving} options={options} />
         </ApplicationFunnelWrapper>
       </Flex>
     </FormProvider>

--- a/frontend/apps/customer/test/applications/[id]/page1.test.tsx
+++ b/frontend/apps/customer/test/applications/[id]/page1.test.tsx
@@ -6,10 +6,31 @@ import { MockedGraphQLProvider } from "@test/test.react.utils";
 import { selectFirstOption } from "@test/test.utils";
 import { render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { vi, expect, test, describe } from "vitest";
+import { vi, expect, test, describe, beforeEach } from "vitest";
 import type { OptionsListT } from "ui/src/modules/search";
 import { SEASONAL_SELECTED_PARAM_KEY } from "@/hooks/useReservationUnitList";
 import Page1 from "@/pages/applications/[id]/page1";
+
+const { isSavingRef, mutateFn } = vi.hoisted(() => {
+  const isSavingRef = { current: false };
+  const mutateFn = vi.fn().mockResolvedValue({ data: { updateApplication: { pk: 1 } } });
+  return { isSavingRef, mutateFn };
+});
+
+vi.mock("@gql/gql-types", async (importOriginal) => {
+  const mod: unknown = await importOriginal();
+  return {
+    ...(mod as Record<string, unknown>),
+    useUpdateApplicationMutation: () => [
+      mutateFn,
+      {
+        get loading() {
+          return isSavingRef.current;
+        },
+      },
+    ],
+  };
+});
 
 const { mockedRouterPush, useRouter } = vi.hoisted(() => {
   const mockedRouterReplace = vi.fn();
@@ -62,6 +83,11 @@ function customRender(props: CreateMockApplicationFragmentProps = {}): ReturnTyp
   );
 }
 
+beforeEach(() => {
+  isSavingRef.current = false;
+  mutateFn.mockClear();
+});
+
 describe("Page1 common to all funnel pages", () => {
   test("should render empty application page", () => {
     const view = customRender();
@@ -81,6 +107,13 @@ describe("Page1 common to all funnel pages", () => {
 });
 
 describe("Page1", () => {
+  test("disables next and add-section while saving", () => {
+    isSavingRef.current = true;
+    const view = customRender();
+    expect(view.getByRole("button", { name: "common:next" })).toBeDisabled();
+    expect(view.getByRole("button", { name: "application:Page1.createNew" })).toBeDisabled();
+  });
+
   // this case only happens if user manually removes the last section
   test("empty application should not allow submitting", async () => {
     const view = customRender();


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Prevents repeated clicks (double submit / duplicate requests) while the GraphQL mutation that saves or creates the application is still running.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Open application page 1, submit with throttled/slow network (or devtools): buttons should stay disabled for the duration of the request.
- Same idea on the recurring start-application entry point if it applies to your flow.

Matti Eiden

- page1 määrittele uuden kausivarauksen tiedot
- laita verkko hitaaksi, firefoxilla throttle GPRS tasolle (:D) 
- klikkaa seuraava nappia sekunnin välein, ehtii klikkaamaan ehkä 4-5 kertaa ennen kuin sivu vaihtuu
- siirtyy seuraavalle sivulle, vanhoja requja on vielä matkalla, odotellaan kaikki valmiiksi
- valitaan jotain aikoja ja seuraava -> ApplicationSection matching query does not exist

- Automated tests updated

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4401](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4401)


[TILA-4401]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ