### PR TITLE
refactor: pre-commit auto update compatibility

### DIFF
--- a/backend/tilavarauspalvelu/models/intended_use/model.py
+++ b/backend/tilavarauspalvelu/models/intended_use/model.py
@@ -30,8 +30,9 @@ class IntendedUse(models.Model):
 
     name: str = models.CharField(max_length=200)
 
-    image: ThumbnailerImageFieldFile | None
-    image = ThumbnailerImageField(upload_to=settings.RESERVATION_UNIT_PURPOSE_IMAGES_ROOT, null=True, blank=True)
+    image: ThumbnailerImageFieldFile | None = ThumbnailerImageField(
+        upload_to=settings.RESERVATION_UNIT_PURPOSE_IMAGES_ROOT, null=True, blank=True
+    )
 
     # Translated field hints
     name_fi: str | None

--- a/backend/tilavarauspalvelu/models/reservation_unit_image/model.py
+++ b/backend/tilavarauspalvelu/models/reservation_unit_image/model.py
@@ -32,8 +32,9 @@ class ReservationUnitImage(models.Model):
         on_delete=models.CASCADE,
     )
 
-    image: ThumbnailerImageFieldFile | None
-    image = ThumbnailerImageField(upload_to=settings.RESERVATION_UNIT_IMAGES_ROOT, null=True, blank=True)
+    image: ThumbnailerImageFieldFile | None = ThumbnailerImageField(
+        upload_to=settings.RESERVATION_UNIT_IMAGES_ROOT, null=True, blank=True
+    )
     image_type: ReservationUnitImageType = TextChoicesField(enum=ReservationUnitImageType)
 
     large_url: str = models.URLField(max_length=255, default="", blank=True)


### PR DESCRIPTION
Pre-commit's auto update applies unsafe fixes via ruff, which ends up
removing a field assignment line after the type definition.
Attempting to work around this by combining type definition with the
assignment on a single line.


The type definition is incorrect, but that is beyond the scope of this.

Refs: TILA-4416


The pre-commit autoudpate in question is here: https://github.com/City-of-Helsinki/tilavarauspalvelu-core/pull/2456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reformatted image field declarations to use inline type-annotated assignments for clearer consistency.
  * Kept the same upload targets and form/nullable behavior.
  * No user-visible behavior or configuration changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->