### PR TITLE
fix: wait for navigation after mutation and routing

### DIFF
--- a/frontend/apps/customer/src/pages/applications/[id]/page1.tsx
+++ b/frontend/apps/customer/src/pages/applications/[id]/page1.tsx
@@ -38,7 +38,8 @@ function Page1({ application, options: optionsOrig }: Pick<PropsNarrowed, "appli
       if (pk == null) {
         throw new Error("Failed to save application");
       }
-      router.push(getApplicationPath(pk, "page2"));
+      // Await navigation so the UI stays disabled until the route transition completes.
+      await router.push(getApplicationPath(pk, "page2"));
     } catch (err) {
       dislayError(err);
     }
@@ -64,15 +65,17 @@ function Page1({ application, options: optionsOrig }: Pick<PropsNarrowed, "appli
 
   const { handleSubmit } = form;
 
-  const onSubmit = (values: ApplicationPage1FormValues) => {
-    saveAndNavigate(values);
-  };
+  const onSubmit = (values: ApplicationPage1FormValues) => saveAndNavigate(values);
 
   return (
     <FormProvider {...form}>
       <Flex as="form" noValidate onSubmit={handleSubmit(onSubmit)}>
         <ApplicationFunnelWrapper page="page1" application={application}>
-          <Page1Impl applicationRound={applicationRound} isSaving={isSaving} options={options} />
+          <Page1Impl
+            applicationRound={applicationRound}
+            isSaving={isSaving || form.formState.isSubmitting}
+            options={options}
+          />
         </ApplicationFunnelWrapper>
       </Flex>
     </FormProvider>

--- a/frontend/apps/customer/src/pages/applications/[id]/page2.tsx
+++ b/frontend/apps/customer/src/pages/applications/[id]/page2.tsx
@@ -45,7 +45,8 @@ function Page2({ application }: Pick<PropsNarrowed, "application">): JSX.Element
       if (pk == null) {
         throw new Error("Failed to save application");
       }
-      router.push(getApplicationPath(pk, "page3"));
+      // Await navigation so form "submitting" state covers the full transition.
+      await router.push(getApplicationPath(pk, "page3"));
     } catch (err) {
       displayError(err);
     }

--- a/frontend/apps/customer/src/pages/applications/[id]/page3.tsx
+++ b/frontend/apps/customer/src/pages/applications/[id]/page3.tsx
@@ -85,9 +85,10 @@ export default function Page3({ application }: Pick<PropsNarrowed, "application"
   });
 
   const { handleSubmit } = form;
+  const { isSubmitting } = form.formState;
 
   const { t } = useTranslation();
-  const [mutate] = useUpdateApplicationMutation();
+  const [mutate, { loading: isSaving }] = useUpdateApplicationMutation();
   const displayError = useDisplayError();
 
   const onSubmit = async (values: ApplicationPage3FormValues) => {
@@ -98,13 +99,15 @@ export default function Page3({ application }: Pick<PropsNarrowed, "application"
       if (pk == null) {
         throw new Error("Failed to save application");
       }
-      router.push(getApplicationPath(pk, "page4"));
+      // Await navigation so the form stays "submitting" until the transition completes.
+      await router.push(getApplicationPath(pk, "page4"));
     } catch (err) {
       displayError(err);
     }
   };
 
   const onPrev = () => router.push(getApplicationPath(application.pk, "page2"));
+  const disableNav = isSubmitting || isSaving;
 
   return (
     <FormProvider {...form}>
@@ -121,10 +124,17 @@ export default function Page3({ application }: Pick<PropsNarrowed, "application"
               iconStart={<IconArrowLeft />}
               size={ButtonSize.Small}
               onClick={onPrev}
+              disabled={disableNav}
             >
               {t("common:prev")}
             </Button>
-            <Button id="button__application--next" iconEnd={<IconArrowRight />} size={ButtonSize.Small} type="submit">
+            <Button
+              id="button__application--next"
+              iconEnd={<IconArrowRight />}
+              size={ButtonSize.Small}
+              type="submit"
+              disabled={disableNav}
+            >
               {t("common:next")}
             </Button>
           </ButtonContainer>

--- a/frontend/apps/customer/src/pages/applications/[id]/page4.tsx
+++ b/frontend/apps/customer/src/pages/applications/[id]/page4.tsx
@@ -64,7 +64,8 @@ function Page4({ application, tos }: Pick<PropsNarrowed, "application" | "tos">)
         throw new Error("no pk in response");
       }
 
-      router.push(getApplicationPath(resPk, "sent"));
+      // Await navigation so submit stays disabled until the transition completes.
+      await router.push(getApplicationPath(resPk, "sent"));
     } catch (err) {
       dislayError(err);
     }

--- a/frontend/apps/customer/test/applications/[id]/page1.test.tsx
+++ b/frontend/apps/customer/test/applications/[id]/page1.test.tsx
@@ -11,6 +11,16 @@ import type { OptionsListT } from "ui/src/modules/search";
 import { SEASONAL_SELECTED_PARAM_KEY } from "@/hooks/useReservationUnitList";
 import Page1 from "@/pages/applications/[id]/page1";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { promise, resolve, reject };
