### PR TITLE
Tila-4426 & Tila-4425 sonar reliability issues

### DIFF
--- a/frontend/apps/customer/next-env.d.ts
+++ b/frontend/apps/customer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/frontend/apps/customer/next-env.d.ts
+++ b/frontend/apps/customer/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/frontend/apps/customer/src/components/SortingComponent.tsx
+++ b/frontend/apps/customer/src/components/SortingComponent.tsx
@@ -89,7 +89,7 @@ export function SortingComponent() {
   const sortingOptions = SORTING_OPTIONS.map((option) => ({
     label: t(option.label),
     value: option.value,
-  })).map(convertOptionToHDS);
+  })).map((option) => convertOptionToHDS(option));
 
   const isOrderingAsc = searchValues.get("order") !== "desc";
   const value = validateSorting(searchValues.get("sort"));

--- a/frontend/apps/customer/src/components/UnitMap.test.tsx
+++ b/frontend/apps/customer/src/components/UnitMap.test.tsx
@@ -1,0 +1,25 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { mapUrlPrefix } from "@/modules/const";
+import { UnitMap } from "./UnitMap";
+
+// The iframe is rendered into a detached container on purpose: happy-dom fetches the src of an
+// iframe as soon as it is connected to the document, and tests must not make outbound requests.
+function renderUnitMap(props: { tprekId: string; height?: string }): HTMLElement {
+  const view = render(<UnitMap {...props} />, { container: document.createElement("div") });
+  return view.getByTitle("reservationUnit:mapTitle");
+}
+
+describe("Component: UnitMap", () => {
+  it("embeds the service map for the given tprek id in the active language", () => {
+    expect(renderUnitMap({ tprekId: "12345" })).toHaveAttribute("src", `${mapUrlPrefix}fi/embed/unit/12345`);
+  });
+
+  it("uses the default height when none is given", () => {
+    expect(renderUnitMap({ tprekId: "12345" }).style.height).toBe("480px");
+  });
+
+  it("uses the given height", () => {
+    expect(renderUnitMap({ tprekId: "12345", height: "200px" }).style.height).toBe("200px");
+  });
+});

--- a/frontend/apps/customer/src/components/UnitMap.tsx
+++ b/frontend/apps/customer/src/components/UnitMap.tsx
@@ -7,7 +7,7 @@ type Props = {
   height?: string;
 };
 
-export const Map = ({ tprekId, height = "480px" }: Props): React.ReactElement | null => {
+export const UnitMap = ({ tprekId, height = "480px" }: Props): React.ReactElement | null => {
   const { t, i18n } = useTranslation();
   const mapUrl = `${mapUrlPrefix}${i18n.language}/embed/unit/${tprekId}`;
   return (

--- a/frontend/apps/customer/src/components/application/funnel/form.ts
+++ b/frontend/apps/customer/src/components/application/funnel/form.ts
@@ -140,7 +140,7 @@ function transformApplicationSectionPage2(
   // NOTE: there is a type issue somewhere that causes this to be a string for some cases
   return {
     pk: Number(values.pk),
-    suitableTimeRanges: values.suitableTimeRanges.map(transformSuitableTimeRange),
+    suitableTimeRanges: values.suitableTimeRanges.map((timeRange) => transformSuitableTimeRange(timeRange)),
   };
 }
 
@@ -451,7 +451,7 @@ export function convertApplicationPage2(
 ): ApplicationPage2FormValues {
   return {
     pk: app?.pk ?? 0,
-    applicationSections: app.applicationSections?.map(convertApplicationSectionPage2) ?? [],
+    applicationSections: app.applicationSections?.map((section) => convertApplicationSectionPage2(section)) ?? [],
   };
 }
 

--- a/frontend/apps/customer/src/lib/reservation-unit/[id]/ReservationUnitMoreDetails.tsx
+++ b/frontend/apps/customer/src/lib/reservation-unit/[id]/ReservationUnitMoreDetails.tsx
@@ -18,7 +18,7 @@ import {
   toNumber,
 } from "@ui/modules/helpers";
 import { AddressSection } from "@/components/AddressSection";
-import { Map as MapComponent } from "@/components/Map";
+import { UnitMap } from "@/components/UnitMap";
 import { getFuturePricing, getPriceString } from "@/modules/reservationUnit";
 import { JustForMobile } from "@/modules/style/layout";
 import type {
@@ -89,7 +89,7 @@ export function ReservationUnitMoreDetails({
           <JustForMobile customBreakpoint={breakpoints.l}>
             <AddressSection unit={reservationUnit.unit} title={getTranslation(reservationUnit, "name", lang) ?? "-"} />
           </JustForMobile>
-          <MapComponent tprekId={reservationUnit.unit?.tprekId ?? ""} />
+          <UnitMap tprekId={reservationUnit.unit?.tprekId ?? ""} />
         </Accordion>
       )}
       {(paymentTermsContent || cancellationTermsContent) && (

--- a/frontend/apps/customer/src/modules/search.ts
+++ b/frontend/apps/customer/src/modules/search.ts
@@ -136,7 +136,9 @@ export function processVariables({
   const reservableDateEnd = filterEmpty(reservableDateEndCleaned);
   const timeEnd = filterEmpty(ignoreMaybeArray(values.getAll("timeEnd")));
   const timeBegin = filterEmpty(ignoreMaybeArray(values.getAll("timeBegin")));
-  const accessType = filterEmptyArray(filterNonNullable(values.getAll("accessTypes").map(transformAccessTypeSafe)));
+  const accessType = filterEmptyArray(
+    filterNonNullable(values.getAll("accessTypes").map((value) => transformAccessTypeSafe(value)))
+  );
 
   return {
     textSearch: filterEmpty(textSearch),

--- a/frontend/apps/staff/next-env.d.ts
+++ b/frontend/apps/staff/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/frontend/apps/staff/next-env.d.ts
+++ b/frontend/apps/staff/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/frontend/apps/staff/src/components/DenyDialog.tsx
+++ b/frontend/apps/staff/src/components/DenyDialog.tsx
@@ -177,7 +177,7 @@ function DialogContent({
               label: t("reservation:DenyDialog.denyReason"),
               assistive: t("reservation:DenyDialog.denyReasonHelper"),
             }}
-            options={options.map(convertOptionToHDS)}
+            options={options.map((option) => convertOptionToHDS(option))}
             value={denyReasonPk ? denyReasonPk.toString() : undefined}
             onChange={(selected) => {
               const v = selected.find(() => true)?.value;

--- a/frontend/apps/staff/src/components/QueryParamFilters/MultiSelectFilter.tsx
+++ b/frontend/apps/staff/src/components/QueryParamFilters/MultiSelectFilter.tsx
@@ -61,9 +61,9 @@ function BaseMultiSelectFilter({
         placeholder,
       }}
       noTags
-      options={options.map(convertOptionToHDS)}
+      options={options.map((option) => convertOptionToHDS(option))}
       disabled={options.length === 0}
-      value={options.filter((v) => filter.includes(v.value.toString())).map(convertOptionToHDS)}
+      value={options.filter((v) => filter.includes(v.value.toString())).map((option) => convertOptionToHDS(option))}
       onChange={(selected) => {
         const vals = selected.map((x) => x.value);
         setFilter(vals);

--- a/frontend/apps/staff/src/components/QueryParamFilters/SelectFilter.tsx
+++ b/frontend/apps/staff/src/components/QueryParamFilters/SelectFilter.tsx
@@ -79,7 +79,7 @@ function BaseSelectFilter({
         label,
         placeholder,
       }}
-      options={sortedOptions.map(convertOptionToHDS)}
+      options={sortedOptions.map((option) => convertOptionToHDS(option))}
       onChange={(sel) => handleChange(sel)}
       value={options.find((x) => x.value.toString() === value?.toString())?.value?.toString()}
       clearable={clearable ?? false}

--- a/frontend/apps/staff/src/hooks/useGetFilterSearchParams.test.ts
+++ b/frontend/apps/staff/src/hooks/useGetFilterSearchParams.test.ts
@@ -1,0 +1,138 @@
+import type { ReadonlyURLSearchParams } from "next/navigation";
+import { describe, expect, it } from "vitest";
+import { VALID_ALLOCATION_APPLICATION_STATUSES } from "@/modules/const";
+import {
+  AccessCodeState,
+  ApplicationSectionStatusChoice,
+  ApplicationStatusChoice,
+  MunicipalityChoice,
+  OrderStatusWithFree,
+  ReservationStateChoice,
+  ReservationTypeChoice,
+  ReservationUnitPublishingState,
+  ReserveeType,
+  Weekday,
+} from "@gql/gql-types";
+import { getFilterSearchParams } from "./useGetFilterSearchParams";
+
+function toSearchParams(init: Array<[string, string]>): ReadonlyURLSearchParams {
+  return new URLSearchParams(init) as ReadonlyURLSearchParams;
+}
+
+describe("getFilterSearchParams", () => {
+  it("leaves every filter undefined when there are no search params", () => {
+    const res = getFilterSearchParams({ searchParams: toSearchParams([]) });
+    expect(res.unitFilter).toBeUndefined();
+    expect(res.textFilter).toBeUndefined();
+    expect(res.reservationStatusFilter).toBeUndefined();
+    expect(res.weekDayFilter).toBeUndefined();
+    expect(res.recurringFilter).toBeUndefined();
+    // the application status filter is the one filter with a default
+    expect(res.applicationStatusFilter).toEqual(VALID_ALLOCATION_APPLICATION_STATUSES);
+  });
+
+  it("transforms each enum param into its gql enum value", () => {
+    const res = getFilterSearchParams({
+      searchParams: toSearchParams([
+        ["applicantType", ReserveeType.Individual],
+        ["state", ReservationStateChoice.Confirmed],
+        ["sectionStatus", ApplicationSectionStatusChoice.Handled],
+        ["accessCodeState", AccessCodeState.AccessCodeCreated],
+        ["reservationType", ReservationTypeChoice.Staff],
+        ["orderStatus", OrderStatusWithFree.Paid],
+        ["reservationUnitState", ReservationUnitPublishingState.Published],
+        ["municipality", MunicipalityChoice.Helsinki],
+        ["status", ApplicationStatusChoice.Handled],
+        ["weekday", "1"],
+      ]),
+    });
+    expect(res.applicantTypeFilter).toEqual([ReserveeType.Individual]);
+    expect(res.reservationStatusFilter).toEqual([ReservationStateChoice.Confirmed]);
+    expect(res.sectionStatusFilter).toEqual([ApplicationSectionStatusChoice.Handled]);
+    expect(res.accessCodeStateFilter).toEqual([AccessCodeState.AccessCodeCreated]);
+    expect(res.reservationTypeFilter).toEqual([ReservationTypeChoice.Staff]);
+    expect(res.orderStatusFilter).toEqual([OrderStatusWithFree.Paid]);
+    expect(res.reservationUnitStateFilter).toEqual([ReservationUnitPublishingState.Published]);
+    expect(res.municipalityFilter).toEqual([MunicipalityChoice.Helsinki]);
+    expect(res.applicationStatusFilter).toEqual([ApplicationStatusChoice.Handled]);
+    expect(res.weekDayFilter).toEqual([Weekday.Tuesday]);
+  });
+
+  it("drops values that are not known enum members", () => {
+    const res = getFilterSearchParams({
+      searchParams: toSearchParams([
+        ["applicantType", "NOT_A_RESERVEE_TYPE"],
+        ["state", "NOT_A_STATE"],
+        ["municipality", "NOT_A_MUNICIPALITY"],
+        ["weekday", "7"],
+        ["status", "NOT_A_STATUS"],
+      ]),
+    });
+    expect(res.applicantTypeFilter).toBeUndefined();
+    expect(res.reservationStatusFilter).toBeUndefined();
+    expect(res.municipalityFilter).toBeUndefined();
+    expect(res.weekDayFilter).toBeUndefined();
+    // an unknown status falls back to the default instead of filtering nothing out
+    expect(res.applicationStatusFilter).toEqual(VALID_ALLOCATION_APPLICATION_STATUSES);
+  });
+
+  it("reads the applicant type from the legacy applicant param", () => {
+    const res = getFilterSearchParams({
+      searchParams: toSearchParams([["applicant", ReserveeType.Company]]),
+    });
+    expect(res.applicantTypeFilter).toEqual([ReserveeType.Company]);
+  });
+
+  it("prefers the applicantType param over the legacy applicant param", () => {
+    const res = getFilterSearchParams({
+      searchParams: toSearchParams([
+        ["applicant", ReserveeType.Company],
+        ["applicantType", ReserveeType.Nonprofit],
+      ]),
+    });
+    expect(res.applicantTypeFilter).toEqual([ReserveeType.Nonprofit]);
+  });
+
+  it("falls back to the units the user has permission to when no unit is selected", () => {
+    const unitOptions = [
+      { label: "Unit 1", value: 1 },
+      { label: "Unit 2", value: 2 },
+    ];
+    expect(getFilterSearchParams({ searchParams: toSearchParams([]), unitOptions }).unitFilter).toEqual([1, 2]);
+    expect(getFilterSearchParams({ searchParams: toSearchParams([["unit", "2"]]), unitOptions }).unitFilter).toEqual([
+      2,
+    ]);
+  });
+
+  it("clips the person and surface area limits to integers", () => {
+    const res = getFilterSearchParams({
+      searchParams: toSearchParams([
+        ["maxPersonsGte", "1.7"],
+        ["surfaceAreaLte", "20.4"],
+        ["minPrice", "10.5"],
+      ]),
+    });
+    expect(res.maxPersonsGteFilter).toBe(1);
+    expect(res.surfaceAreaLteFilter).toBe(20);
+    // prices are not clipped
+    expect(res.minPriceFilter).toBe(10.5);
+  });
+
+  it("reads the recurring and free of charge flags", () => {
+    expect(getFilterSearchParams({ searchParams: toSearchParams([["recurring", "only"]]) }).recurringFilter).toBe(
+      "only"
+    );
+    expect(getFilterSearchParams({ searchParams: toSearchParams([["recurring", "onlyNot"]]) }).recurringFilter).toBe(
+      "onlyNot"
+    );
+    expect(
+      getFilterSearchParams({ searchParams: toSearchParams([["recurring", "??"]]) }).recurringFilter
+    ).toBeUndefined();
+    expect(getFilterSearchParams({ searchParams: toSearchParams([["freeOfCharge", "true"]]) }).freeOfChargeFilter).toBe(
+      true
+    );
+    expect(
+      getFilterSearchParams({ searchParams: toSearchParams([["freeOfCharge", "false"]]) }).freeOfChargeFilter
+    ).toBe(false);
+  });
+});

--- a/frontend/apps/staff/src/hooks/useGetFilterSearchParams.ts
+++ b/frontend/apps/staff/src/hooks/useGetFilterSearchParams.ts
@@ -34,7 +34,9 @@ export function getFilterSearchParams({
     searchParams.getAll("applicantType").length > 0
       ? searchParams.getAll("applicantType")
       : searchParams.getAll("applicant");
-  const applicantTypeFilter = filterEmptyArray(filterNonNullable(applicantTypeParam.map(transformReserveeType)));
+  const applicantTypeFilter = filterEmptyArray(
+    filterNonNullable(applicantTypeParam.map((reserveeType) => transformReserveeType(reserveeType)))
+  );
 
   const priorityFilter = filterEmptyArray(transformPriorityFilter(searchParams.getAll("priority")));
   const orderFilter = filterEmptyArray(mapParamToInteger(searchParams.getAll("order")));
@@ -48,30 +50,32 @@ export function getFilterSearchParams({
     reservationUnitTypeFilter: filterEmptyArray(mapParamToInteger(searchParams.getAll("reservationUnitType"), 1)),
     applicationStatusFilter: filterEmptyArray(transformApplicationStatusList(searchParams.getAll("status"))),
     reservationStatusFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("state").map(transformReservationState))
+      filterNonNullable(searchParams.getAll("state").map((state) => transformReservationState(state)))
     ),
     sectionStatusFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("sectionStatus").map(transformApplicationSectionStatus))
+      filterNonNullable(searchParams.getAll("sectionStatus").map((status) => transformApplicationSectionStatus(status)))
     ),
     applicantTypeFilter,
     accessCodeStateFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("accessCodeState").map(transformAccessCodeState))
+      filterNonNullable(searchParams.getAll("accessCodeState").map((state) => transformAccessCodeState(state)))
     ),
     reservationTypeFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("reservationType").map(transformReservationType))
+      filterNonNullable(searchParams.getAll("reservationType").map((type) => transformReservationType(type)))
     ),
     orderStatusFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("orderStatus").map(transformPaymentStatus))
+      filterNonNullable(searchParams.getAll("orderStatus").map((status) => transformPaymentStatus(status)))
     ),
     reservationUnitStateFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("reservationUnitState").map(transformReservationUnitState))
+      filterNonNullable(
+        searchParams.getAll("reservationUnitState").map((state) => transformReservationUnitState(state))
+      )
     ),
     recurringFilter: convertRecurringParam(searchParams.get("recurring")),
     priorityFilter,
     orderFilter,
     ageGroupFilter,
     municipalityFilter: filterEmptyArray(
-      filterNonNullable(searchParams.getAll("municipality").map(transformMunicipality))
+      filterNonNullable(searchParams.getAll("municipality").map((municipality) => transformMunicipality(municipality)))
     ),
     purposeFilter,
     // backend error if these are floats
@@ -90,7 +94,7 @@ export function getFilterSearchParams({
     weekDayFilter: filterEmptyArray(
       mapParamToInteger(searchParams.getAll("weekday"))
         .filter((n): n is DayT => n >= 0 && n <= 6)
-        .map(transformWeekday)
+        .map((weekday) => transformWeekday(weekday))
     ),
   };
 }
@@ -126,7 +130,7 @@ export function useGetFilterSearchParams({
 }
 
 function transformApplicationStatusList(filters: string[]): ApplicationStatusChoice[] {
-  const vals = filterNonNullable(filters.map(transformApplicationStatus));
+  const vals = filterNonNullable(filters.map((status) => transformApplicationStatus(status)));
   if (vals.length === 0) {
     return VALID_ALLOCATION_APPLICATION_STATUSES;
   }

--- a/frontend/apps/staff/src/hooks/useUnitResources.ts
+++ b/frontend/apps/staff/src/hooks/useUnitResources.ts
@@ -60,7 +60,8 @@ export function useUnitResources({
 
   const { affectingReservations, unit } = data ?? previousData ?? {};
 
-  let reservationUnits = unit?.reservationUnits ?? reservationUnitOptions.map(createDummyReservationUnit);
+  let reservationUnits =
+    unit?.reservationUnits ?? reservationUnitOptions.map((option) => createDummyReservationUnit(option));
   if (reservationUnitTypeFilter?.length) {
     reservationUnits = reservationUnits.filter(
       (ru) => ru.reservationUnitType?.pk != null && reservationUnitTypeFilter.includes(ru.reservationUnitType.pk)

--- a/frontend/apps/staff/src/lib/application-rounds/ApplicationRoundCard.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/ApplicationRoundCard.tsx
@@ -21,7 +21,7 @@ const Times = styled(Flex).attrs({
   padding-bottom: var(--spacing-s);
 `;
 
-const Number = styled.span`
+const StatValue = styled.span`
   font-size: var(--fontsize-body-xl);
   ${fontMedium}
 `;
@@ -54,7 +54,7 @@ function ReservationPeriod({
 function Stat({ value, label }: { value: number; label: string }): React.ReactElement {
   return (
     <div>
-      <Number>{value}</Number>
+      <StatValue>{value}</StatValue>
       <Label> {label}</Label>
     </div>
   );

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/Filters.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/Filters.tsx
@@ -58,7 +58,7 @@ function mapParamsToForm(params: ReadonlyURLSearchParams): SearchFormValues {
     status: applicationStatusFilter ?? [],
     reservationUnit: reservationUnitFilter ?? [],
     applicant: applicantTypeFilter ?? [],
-    weekday: (weekDayFilter ?? []).map(convertWeekday),
+    weekday: (weekDayFilter ?? []).map((weekday) => convertWeekday(weekday)),
     accessCodeState: accessCodeStateFilter ?? [],
     search: textFilter ?? "",
   };

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/AllocationColumn.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/AllocationColumn.tsx
@@ -93,8 +93,8 @@ function getTimeLabel(selection: string[], t: TFunction): string {
   if (!selectionStart || !selectionEnd) {
     return "";
   }
-  const [day, startHour, startMinute] = selectionStart.split("-").map(toNumber);
-  const [, endHour, endMinute] = selectionEnd.split("-").map(toNumber);
+  const [day, startHour, startMinute] = selectionStart.split("-").map((part) => toNumber(part));
+  const [, endHour, endMinute] = selectionEnd.split("-").map((part) => toNumber(part));
   if (day == null || startHour == null || startMinute == null || endHour == null || endMinute == null) {
     return "";
   }
@@ -109,7 +109,7 @@ function getTimeLabel(selection: string[], t: TFunction): string {
 }
 
 function deserializeSlot(slot: string): { day: DayT; hour: number; mins: number } | null {
-  const res = slot.split("-").map(toNumber);
+  const res = slot.split("-").map((part) => toNumber(part));
   if (res.length !== 3) {
     return null;
   }
@@ -240,11 +240,13 @@ function TimeSelection(): React.ReactElement {
     return endTime <= startTime && minsEnd !== 0;
   };
 
-  const startTimeOptions = timeSlotStartOptions.map(convertOptionToHDS);
-  const endTimeOptions = timeSlotEndOptions.map(convertOptionToHDS).map((n) => ({
-    ...n,
-    disabled: isOptionDisabled(n),
-  }));
+  const startTimeOptions = timeSlotStartOptions.map((option) => convertOptionToHDS(option));
+  const endTimeOptions = timeSlotEndOptions
+    .map((option) => convertOptionToHDS(option))
+    .map((n) => ({
+      ...n,
+      disabled: isOptionDisabled(n),
+    }));
 
   return (
     <TimeSelectWrapper>

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/modules/applicationRoundAllocation.test.ts
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/modules/applicationRoundAllocation.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  decodeTimeSlot,
+  encodeTimeSlot,
+  getTimeSeries,
+  timeSlotKeyToScheduleTime,
+  timeSlotKeyToTime,
+} from "./applicationRoundAllocation";
+
+// Time slot keys are "<day>-<hour>-<minute>" strings, e.g. "1-10-30" for Tuesday at 10:30
+
+describe("timeSlotKeyToTime", () => {
+  it("returns today at the hour and minute of the slot", () => {
+    const date = new Date(timeSlotKeyToTime("1-10-30"));
+    expect(date.getHours()).toBe(10);
+    expect(date.getMinutes()).toBe(30);
+  });
+
+  it("returns 0 for a slot that is missing the minutes", () => {
+    expect(timeSlotKeyToTime("1-10")).toBe(0);
+  });
+});
+
+describe("decodeTimeSlot", () => {
+  it("converts the minutes into a fraction of an hour", () => {
+    expect(decodeTimeSlot("2-14-30")).toEqual({ day: 2, hour: 14.5 });
+    expect(decodeTimeSlot("2-14-00")).toEqual({ day: 2, hour: 14 });
+  });
+
+  it("falls back to the first slot of the week for an unparseable key", () => {
+    expect(decodeTimeSlot("")).toEqual({ day: 0, hour: 0 });
+  });
+
+  it("round trips with encodeTimeSlot", () => {
+    expect(decodeTimeSlot(encodeTimeSlot(3, 9.5))).toEqual({ day: 3, hour: 9.5 });
+  });
+});
+
+describe("getTimeSeries", () => {
+  it("lists every half hour slot from the beginning to the end, end included", () => {
+    expect(getTimeSeries("1", "1-10-00", "1-12-00")).toEqual(["1-10-00", "1-10-30", "1-11-00", "1-11-30", "1-12-00"]);
+  });
+
+  it("starts at the half hour when the beginning is not on the hour", () => {
+    expect(getTimeSeries("1", "1-10-30", "1-12-30")).toEqual(["1-10-30", "1-11-00", "1-11-30", "1-12-00", "1-12-30"]);
+  });
+
+  it("returns nothing when the beginning cannot be parsed", () => {
+    expect(getTimeSeries("1", "1-10", "1-12-00")).toEqual([]);
+  });
+});
+
+describe("timeSlotKeyToScheduleTime", () => {
+  it("formats the slot as a zero padded time", () => {
+    expect(timeSlotKeyToScheduleTime("1-10-30")).toBe("10:30:00");
+    expect(timeSlotKeyToScheduleTime("1-09-00")).toBe("09:00:00");
+  });
+
+  it("pads a half hour slot to the end of the slot", () => {
+    expect(timeSlotKeyToScheduleTime("1-10-00", true)).toBe("10:30:00");
+    expect(timeSlotKeyToScheduleTime("1-10-30", true)).toBe("11:00:00");
+  });
+
+  it("wraps around midnight when padding the last slot of the day", () => {
+    expect(timeSlotKeyToScheduleTime("1-23-30", true)).toBe("00:00:00");
+  });
+
+  it("returns an empty string when there is no slot", () => {
+    expect(timeSlotKeyToScheduleTime(undefined)).toBe("");
+    expect(timeSlotKeyToScheduleTime("1-10")).toBe("");
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/modules/applicationRoundAllocation.ts
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/modules/applicationRoundAllocation.ts
@@ -61,7 +61,7 @@ export function applicationEventSchedulesToCells(
 }
 
 export function timeSlotKeyToTime(slot: string): number {
-  const [, hours, minutes] = slot.split("-").map(toNumber);
+  const [, hours, minutes] = slot.split("-").map((part) => toNumber(part));
   if (hours == null || minutes == null) {
     return 0;
   }
@@ -106,7 +106,7 @@ export function getTimeSlotOptions(
 type TimeSlot = { day: number; hour: number };
 
 export function decodeTimeSlot(slot: string): TimeSlot {
-  const [day, hour, min] = slot.split("-").map(toNumber);
+  const [day, hour, min] = slot.split("-").map((part) => toNumber(part));
   return { day: day ?? 0, hour: (hour ?? 0) + (min ?? 0) / 60 };
 }
 
@@ -125,8 +125,8 @@ function constructTimeSlot(day: number, begin: string): TimeSlot | null {
 }
 
 export function getTimeSeries(day: string, begin: string, end: string): string[] {
-  const [, startHours, startMinutes] = begin.split("-").map(toNumber);
-  const [, endHours, endMinutes] = end.split("-").map(toNumber);
+  const [, startHours, startMinutes] = begin.split("-").map((part) => toNumber(part));
+  const [, endHours, endMinutes] = end.split("-").map((part) => toNumber(part));
   const timeSlots: string[] = [];
   if (startHours == null || startMinutes == null || endHours == null) {
     return timeSlots;
@@ -181,7 +181,7 @@ export function formatTimeRangeList(
 }
 
 export function timeSlotKeyToScheduleTime(slot: string | undefined, padEnd = false): string {
-  let [, hours, minutes] = slot?.split("-").map(toNumber) ?? [];
+  let [, hours, minutes] = slot?.split("-").map((part) => toNumber(part)) ?? [];
   if (hours == null || minutes == null) {
     return "";
   }

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/PricingSection.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/PricingSection.tsx
@@ -29,7 +29,7 @@ const FuturePricingContainer = styled(Flex)<{ $toggled: boolean }>`
   ${({ $toggled }) => $toggled && "background: var(--color-black-5);"}
 `;
 
-const Error = styled.div`
+const ErrorText = styled.div`
   margin-top: var(--spacing-3-xs);
   color: var(--color-error);
   display: flex;
@@ -255,10 +255,10 @@ export function PricingTypeView({ pk, form, taxPercentageOptions }: Props): Reac
         )}
       />
       {errors.pricings?.message != null && (
-        <Error>
+        <ErrorText>
           <IconAlertCircleFill />
           <span>{getTranslatedError(t, errors.pricings.message)}</span>
-        </Error>
+        </ErrorText>
       )}
       {isPaid && <PaidPricingPart form={form} index={index} taxPercentageOptions={taxPercentageOptions} />}
     </AutoGrid>

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/form.ts
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/form.ts
@@ -803,7 +803,7 @@ function convertPricing(p?: PricingNode): PricingFormValues {
 
 function convertPricingList(pricings: PricingNode[]): PricingFormValues[] {
   // NOTE Even though the frontend doesn't support adding more than two prices we can show / save more
-  const convertedPrices = pricings.map(convertPricing);
+  const convertedPrices = pricings.map((pricing) => convertPricing(pricing));
   const activePrices = convertedPrices.filter((p) => !p.isFuture);
   const futurePrices = convertedPrices.filter((p) => p.isFuture);
 

--- a/frontend/apps/staff/src/lib/units/[id]/ParentSelector.tsx
+++ b/frontend/apps/staff/src/lib/units/[id]/ParentSelector.tsx
@@ -82,7 +82,7 @@ export function ParentSelector({
 
   const options = noParentless ? opts : [...opts, parentLessOption(t)];
 
-  const hdsOptions = options.map(convertOptionToHDS);
+  const hdsOptions = options.map((option) => convertOptionToHDS(option));
   return (
     <Select
       id="parentSelector"

--- a/frontend/apps/staff/src/modules/urls.test.ts
+++ b/frontend/apps/staff/src/modules/urls.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { getOpeningHoursUrl } from "./urls";
+
+const API_BASE_URL = "https://api.test.hel.ninja";
+
+function getReservationUnits(url: string): string | null {
+  return new URL(url).searchParams.get("reservation_units");
+}
+
+describe("getOpeningHoursUrl", () => {
+  it("builds the opening hours url for a single reservation unit", () => {
+    const url = getOpeningHoursUrl(API_BASE_URL, 5);
+    expect(new URL(url).pathname).toBe("/v1/edit_opening_hours/");
+    expect(getReservationUnits(url)).toBe("5");
+  });
+
+  it("keeps only the positive pks in a list", () => {
+    const url = getOpeningHoursUrl(API_BASE_URL, [1, 0, -2, 3]);
+    expect(getReservationUnits(url)).toBe("1,3");
+  });
+
+  it("returns an empty string when none of the pks in a list are positive", () => {
+    expect(getOpeningHoursUrl(API_BASE_URL, [0, -2])).toBe("");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(getOpeningHoursUrl(API_BASE_URL, [])).toBe("");
+  });
+
+  it.each([null, 0, -1])("returns an empty string for the pk %s", (pk) => {
+    expect(getOpeningHoursUrl(API_BASE_URL, pk)).toBe("");
+  });
+
+  it("adds the error url as a redirect target", () => {
+    const errorUrl = "https://staff.test.hel.ninja/units/5";
+    const url = getOpeningHoursUrl(API_BASE_URL, 5, errorUrl);
+    expect(new URL(url).searchParams.get("redirect_on_error")).toBe(errorUrl);
+  });
+});

--- a/frontend/apps/staff/src/modules/urls.ts
+++ b/frontend/apps/staff/src/modules/urls.ts
@@ -133,11 +133,11 @@ export function getOpeningHoursUrl(
 ): string {
   let reservationUnitsParam = "";
   if (Array.isArray(reservationUnitPk)) {
-    reservationUnitPk.filter((pk) => pk > 0);
-    if (reservationUnitPk.length === 0) {
+    const validPks = reservationUnitPk.filter((pk) => pk > 0);
+    if (validPks.length === 0) {
       return "";
     }
-    reservationUnitsParam = reservationUnitPk.join(",");
+    reservationUnitsParam = validPks.join(",");
   } else if (reservationUnitPk == null || !(reservationUnitPk > 0)) {
     return "";
   } else {

--- a/frontend/apps/staff/src/pages/application-rounds/[id]/index.tsx
+++ b/frontend/apps/staff/src/pages/application-rounds/[id]/index.tsx
@@ -290,7 +290,7 @@ function toOption(
 function getRoundReservationUnitOptions(
   applicationRound: Maybe<Pick<ApplicationRoundAdminFragment, "reservationUnits">> | undefined
 ) {
-  return filterNonNullable(applicationRound?.reservationUnits.map(toOption));
+  return filterNonNullable(applicationRound?.reservationUnits.map((reservationUnit) => toOption(reservationUnit)));
 }
 
 function getRoundUnitOptions(reservationUnits: ApplicationRoundAdminFragment["reservationUnits"]) {

--- a/frontend/packages/ui/src/components/form/ControlledSelect.tsx
+++ b/frontend/packages/ui/src/components/form/ControlledSelect.tsx
@@ -49,9 +49,9 @@ const toHDSValue = (
   }
   if (Array.isArray(val)) {
     const keyVals = filterNonNullable(val.map((v) => opts.find((o) => o.value === v)));
-    return keyVals.map(convertOptionToHDS);
+    return keyVals.map((option) => convertOptionToHDS(option));
   }
-  return opts.filter((o) => o.value === val).map(convertOptionToHDS);
+  return opts.filter((o) => o.value === val).map((option) => convertOptionToHDS(option));
 };
 
 export function ControlledSelect<T extends FieldValues>({
@@ -128,7 +128,7 @@ export function ControlledSelect<T extends FieldValues>({
       }}
       tooltip={tooltip != null && tooltip !== "" ? <Tooltip>{tooltip}</Tooltip> : undefined}
       value={toHDSValue(options, value)}
-      options={options.map(convertOptionToHDS)}
+      options={options.map((option) => convertOptionToHDS(option))}
       onChange={handleChange}
       invalid={Boolean(error)}
       disabled={disabled ?? options.length === 0}

--- a/frontend/packages/ui/src/modules/apollo/helpers.ts
+++ b/frontend/packages/ui/src/modules/apollo/helpers.ts
@@ -474,7 +474,7 @@ export function logGraphQLQuery(
   documents: DocumentNode | DocumentNode[]
 ): void {
   const operationName = Array.isArray(documents)
-    ? documents.map(getOperationName).map((x) => x ?? "")
+    ? documents.map((doc) => getOperationName(doc)).map((x) => x ?? "")
     : (getOperationName(documents) ?? "");
   const t = Math.round(timeMs);
   log.info(


### PR DESCRIPTION
Closes the 16 open reliability issues SonarCloud reports for
tilavarauspalvelu-staff-ui and tilavarauspalvelu-customer-ui. The
backend project was already clean.

Three commits, easiest reviewed one by one:

1. **`getOpeningHoursUrl` dropped its filter result** — the only real bug
   here. Non-positive reservation unit pks were still sent, and the
   emptiness check tested the unfiltered list. Adds tests for the
   function, which had none.
2. **`Number`, `Error` and `Map` renamed** — they shadowed the globals of
   the same name. The map component file is renamed to match, which also
   removes an import alias at its only consumer.
3. **Callbacks no longer passed directly to `Array.map`** — no behaviour
   change (none of them takes a second parameter), so this is rule
   compliance. Applied at all 37 sites in the frontend rather than only
   the 12 reported, to keep the pattern consistent.

Two things left alone on purpose: `.map(Number)`, because oxlint requires
native coercion functions to be passed directly, and test files, which
Sonar excludes from this rule.

Refs: TILA-4426

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Opening-hours links now exclude invalid reservation unit IDs and return no link when no valid IDs are provided.
  - Reservation unit maps continue to display with the correct language and sizing, including the default height.

- **Tests**
  - Added coverage for opening-hours links, reservation unit maps, filter handling, and application-round time-slot calculations.

- **Refactor**
  - Improved consistency across option and data transformations without changing user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->