+}
+
 const { isSavingRef, mutateFn } = vi.hoisted(() => {
   const isSavingRef = { current: false };
   const mutateFn = vi.fn().mockResolvedValue({ data: { updateApplication: { pk: 1 } } });
@@ -113,6 +123,47 @@ describe("Page1", () => {
     expect(view.getByRole("button", { name: "common:next" })).toBeDisabled();
     expect(view.getByRole("button", { name: "application:Page1.createNew" })).toBeDisabled();
   });
+
+  test("keeps buttons disabled until navigation completes", async () => {
+    const params = new URLSearchParams();
+    params.set(SEASONAL_SELECTED_PARAM_KEY, "1");
+    mockedSearchParams.mockReturnValue(params);
+    const nav = deferred<boolean>();
+    mockedRouterPush.mockReturnValueOnce(nav.promise);
+
+    const view = customRender();
+    const user = userEvent.setup();
+
+    const section = view.getByTestId("application__applicationSection_0");
+    const name = within(section).getByLabelText(/application:Page1.name/);
+    await user.type(name, "Test section name");
+    await selectFirstOption(within(section), /application:Page1.ageGroup/);
+    await selectFirstOption(within(section), /application:Page1.purpose/);
+    const groupSize = within(section).getByLabelText(/application:Page1.groupSize/, { selector: "input" });
+    await user.type(groupSize, "1");
+    const checkDefaultPeriod = within(section).getByRole("checkbox", {
+      name: /application:Page1.defaultPeriodPrefix/,
+    });
+    await user.click(checkDefaultPeriod);
+    await selectFirstOption(within(section), /application:Page1.minDuration/);
+    await selectFirstOption(within(section), /application:Page1.maxDuration/);
+    const eventsPerWeek = within(section).getByLabelText(/application:Page1.eventsPerWeek/, { selector: "input" });
+    await user.clear(eventsPerWeek);
+    await user.type(eventsPerWeek, "1");
+
+    const addSectionBtn = view.getByRole("button", { name: "application:Page1.createNew" });
+    const submitBtn = view.getByRole("button", { name: "common:next" });
+    expect(addSectionBtn).not.toBeDisabled();
+    expect(submitBtn).not.toBeDisabled();
+
+    await user.click(submitBtn);
+
+    expect(submitBtn).toBeDisabled();
+    expect(addSectionBtn).toBeDisabled();
+
+    nav.resolve(true);
+    await nav.promise;
+  }, 20_000);
 
   // this case only happens if user manually removes the last section
   test("empty application should not allow submitting", async () => {

--- a/frontend/apps/customer/test/applications/[id]/page2.test.tsx
+++ b/frontend/apps/customer/test/applications/[id]/page2.test.tsx
@@ -9,6 +9,16 @@ import { getApplicationPath } from "@/modules/urls";
 import Page2 from "@/pages/applications/[id]/page2";
 import type { ApplicationPage2Query } from "@gql/gql-types";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { promise, resolve, reject };
+}
+
 const { mockedRouterPush, useRouter } = vi.hoisted(() => {
   const mockedRouterReplace = vi.fn();
   const mockedRouterPush = vi.fn();
@@ -100,6 +110,22 @@ describe("Application Page2", () => {
     });
     await userEvent.click(nextButton);
     expect(mockedRouterPush).toHaveBeenCalledWith(getApplicationPath(1, "page3"));
+  });
+
+  test("keeps next disabled until navigation completes", async () => {
+    const nav = deferred<boolean>();
+    mockedRouterPush.mockReturnValueOnce(nav.promise);
+    const user = userEvent.setup();
+    const view = customRender({ page: "page2" });
+    const nextButton = await view.findByRole("button", { name: "common:next" });
+
+    expect(nextButton).not.toBeDisabled();
+    await user.click(nextButton);
+    expect(mockedRouterPush).toHaveBeenCalledWith(getApplicationPath(1, "page3"));
+    expect(nextButton).toBeDisabled();
+
+    nav.resolve(true);
+    await nav.promise;
   });
 
   test("submit button is disabled without selection", async () => {

--- a/frontend/apps/customer/test/applications/[id]/page3.test.tsx
+++ b/frontend/apps/customer/test/applications/[id]/page3.test.tsx
@@ -9,6 +9,16 @@ import { getApplicationPath } from "@/modules/urls";
 import Page3 from "@/pages/applications/[id]/page3";
 import type { ApplicationPage3Query } from "@gql/gql-types";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  return { promise, resolve, reject };
+}
+
 const { mockedRouterPush, useRouter } = vi.hoisted(() => {
   const mockedRouterReplace = vi.fn();
   const mockedRouterPush = vi.fn();
@@ -84,5 +94,21 @@ describe("Application Page3", () => {
     });
     await userEvent.click(nextButton);
     expect(mockedRouterPush).toHaveBeenCalledWith(getApplicationPath(1, "page4"));
+  });
+
+  test("keeps next disabled until navigation completes", async () => {
+    const nav = deferred<boolean>();
+    mockedRouterPush.mockReturnValueOnce(nav.promise);
+    const user = userEvent.setup();
+    const view = customRender({ page: "page3" });
+    const nextButton = await view.findByRole("button", { name: "common:next" });
+
+    expect(nextButton).not.toBeDisabled();
+    await user.click(nextButton);
+    expect(mockedRouterPush).toHaveBeenCalledWith(getApplicationPath(1, "page4"));
+    expect(nextButton).toBeDisabled();
+
+    nav.resolve(true);
+    await nav.promise;
   });
 });


### PR DESCRIPTION
Refs: TILA-4401

## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

- Keep the buttons disabled while navigation is not yet done

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Same plane as the previous fix for this, there was a slight time when mutation was ready but navigatoin not yet done in which the buttons were active again.

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-4401](https://helsinkisolutionoffice.atlassian.net/browse/TILA-4401)


[TILA-4401]: https://helsinkisolutionoffice.atlassian.net/browse/TILA-4401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