### PR TITLE
TILA-4423 TILA-4424 Sonar coverage increase part 2

### DIFF
--- a/frontend/apps/customer/src/components/AccordionWithIcons.test.tsx
+++ b/frontend/apps/customer/src/components/AccordionWithIcons.test.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect } from "vitest";
+import { AccordionWithIcons } from "./AccordionWithIcons";
+
+describe("AccordionWithIcons", () => {
+  test("renders the heading, icon list, and closed children by default", () => {
+    render(
+      <AccordionWithIcons heading="My heading" icons={[{ text: "5 people", icon: <svg /> }]}>
+        <div>hidden content</div>
+      </AccordionWithIcons>
+    );
+
+    expect(screen.getByRole("heading", { name: "My heading" })).toBeInTheDocument();
+    expect(screen.getByText("5 people")).toBeInTheDocument();
+    expect(screen.getByText("hidden content")).not.toBeVisible();
+  });
+
+  test("renders open when initiallyOpen is set", () => {
+    render(
+      <AccordionWithIcons heading="My heading" initiallyOpen>
+        <div>visible content</div>
+      </AccordionWithIcons>
+    );
+
+    expect(screen.getByText("visible content")).toBeVisible();
+  });
+
+  test("toggles content visibility when the toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <AccordionWithIcons heading="My heading">
+        <div>toggle content</div>
+      </AccordionWithIcons>
+    );
+
+    const button = screen.getByRole("button", { name: "common:show" });
+    expect(screen.getByText("toggle content")).not.toBeVisible();
+
+    await user.click(button);
+    expect(screen.getByText("toggle content")).toBeVisible();
+    expect(screen.getByRole("button", { name: "common:close" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common:close" }));
+    expect(screen.getByText("toggle content")).not.toBeVisible();
+  });
+
+  test("renders an optional textPostfix alongside the icon text", () => {
+    render(
+      <AccordionWithIcons heading="My heading" icons={[{ text: "Price", textPostfix: "€10", icon: <svg /> }]}>
+        <div>content</div>
+      </AccordionWithIcons>
+    );
+
+    expect(screen.getByText("Price")).toBeInTheDocument();
+    expect(screen.getByText("€10")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/customer/src/components/Footer.test.tsx
+++ b/frontend/apps/customer/src/components/Footer.test.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import { Footer } from "./Footer";
+
+describe("Footer", () => {
+  test("renders localized links using the provided feedback URL", () => {
+    render(<Footer feedbackUrl="https://example.com/feedback" />);
+
+    expect(screen.getByRole("link", { name: /footer:Navigation.serviceTermsLabel/ })).toHaveAttribute(
+      "href",
+      "/terms/service"
+    );
+    expect(screen.getByRole("link", { name: /footer:Base.Item.privacyStatement/ })).toHaveAttribute(
+      "href",
+      "/terms/privacy"
+    );
+    expect(screen.getByRole("link", { name: /footer:Base.Item.accessibilityStatement/ })).toHaveAttribute(
+      "href",
+      "/terms/accessibility"
+    );
+    expect(screen.getByRole("link", { name: /footer:Navigation.feedbackLabel/ })).toHaveAttribute(
+      "href",
+      "https://example.com/feedback?lang=fi"
+    );
+  });
+});

--- a/frontend/apps/customer/src/components/application/funnel/ReservationUnitModalContent.test.tsx
+++ b/frontend/apps/customer/src/components/application/funnel/ReservationUnitModalContent.test.tsx
@@ -134,7 +134,7 @@ describe("Modal render", () => {
         })
       ).toBeInTheDocument();
     }
-  });
+  }, 10_000);
 });
 
 describe("Modal search", () => {

--- a/frontend/apps/customer/src/hooks/useDebounce.test.tsx
+++ b/frontend/apps/customer/src/hooks/useDebounce.test.tsx
@@ -1,0 +1,56 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { useDebounce } from "./useDebounce";
+
+describe("useDebounce", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test("returns the initial truthy value immediately, without waiting for the delay", () => {
+    const { result } = renderHook(() => useDebounce("initial", 500));
+    expect(result.current).toBe("initial");
+  });
+
+  test("does not update immediately on subsequent value changes", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: "initial" },
+    });
+
+    rerender({ value: "updated" });
+    expect(result.current).toBe("initial");
+  });
+
+  test("updates to the latest value after the delay elapses", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: "initial" },
+    });
+
+    rerender({ value: "updated" });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(result.current).toBe("updated");
+  });
+
+  test("only applies the latest value when changed multiple times within the delay window", () => {
+    const { result, rerender } = renderHook(({ value }) => useDebounce(value, 500), {
+      initialProps: { value: "initial" },
+    });
+
+    rerender({ value: "first" });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    rerender({ value: "second" });
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current).toBe("second");
+  });
+});

--- a/frontend/apps/customer/src/lib/index/IntendedUses.test.tsx
+++ b/frontend/apps/customer/src/lib/index/IntendedUses.test.tsx
@@ -1,0 +1,83 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect, vi } from "vitest";
+import type { IntendedUseCardFragment } from "@gql/gql-types";
+import { IntendedUses } from "./IntendedUses";
+
+const mockUseMedia = vi.fn();
+vi.mock("react-use", () => ({ useMedia: (...args: unknown[]) => mockUseMedia(...args) }));
+
+vi.mock("./ReservationUnitSearch", () => ({
+  ReservationUnitSearch: () => <div data-testid="mocked-reservation-unit-search" />,
+}));
+
+function createIntendedUse(overrides: Partial<IntendedUseCardFragment> = {}): IntendedUseCardFragment {
+  return {
+    id: "intended-use-1",
+    pk: 1,
+    nameFi: "Liikunta FI",
+    nameEn: "Sports EN",
+    nameSv: "Sport SV",
+    imageUrl: "https://example.com/image.jpg",
+    smallUrl: null,
+    ...overrides,
+  };
+}
+
+describe("IntendedUses", () => {
+  test("renders the heading and search box", () => {
+    mockUseMedia.mockReturnValue(false);
+    render(<IntendedUses intendedUses={[createIntendedUse()]} />);
+
+    expect(screen.getByText("intendedUsesHeading")).toBeInTheDocument();
+    expect(screen.getByTestId("mocked-reservation-unit-search")).toBeInTheDocument();
+  });
+
+  test("renders a card per intended use with a link to the search page", () => {
+    mockUseMedia.mockReturnValue(false);
+    const intendedUses = [
+      createIntendedUse({ pk: 1, nameFi: "Liikunta" }),
+      createIntendedUse({ pk: 2, nameFi: "Kokous" }),
+    ];
+    render(<IntendedUses intendedUses={intendedUses} />);
+
+    const cards = screen.getAllByTestId("front-page__intended-uses__intended-use");
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText("Liikunta")).toBeInTheDocument();
+    expect(screen.getByText("Kokous")).toBeInTheDocument();
+
+    const link = screen.getByText("Liikunta").closest("a");
+    expect(link).toHaveAttribute("href", expect.stringContaining("intendedUses=1"));
+  });
+
+  test("falls back to imageUrl when smallUrl is missing, and to a pixel when both are missing", () => {
+    mockUseMedia.mockReturnValue(false);
+    const intendedUses = [
+      createIntendedUse({ pk: 1, nameFi: "HasImageUrl", smallUrl: null, imageUrl: "https://example.com/full.jpg" }),
+      createIntendedUse({ pk: 2, nameFi: "HasSmallUrl", smallUrl: "https://example.com/small.jpg", imageUrl: null }),
+      createIntendedUse({ pk: 3, nameFi: "NoImage", smallUrl: null, imageUrl: null }),
+    ];
+    const { container } = render(<IntendedUses intendedUses={intendedUses} />);
+
+    const images = container.querySelectorAll("img");
+    expect(images[0]).toHaveAttribute("src", "https://example.com/full.jpg");
+    expect(images[1]).toHaveAttribute("src", "https://example.com/small.jpg");
+    expect(images[2]?.getAttribute("src")).not.toBe("");
+  });
+
+  test("shows a 'show more' toggle once the item count exceeds the mobile limit of 4", () => {
+    mockUseMedia.mockReturnValue(true);
+    const intendedUses = Array.from({ length: 5 }, (_, i) => createIntendedUse({ pk: i + 1, nameFi: `Use ${i + 1}` }));
+    render(<IntendedUses intendedUses={intendedUses} />);
+
+    expect(screen.getByTestId("show-all__toggle-button")).toBeInTheDocument();
+  });
+
+  test("does not show a 'show more' toggle when under the desktop limit of 8", () => {
+    mockUseMedia.mockReturnValue(false);
+    const intendedUses = Array.from({ length: 5 }, (_, i) => createIntendedUse({ pk: i + 1, nameFi: `Use ${i + 1}` }));
+    render(<IntendedUses intendedUses={intendedUses} />);
+
+    expect(screen.queryByTestId("show-all__toggle-button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/customer/src/lib/index/ReservationUnitSearch.test.tsx
+++ b/frontend/apps/customer/src/lib/index/ReservationUnitSearch.test.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { ReservationUnitSearch } from "./ReservationUnitSearch";
+
+const { useRouter, mockedRouterPush } = vi.hoisted(() => {
+  const mockedRouterPush = vi.fn();
+  return {
+    useRouter: () => ({ push: mockedRouterPush }),
+    mockedRouterPush,
+  };
+});
+
+vi.mock("next/router", () => ({
+  useRouter,
+}));
+
+describe("ReservationUnitSearch", () => {
+  beforeEach(() => {
+    mockedRouterPush.mockClear();
+  });
+
+  test("renders the search input", () => {
+    render(<ReservationUnitSearch />);
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+  });
+
+  test("submitting the form navigates to the search page with the entered text", async () => {
+    const user = userEvent.setup();
+    render(<ReservationUnitSearch />);
+
+    const input = screen.getByRole("textbox");
+    await user.type(input, "sauna");
+    await user.keyboard("{Enter}");
+
+    expect(mockedRouterPush).toHaveBeenCalledTimes(1);
+    const [url] = mockedRouterPush.mock.calls[0] ?? [];
+    expect(url).toContain("textSearch=sauna");
+  });
+
+  test("clicking the search icon navigates with an empty search when no text was entered", async () => {
+    const user = userEvent.setup();
+    render(<ReservationUnitSearch />);
+
+    await user.click(screen.getByLabelText("common:search"));
+
+    expect(mockedRouterPush).toHaveBeenCalledTimes(1);
+    const [url] = mockedRouterPush.mock.calls[0] ?? [];
+    expect(url).toContain("textSearch=");
+  });
+});

--- a/frontend/apps/customer/src/lib/index/Units.test.tsx
+++ b/frontend/apps/customer/src/lib/index/Units.test.tsx
@@ -1,0 +1,48 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import type { UnitListFieldsFragment } from "@gql/gql-types";
+import { Units } from "./Units";
+
+function createUnit(overrides: Partial<UnitListFieldsFragment> = {}): UnitListFieldsFragment {
+  return {
+    id: "unit-1",
+    pk: 1,
+    nameFi: "Yksikkö FI",
+    nameEn: "Unit EN",
+    nameSv: "Enhet SV",
+    ...overrides,
+  };
+}
+
+describe("Units", () => {
+  test("renders nothing when there are no units", () => {
+    const { container } = render(<Units units={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("renders a link per unit with a search href, and no 'show all' link under the limit", () => {
+    const units = [createUnit({ pk: 1, nameFi: "Yksikkö A" }), createUnit({ pk: 2, nameFi: "Yksikkö B" })];
+    render(<Units units={units} />);
+
+    const links = screen.getAllByTestId("front-page__units--unit");
+    expect(links).toHaveLength(2);
+    expect(screen.getByText("Yksikkö A").closest("a")).toHaveAttribute("href", expect.stringContaining("units=1"));
+    expect(screen.queryByTestId("front-page__units--more-link")).not.toBeInTheDocument();
+  });
+
+  test("shows only the first 8 units and a 'show all' link when there are more", () => {
+    const units = Array.from({ length: 10 }, (_, i) => createUnit({ pk: i + 1, nameFi: `Yksikkö ${i + 1}` }));
+    render(<Units units={units} />);
+
+    expect(screen.getAllByTestId("front-page__units--unit")).toHaveLength(8);
+    expect(screen.getByTestId("front-page__units--more-link")).toBeInTheDocument();
+  });
+
+  test("falls back to a dash when a unit has no translated name", () => {
+    const units = [createUnit({ pk: 1, nameFi: null, nameEn: null, nameSv: null })];
+    render(<Units units={units} />);
+
+    expect(screen.getByTestId("front-page__units--unit")).toHaveTextContent("-");
+  });
+});

--- a/frontend/apps/customer/src/lib/reservation-unit/[id]/EquipmentList.test.tsx
+++ b/frontend/apps/customer/src/lib/reservation-unit/[id]/EquipmentList.test.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect } from "vitest";
+import type { EquipmentFieldsFragment } from "@gql/gql-types";
+import { EquipmentList } from "./EquipmentList";
+
+function createEquipment(overrides: Partial<EquipmentFieldsFragment> = {}): EquipmentFieldsFragment {
+  return {
+    id: "eq-1",
+    pk: 1,
+    nameFi: "Tuoli",
+    nameEn: "Chair",
+    nameSv: "Stol",
+    category: { id: "cat-1", nameFi: "Huonekalut", nameEn: "Furniture", nameSv: "Möbler" },
+    ...overrides,
+  };
+}
+
+describe("EquipmentList", () => {
+  test("renders every piece of equipment when under the item limit", () => {
+    const equipment = [createEquipment({ pk: 1, nameFi: "Tuoli" }), createEquipment({ pk: 2, nameFi: "Pöytä" })];
+    render(<EquipmentList equipment={equipment} />);
+
+    expect(screen.getByText("Tuoli")).toBeInTheDocument();
+    expect(screen.getByText("Pöytä")).toBeInTheDocument();
+    expect(screen.queryByTestId("show-all__toggle-button")).not.toBeInTheDocument();
+  });
+
+  test("shows a 'show all' toggle once equipment exceeds itemsToShow", () => {
+    const equipment = Array.from({ length: 4 }, (_, i) => createEquipment({ pk: i + 1, nameFi: `Item ${i + 1}` }));
+    render(<EquipmentList equipment={equipment} itemsToShow={2} />);
+
+    expect(screen.getByTestId("show-all__toggle-button")).toBeInTheDocument();
+  });
+
+  test("renders nothing but the (empty) container when there is no equipment", () => {
+    render(<EquipmentList equipment={[]} />);
+
+    expect(screen.getByTestId("reservation-unit__equipment")).toBeInTheDocument();
+    expect(screen.queryByTestId("show-all__toggle-button")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/customer/src/lib/reservation/[id]/cancel/CancelledLinkSet.test.tsx
+++ b/frontend/apps/customer/src/lib/reservation/[id]/cancel/CancelledLinkSet.test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { CancelledLinkSet, BackLinkList } from "./CancelledLinkSet";
+
+const mockedSignOut = vi.fn();
+vi.mock("ui/src/modules/browserHelpers", () => ({
+  signOut: (...args: unknown[]) => mockedSignOut(...args),
+}));
+
+describe("CancelledLinkSet", () => {
+  beforeEach(() => {
+    mockedSignOut.mockClear();
+  });
+
+  test("links back to the search page when no reservation unit home is given", () => {
+    render(<CancelledLinkSet apiBaseUrl="https://api.example.com" />);
+
+    expect(screen.getByText(/reservation:searchPage/)).toBeInTheDocument();
+    expect(screen.getByText("common:gotoFrontpage")).toBeInTheDocument();
+  });
+
+  test("calls signOut with the api base url when the logout button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CancelledLinkSet apiBaseUrl="https://api.example.com" />);
+
+    await user.click(screen.getByText("common:logout"));
+
+    expect(mockedSignOut).toHaveBeenCalledWith("https://api.example.com");
+  });
+});
+
+describe("BackLinkList", () => {
+  test("links back to the reservation unit page when a home url is given", () => {
+    render(<BackLinkList apiBaseUrl="https://api.example.com" reservationUnitHome="/reservation-unit/1" />);
+
+    expect(screen.getByText(/reservation:reservationUnitPage/)).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/customer/src/modules/queryOptions.test.ts
+++ b/frontend/apps/customer/src/modules/queryOptions.test.ts
@@ -1,0 +1,74 @@
+import type { ApolloClient } from "@apollo/client";
+import { describe, test, expect, vi } from "vitest";
+import type { OptionsQuery } from "@gql/gql-types";
+import { queryOptions } from "./queryOptions";
+
+function createMockApolloClient(data: OptionsQuery): ApolloClient<unknown> {
+  return {
+    query: vi.fn().mockResolvedValue({ data }),
+  } as unknown as ApolloClient<unknown>;
+}
+
+function createOptionsData(overrides: Partial<OptionsQuery> = {}): OptionsQuery {
+  return {
+    reservationUnitTypes: { edges: [] },
+    intendedUses: { edges: [] },
+    reservationPurposes: {
+      edges: [
+        { node: { id: "p-2", pk: 2, nameFi: "Kokous", nameEn: "Meeting", nameSv: "Möte" } },
+        { node: { id: "p-1", pk: 1, nameFi: "Liikunta", nameEn: "Sports", nameSv: "Sport" } },
+      ],
+    },
+    ageGroups: {
+      edges: [
+        { node: { id: "a-1", pk: 1, minimum: 18, maximum: 30 } },
+        { node: { id: "a-2", pk: 2, minimum: 1, maximum: 17 } },
+      ],
+    },
+    equipmentsAll: [],
+    unitsAll: [],
+    ...overrides,
+  };
+}
+
+describe("queryOptions", () => {
+  test("maps reservation purposes to translated label/value options", async () => {
+    const client = createMockApolloClient(createOptionsData());
+    const result = await queryOptions(client, "fi");
+
+    expect(result.purpose).toEqual([
+      { label: "Kokous", value: 2 },
+      { label: "Liikunta", value: 1 },
+    ]);
+  });
+
+  test("maps and sorts age groups", async () => {
+    const client = createMockApolloClient(createOptionsData());
+    const result = await queryOptions(client, "fi");
+
+    expect(result.ageGroup).toEqual([
+      { label: "1 - 17", value: 2 },
+      { label: "18 - 30", value: 1 },
+    ]);
+  });
+
+  test("handles missing ageGroups without throwing", async () => {
+    const client = createMockApolloClient(createOptionsData({ ageGroups: { edges: [] } }));
+    const result = await queryOptions(client, "fi");
+
+    expect(result.ageGroup).toEqual([]);
+  });
+
+  test("falls back to 0 for missing purpose/ageGroup pks", async () => {
+    const client = createMockApolloClient(
+      createOptionsData({
+        reservationPurposes: {
+          edges: [{ node: { id: "p-1", pk: null, nameFi: "Foo", nameEn: "Foo", nameSv: "Foo" } }],
+        },
+      })
+    );
+    const result = await queryOptions(client, "fi");
+
+    expect(result.purpose).toEqual([{ label: "Foo", value: 0 }]);
+  });
+});

--- a/frontend/apps/customer/src/modules/tracking.test.tsx
+++ b/frontend/apps/customer/src/modules/tracking.test.tsx
@@ -1,0 +1,49 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach } from "vitest";
+import { TrackingWrapper } from "./tracking";
+
+const { useRouter, mockedOn } = vi.hoisted(() => {
+  const mockedOn = vi.fn();
+  return {
+    useRouter: () => ({ events: { on: mockedOn, off: vi.fn() } }),
+    mockedOn,
+  };
+});
+
+vi.mock("next/router", () => ({
+  useRouter,
+}));
+
+describe("TrackingWrapper", () => {
+  beforeEach(() => {
+    mockedOn.mockClear();
+  });
+
+  test("renders its children", () => {
+    render(
+      <TrackingWrapper matomoEnabled={false}>
+        <div>child content</div>
+      </TrackingWrapper>
+    );
+    expect(screen.getByText("child content")).toBeInTheDocument();
+  });
+
+  test("subscribes to routeChangeComplete when matomo is enabled", () => {
+    render(
+      <TrackingWrapper matomoEnabled>
+        <div>child content</div>
+      </TrackingWrapper>
+    );
+    expect(mockedOn).toHaveBeenCalledWith("routeChangeComplete", expect.any(Function));
+  });
+
+  test("does not subscribe when matomo is disabled", () => {
+    render(
+      <TrackingWrapper matomoEnabled={false}>
+        <div>child content</div>
+      </TrackingWrapper>
+    );
+    expect(mockedOn).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/staff/src/components/BirthDate.test.tsx
+++ b/frontend/apps/staff/src/components/BirthDate.test.tsx
@@ -1,0 +1,206 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useReservationDateOfBirthQuery, useApplicationDateOfBirthQuery } from "@gql/gql-types";
+import { BirthDate } from "./BirthDate";
+
+vi.mock("@gql/gql-types");
+
+describe("BirthDate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders masked date initially for reservation", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+    expect(screen.getByText("XX.XX.XXXX")).toBeInTheDocument();
+  });
+
+  it("renders masked date initially for application", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate applicationPk={1} />);
+    expect(screen.getByText("XX.XX.XXXX")).toBeInTheDocument();
+  });
+
+  it("shows loading state for reservation", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("shows error state for reservation", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error("Query failed"),
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+    expect(screen.getByText(/error/i)).toBeInTheDocument();
+  });
+
+  it("shows loading state for application", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: true,
+      error: null,
+    } as never);
+
+    render(<BirthDate applicationPk={1} />);
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("shows error state for application", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: new Error("Query failed"),
+    } as never);
+
+    render(<BirthDate applicationPk={1} />);
+    expect(screen.getByText(/error/i)).toBeInTheDocument();
+  });
+
+  it("toggles birth date visibility for reservation", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: {
+        reservation: {
+          user: { dateOfBirth: "1990-01-15" },
+        },
+      },
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+    expect(screen.getByText("XX.XX.XXXX")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show/i }));
+    // Date should not be masked anymore - just verify the mask is gone
+    expect(screen.queryByText("XX.XX.XXXX")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /hide/i }));
+    expect(screen.getByText("XX.XX.XXXX")).toBeInTheDocument();
+  });
+
+  it("toggles birth date visibility for application", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: {
+        application: {
+          user: { dateOfBirth: "1985-06-20" },
+        },
+      },
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate applicationPk={1} />);
+    expect(screen.getByText("XX.XX.XXXX")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /show/i }));
+    // Date should not be masked anymore
+    expect(screen.queryByText("XX.XX.XXXX")).not.toBeInTheDocument();
+  });
+
+  it("handles null birth date", async () => {
+    const user = userEvent.setup();
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: {
+        reservation: {
+          user: { dateOfBirth: null },
+        },
+      },
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+    await user.click(screen.getByRole("button", { name: /show/i }));
+    expect(screen.getByText("-")).toBeInTheDocument();
+  });
+
+  it("skips query when reservationPk is not visible", () => {
+    vi.mocked(useReservationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+    vi.mocked(useApplicationDateOfBirthQuery).mockReturnValue({
+      data: undefined,
+      loading: false,
+      error: null,
+    } as never);
+
+    render(<BirthDate reservationPk={1} />);
+
+    expect(useReservationDateOfBirthQuery).toHaveBeenCalledWith({
+      variables: expect.any(Object),
+      fetchPolicy: "no-cache",
+      skip: true,
+    });
+  });
+});

--- a/frontend/apps/staff/src/components/FormErrorSummary.test.tsx
+++ b/frontend/apps/staff/src/components/FormErrorSummary.test.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import type { FieldError, FieldErrors } from "react-hook-form";
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { FormErrorSummary } from "./FormErrorSummary";
+
+function makeErrors(fields: Record<string, string>): FieldErrors {
+  const errors: FieldErrors = {};
+  for (const [key, message] of Object.entries(fields)) {
+    errors[key] = { type: "validate", message } satisfies FieldError;
+  }
+  return errors;
+}
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("FormErrorSummary", () => {
+  it("returns null when there are no errors", () => {
+    const { container } = render(<FormErrorSummary errors={{}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders when there are errors", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    const { container } = render(<FormErrorSummary errors={errors} />);
+    expect(container.querySelector("ul")).toBeInTheDocument();
+  });
+
+  it("renders error list items for each error", () => {
+    const errors = makeErrors({ field1: "field1Error", field2: "field2Error" });
+    render(<FormErrorSummary errors={errors} />);
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(2);
+  });
+
+  it("uses default error prefix when fieldNamePrefix is not provided", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    const { container } = render(<FormErrorSummary errors={errors} />);
+    expect(container.querySelector("ul")).toBeInTheDocument();
+  });
+
+  it("uses custom fieldNamePrefix when provided", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    const { container } = render(<FormErrorSummary errors={errors} fieldNamePrefix="customPrefix" />);
+    expect(container.querySelector("ul")).toBeInTheDocument();
+  });
+
+  it("strips trailing dot from fieldNamePrefix", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    const { container } = render(<FormErrorSummary errors={errors} fieldNamePrefix="customPrefix." />);
+    expect(container.querySelector("ul")).toBeInTheDocument();
+  });
+
+  it("focuses summary on mount", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    const { container } = render(<FormErrorSummary errors={errors} />);
+    const wrapper = container.querySelector("[tabindex='-1']");
+    expect(wrapper).toHaveFocus();
+  });
+
+  it("renders error items", () => {
+    const errors = makeErrors({ field1: "field1Error" });
+    render(<FormErrorSummary errors={errors} />);
+    expect(screen.getAllByRole("listitem")).toHaveLength(1);
+  });
+
+  it("handles multiple errors with proper indexing", () => {
+    const errors = makeErrors({
+      firstName: "firstNameError",
+      lastName: "lastNameError",
+      email: "emailError",
+    });
+    render(<FormErrorSummary errors={errors} />);
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+});

--- a/frontend/apps/staff/src/components/QueryParamFilters/DayNavigation.test.tsx
+++ b/frontend/apps/staff/src/components/QueryParamFilters/DayNavigation.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { DayNavigation } from "./DayNavigation";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({
+  mockUseSearchParams: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({
+  mockUseSetSearchParams: vi.fn(),
+}));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+describe("DayNavigation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("throws error when name is empty", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams());
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    expect(() => {
+      render(<DayNavigation name="" />);
+    }).toThrow("name must not be empty");
+  });
+
+  it("renders date from search params", () => {
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<DayNavigation name="date" />);
+    expect(screen.getByDisplayValue("15.01.2024")).toBeInTheDocument();
+  });
+
+  it("renders empty date input when no date in params", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<DayNavigation name="date" />);
+    expect(screen.getByDisplayValue("")).toBeInTheDocument();
+  });
+
+  it("renders day abbreviation", () => {
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<DayNavigation name="date" />);
+    // The i18next mock returns the translation key itself, e.g. "translation:dayShort.0"
+    expect(screen.getByText(/^translation:dayShort\.\d$/)).toBeInTheDocument();
+  });
+
+  it("calls setSearchParams on date input change", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    render(<DayNavigation name="date" />);
+    const dateInput = screen.getByDisplayValue("15.01.2024");
+    await user.clear(dateInput);
+    // HDS DateInput only propagates onChange to its consumer on blur/Enter, not per keystroke
+    await user.type(dateInput, "16.01.2024{Enter}");
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("handles previous day navigation", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    render(<DayNavigation name="date" />);
+    const prevButton = screen.getByRole("button", { name: /prev/i });
+    await user.click(prevButton);
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("handles next day navigation", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    render(<DayNavigation name="date" />);
+    const nextButton = screen.getByRole("button", { name: /next/i });
+    await user.click(nextButton);
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("deletes param when date is cleared", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("date=15.01.2024");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    render(<DayNavigation name="date" />);
+    const dateInput = screen.getByDisplayValue("15.01.2024");
+    // HDS DateInput only propagates onChange to its consumer on blur/Enter, not per keystroke
+    await user.clear(dateInput);
+    await user.type(dateInput, "{Enter}");
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("uses current date when param date is invalid", () => {
+    const mockSearchParams = new URLSearchParams("date=invalid");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<DayNavigation name="date" />);
+    // Should still render with some date (current date as fallback)
+    expect(screen.getByDisplayValue("invalid")).toBeInTheDocument();
+  });
+
+  it("renders with different param names", () => {
+    const mockSearchParams = new URLSearchParams("customDate=15.01.2024");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<DayNavigation name="customDate" />);
+    expect(screen.getByDisplayValue("15.01.2024")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/components/QueryParamFilters/MultiSelectFilter.test.tsx
+++ b/frontend/apps/staff/src/components/QueryParamFilters/MultiSelectFilter.test.tsx
@@ -1,0 +1,238 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MultiSelectFilter, ControlledMultiSelectFilter } from "./MultiSelectFilter";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({
+  mockUseSearchParams: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({
+  mockUseSetSearchParams: vi.fn(),
+}));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("MultiSelectFilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with selected values from search params", () => {
+    const mockSearchParams = new URLSearchParams("status=active&status=pending");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(
+      <MultiSelectFilter
+        name="status"
+        options={[
+          { label: "Active", value: "active" },
+          { label: "Pending", value: "pending" },
+          { label: "Closed", value: "closed" },
+        ]}
+      />
+    );
+
+    // HDS Select renders differently, just check that the filter is applied
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("calls setParams when selection changes", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    render(
+      <MultiSelectFilter
+        name="status"
+        options={[
+          { label: "Active", value: "active" },
+          { label: "Pending", value: "pending" },
+        ]}
+      />
+    );
+
+    // Without a selection, the dropdown trigger has role "combobox" (the
+    // clear "x" button, which has an implicit "button" role, only renders
+    // once something is selected)
+    await user.click(screen.getByRole("combobox"));
+    const [firstOption] = screen.getAllByRole("option");
+    if (firstOption == null) {
+      throw new Error("Expected at least one option to be rendered");
+    }
+    await user.click(firstOption);
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("disables select when no options available", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<MultiSelectFilter name="status" options={[]} />);
+
+    // HDS Select exposes "disabled" via aria-disabled rather than the native
+    // disabled attribute, so toBeDisabled() (which only checks the native
+    // attribute) doesn't apply here.
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("renders with multiple filters from params", () => {
+    const mockSearchParams = new URLSearchParams("type=a&type=b&status=active");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(
+      <MultiSelectFilter
+        name="type"
+        options={[
+          { label: "A", value: "a" },
+          { label: "B", value: "b" },
+        ]}
+      />
+    );
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+
+  it("applies custom styles and className", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const { container } = render(
+      <MultiSelectFilter
+        name="status"
+        options={[{ label: "Active", value: "active" }]}
+        className="custom-class"
+        style={{ color: "red" }}
+      />
+    );
+
+    const selectElement = container.querySelector(".custom-class");
+    expect(selectElement).toBeInTheDocument();
+  });
+
+  it("enables search filter when enableSearch is true", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    render(<MultiSelectFilter name="status" options={[{ label: "Active", value: "active" }]} enableSearch />);
+
+    expect(screen.getByRole("button")).toBeInTheDocument();
+  });
+});
+
+describe("ControlledMultiSelectFilter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders controlled variant with form", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    function TestForm() {
+      const { control } = useForm({
+        defaultValues: { status: [] },
+      });
+
+      return (
+        <ControlledMultiSelectFilter
+          name="status"
+          control={control}
+          options={[
+            { label: "Active", value: "active" },
+            { label: "Pending", value: "pending" },
+          ]}
+        />
+      );
+    }
+
+    render(<TestForm />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("handles numeric values", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    function TestForm() {
+      const { control } = useForm({
+        defaultValues: { ids: [] },
+      });
+
+      return (
+        <ControlledMultiSelectFilter
+          name="ids"
+          control={control}
+          options={[
+            { label: "One", value: 1 },
+            { label: "Two", value: 2 },
+          ]}
+        />
+      );
+    }
+
+    render(<TestForm />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("converts numeric string values to numbers", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    function TestForm() {
+      const { control } = useForm({
+        defaultValues: { ids: [1, 2] },
+      });
+
+      return (
+        <ControlledMultiSelectFilter
+          name="ids"
+          control={control}
+          options={[
+            { label: "One", value: 1 },
+            { label: "Two", value: 2 },
+          ]}
+        />
+      );
+    }
+
+    render(<TestForm />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("disables select when no options available", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    function TestForm() {
+      const { control } = useForm({
+        defaultValues: { status: [] },
+      });
+
+      return <ControlledMultiSelectFilter name="status" control={control} options={[]} />;
+    }
+
+    render(<TestForm />);
+    expect(screen.getByRole("combobox")).toHaveAttribute("aria-disabled", "true");
+  });
+});

--- a/frontend/apps/staff/src/components/ScrollToTop.test.tsx
+++ b/frontend/apps/staff/src/components/ScrollToTop.test.tsx
@@ -1,0 +1,163 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ScrollToTop } from "./ScrollToTop";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe("ScrollToTop", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  it("returns null initially when not scrolled", () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(0);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    const { container } = render(<ScrollToTop />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders button when scrolled down", async () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(1000);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+  });
+
+  it("hides button when scrolled back up", async () => {
+    let scrollValue = 1000;
+    vi.spyOn(window, "scrollY", "get").mockImplementation(() => scrollValue);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    scrollValue = 0;
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+  });
+
+  it("scrolls to top when button is clicked", async () => {
+    const user = userEvent.setup({ delay: null });
+    const mockScroll = vi.spyOn(window, "scroll").mockImplementation(() => {});
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(1000);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    const button = screen.getByRole("button");
+    await user.click(button);
+
+    expect(mockScroll).toHaveBeenCalledWith({
+      top: 0,
+      left: 0,
+      behavior: "smooth",
+    });
+
+    mockScroll.mockRestore();
+  });
+
+  it("has correct aria-label", async () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(1000);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /common:scrollToTop/i })).toBeInTheDocument();
+    });
+  });
+
+  it("sets up polling interval on mount", () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(0);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+  });
+
+  it("clears polling interval on unmount", () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(0);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    const { unmount } = render(<ScrollToTop />);
+    const timerCountBefore = vi.getTimerCount();
+
+    unmount();
+    const timerCountAfter = vi.getTimerCount();
+
+    expect(timerCountAfter).toBeLessThan(timerCountBefore);
+  });
+
+  it("calculates visibility based on scroll position and window height", async () => {
+    const mockScrollY = vi.spyOn(window, "scrollY", "get");
+    const mockInnerHeight = vi.spyOn(window, "innerHeight", "get");
+
+    mockScrollY.mockReturnValue(0);
+    mockInnerHeight.mockReturnValue(800);
+
+    const { rerender } = render(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+
+    mockScrollY.mockReturnValue(900);
+    rerender(<ScrollToTop />);
+    vi.advanceTimersByTime(300);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button")).toBeInTheDocument();
+    });
+
+    mockScrollY.mockRestore();
+    mockInnerHeight.mockRestore();
+  });
+
+  it("uses 300ms polling interval", () => {
+    vi.spyOn(window, "scrollY", "get").mockReturnValue(0);
+    vi.spyOn(window, "innerHeight", "get").mockReturnValue(800);
+
+    render(<ScrollToTop />);
+
+    const timerIdBefore = vi.getTimerCount();
+    vi.advanceTimersByTime(299);
+    const timerIdAfter = vi.getTimerCount();
+
+    // Should only have one timer
+    expect(timerIdBefore - timerIdAfter).toBe(0);
+
+    vi.advanceTimersByTime(1);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+  });
+});

--- a/frontend/apps/staff/src/components/SearchTags.test.tsx
+++ b/frontend/apps/staff/src/components/SearchTags.test.tsx
@@ -1,0 +1,156 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SearchTags } from "./SearchTags";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({
+  mockUseSearchParams: vi.fn(),
+}));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({
+  mockUseSetSearchParams: vi.fn(),
+}));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+describe("SearchTags", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders tags from search params", () => {
+    const mockSearchParams = new URLSearchParams("filter=value&status=active");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(<SearchTags translateTag={translateTag} />);
+
+    expect(screen.getByText("filter: value")).toBeInTheDocument();
+    expect(screen.getByText("status: active")).toBeInTheDocument();
+  });
+
+  it("hides specified param keys", () => {
+    const mockSearchParams = new URLSearchParams("filter=value&hidden=secret&status=active");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(<SearchTags translateTag={translateTag} hide={["hidden"]} />);
+
+    expect(screen.getByText("filter: value")).toBeInTheDocument();
+    expect(screen.getByText("status: active")).toBeInTheDocument();
+    expect(screen.queryByText(/hidden/)).not.toBeInTheDocument();
+  });
+
+  it("skips tags with empty translation", () => {
+    const mockSearchParams = new URLSearchParams("filter=value&skip=notranslation");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const translateTag = vi.fn((key, val) => {
+      if (key === "skip") return "";
+      return `${key}: ${val}`;
+    });
+
+    render(<SearchTags translateTag={translateTag} />);
+
+    expect(screen.getByText("filter: value")).toBeInTheDocument();
+    expect(screen.queryByText(/skip/)).not.toBeInTheDocument();
+  });
+
+  it("deletes a tag when clicked", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("filter=value&status=active");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(<SearchTags translateTag={translateTag} />);
+
+    const deleteButtons = screen.getAllByRole("button");
+    // Find the delete button for the first tag
+    const [firstDeleteButton] = deleteButtons;
+    if (firstDeleteButton == null) {
+      throw new Error("Expected at least one delete button to be rendered");
+    }
+    await user.click(firstDeleteButton);
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("shows reset button when tags exist", () => {
+    const mockSearchParams = new URLSearchParams("filter=value");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(<SearchTags translateTag={translateTag} clearButtonLabel="Clear all" />);
+
+    expect(screen.getByText("Clear all")).toBeInTheDocument();
+  });
+
+  it("hides reset button when no tags and no default tags", () => {
+    const mockSearchParams = new URLSearchParams("");
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+
+    const translateTag = vi.fn();
+
+    const { container } = render(<SearchTags translateTag={translateTag} />);
+
+    // Should only render the container, no reset button
+    expect(container.querySelector("button")).not.toBeInTheDocument();
+  });
+
+  it("resets to default tags when reset button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("filter=value&hidden=keep");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(
+      <SearchTags
+        translateTag={translateTag}
+        hide={["hidden"]}
+        defaultTags={[{ key: "filter", value: "default" }]}
+        clearButtonLabel="Reset"
+      />
+    );
+
+    await user.click(screen.getByText("Reset"));
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+
+  it("handles default tags with array values", async () => {
+    const user = userEvent.setup();
+    const mockSearchParams = new URLSearchParams("filter=value");
+    const mockSetParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(mockSearchParams);
+    mockUseSetSearchParams.mockReturnValue(mockSetParams);
+
+    const translateTag = vi.fn((key, val) => `${key}: ${val}`);
+
+    render(
+      <SearchTags
+        translateTag={translateTag}
+        defaultTags={[{ key: "status", value: ["active", "pending"] }]}
+        clearButtonLabel="Reset"
+      />
+    );
+
+    await user.click(screen.getByText("Reset"));
+
+    expect(mockSetParams).toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/staff/src/components/WorkingMemo.test.tsx
+++ b/frontend/apps/staff/src/components/WorkingMemo.test.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ReservationWorkingMemo, ApplicationWorkingMemo } from "./WorkingMemo";
+
+vi.mock("ui/src/components/toast", () => ({
+  successToast: vi.fn(),
+}));
+
+vi.mock("ui/src/hooks", () => ({
+  useDisplayError: () => vi.fn(),
+}));
+
+vi.mock("@gql/gql-types", () => ({
+  useUpdateReservationWorkingMemoMutation: () => [vi.fn()],
+  useUpdateApplicationWorkingMemoMutation: () => [vi.fn()],
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ReservationWorkingMemo", () => {
+  it("renders textarea with initial value", () => {
+    const mockRefetch = vi.fn();
+    render(<ReservationWorkingMemo reservationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    expect(screen.getByDisplayValue("Test memo")).toBeInTheDocument();
+  });
+
+  it("disables buttons when memo is unchanged", () => {
+    const mockRefetch = vi.fn();
+    render(<ReservationWorkingMemo reservationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+
+  it("enables buttons when memo is changed", async () => {
+    const user = userEvent.setup();
+    const mockRefetch = vi.fn();
+    render(<ReservationWorkingMemo reservationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    await user.type(screen.getByDisplayValue("Test memo"), " changed");
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+  });
+
+  it("cancels changes when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockRefetch = vi.fn();
+    render(<ReservationWorkingMemo reservationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    const textarea = screen.getByDisplayValue("Test memo");
+    await user.clear(textarea);
+    await user.type(textarea, "Test memo changed");
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.getByDisplayValue("Test memo")).toBeInTheDocument();
+  });
+});
+
+describe("ApplicationWorkingMemo", () => {
+  it("renders textarea with initial value", () => {
+    const mockRefetch = vi.fn();
+    render(<ApplicationWorkingMemo applicationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    expect(screen.getByDisplayValue("Test memo")).toBeInTheDocument();
+  });
+
+  it("disables buttons when memo is unchanged", () => {
+    const mockRefetch = vi.fn();
+    render(<ApplicationWorkingMemo applicationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    expect(screen.getByRole("button", { name: /save/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+
+  it("enables buttons when memo is changed", async () => {
+    const user = userEvent.setup();
+    const mockRefetch = vi.fn();
+    render(<ApplicationWorkingMemo applicationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    await user.type(screen.getByDisplayValue("Test memo"), " changed");
+    expect(screen.getByRole("button", { name: /save/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeEnabled();
+  });
+
+  it("cancels changes when cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const mockRefetch = vi.fn();
+    render(<ApplicationWorkingMemo applicationPk={1} initialValue="Test memo" refetch={mockRefetch} />);
+    const textarea = screen.getByDisplayValue("Test memo");
+    await user.clear(textarea);
+    await user.type(textarea, "Test memo changed");
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.getByDisplayValue("Test memo")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/components/units/UnitsDataLoader.test.tsx
+++ b/frontend/apps/staff/src/components/units/UnitsDataLoader.test.tsx
@@ -1,0 +1,122 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { UnitListDocument } from "@gql/gql-types";
+import type { UnitTableElementFragment } from "@gql/gql-types";
+import { UnitsDataLoader } from "./UnitsDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+function createUnit(overrides: Partial<UnitTableElementFragment> = {}): UnitTableElementFragment {
+  return {
+    __typename: "UnitNode",
+    id: "unit-1",
+    pk: 1,
+    nameFi: "Unit Name",
+    nameSv: "Enhet",
+    nameEn: "Unit",
+    reservationunitsCount: 5,
+    unitGroup: {
+      __typename: "UnitGroupNode",
+      id: "ug-1",
+      nameFi: "Group Name",
+    },
+    ...overrides,
+  } as UnitTableElementFragment;
+}
+
+function listMock(units: UnitTableElementFragment[], totalCount: number, hasNextPage = false): MockedResponse {
+  return {
+    request: { query: UnitListDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        units: {
+          __typename: "UnitNodeConnection",
+          edges: units.map((node) => ({ __typename: "UnitNodeEdge", node })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: UnitListDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <UnitsDataLoader />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+});
+
+describe("UnitsDataLoader", () => {
+  it("shows the loading spinner until the query resolves", () => {
+    renderLoader([listMock([createUnit()], 1)]);
+    expect(screen.queryByTestId("hds-table-sorting-header-nameFi")).not.toBeInTheDocument();
+  });
+
+  it("renders the units table once the query resolves", async () => {
+    renderLoader([listMock([createUnit()], 1)]);
+    expect(await screen.findByTestId("hds-table-sorting-header-nameFi")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no units", async () => {
+    renderLoader([listMock([], 0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+
+  it("shows the More button when there are more results, and fetches the next page on click", async () => {
+    const user = userEvent.setup();
+    renderLoader([
+      listMock([createUnit()], 2, true),
+      listMock([createUnit(), createUnit({ pk: 2, id: "unit-2", nameFi: "Unit Two" })], 2),
+    ]);
+
+    expect(await screen.findByRole("button", { name: "common:showMore" })).toBeInTheDocument();
+    const moreButton = screen.getByRole("button", { name: "common:showMore" });
+
+    await user.click(moreButton);
+
+    await waitFor(() => expect(moreButton).not.toBeDisabled());
+  });
+
+  it("shows the all-results message when every unit has been loaded", async () => {
+    renderLoader([listMock([createUnit()], 1, false)]);
+    expect(await screen.findByText("translation:paging.allResults")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/AllocatedSectionDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/AllocatedSectionDataLoader.test.tsx
@@ -1,0 +1,89 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AllocatedTimeSlotsDocument } from "@gql/gql-types";
+import type { AllocatedSectionsTableElementFragment } from "@gql/gql-types";
+import { TimeSlotDataLoader } from "./AllocatedSectionDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), asPath: "/" }),
+}));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+vi.mock("@ui/modules/apollo/helpers", () => ({
+  getPermissionErrors: () => [],
+}));
+
+function listMock(totalCount: number = 0, hasNextPage = false): MockedResponse {
+  const allocatedTimeSlots: AllocatedSectionsTableElementFragment[] = Array.from({ length: totalCount }, (_, i) => ({
+    __typename: "AllocatedTimeSlotNode",
+    pk: i + 1,
+  })) as unknown as AllocatedSectionsTableElementFragment[];
+
+  return {
+    request: { query: AllocatedTimeSlotsDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        allocatedTimeSlots: {
+          __typename: "AllocatedTimeSlotNodeConnection",
+          edges: allocatedTimeSlots.map((node) => ({
+            __typename: "AllocatedTimeSlotNodeEdge",
+            node,
+          })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: AllocatedTimeSlotsDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <TimeSlotDataLoader applicationRoundPk={1} unitOptions={[]} />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+});
+
+describe("TimeSlotDataLoader", () => {
+  it("shows the empty state when there are no allocated time slots", async () => {
+    renderLoader([listMock(0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/AllocatedSectionsTable.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/AllocatedSectionsTable.test.tsx
@@ -1,0 +1,153 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AllocatedSectionsTableElementFragment } from "@gql/gql-types";
+import { AllocatedSectionsTable } from "./AllocatedSectionsTable";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("ui/src/modules/conversion", () => ({
+  convertWeekday: (day: number) => {
+    const days: Record<number, string> = { 0: "Mon", 1: "Tue", 2: "Wed", 3: "Thu", 4: "Fri", 5: "Sat", 6: "Sun" };
+    return days[day] ?? "Mon";
+  },
+}));
+
+vi.mock("ui/src/modules/date-utils", () => ({
+  timeToMinutes: (time: string) => {
+    const parts = time.split(":").map(Number);
+    const h = parts[0] ?? 0;
+    const m = parts[1] ?? 0;
+    return h * 60 + m;
+  },
+  formatTimeRange: (start: number, end: number) => `${start}-${end}`,
+}));
+
+function createAllocatedSection(
+  overrides: Partial<AllocatedSectionsTableElementFragment> = {}
+): AllocatedSectionsTableElementFragment {
+  return {
+    id: "slot-1",
+    pk: 1,
+    dayOfTheWeek: 1,
+    beginTime: "09:00",
+    endTime: "12:00",
+    reservationSeries: {
+      id: "series-1",
+      pk: 100,
+      shouldHaveActiveAccessCode: false,
+      isAccessCodeIsActiveCorrect: true,
+      reservations: [
+        {
+          id: "res-1",
+          pk: 1000,
+        },
+      ],
+    },
+    reservationUnitOption: {
+      id: "opt-1",
+      isRejected: false,
+      isLocked: false,
+      preferredOrder: 1,
+      applicationSection: {
+        id: "section-1",
+        pk: 10,
+        name: "Test Section",
+        reservationsBeginDate: "2024-01-01",
+        reservationsEndDate: "2024-12-31",
+        reservationMinDuration: 3600,
+        reservationMaxDuration: 28_800,
+        application: {
+          pk: 1,
+          id: "app-1",
+        },
+      },
+      reservationUnit: {
+        id: "ru-1",
+        nameFi: "Reservation Unit",
+        unit: {
+          id: "unit-1",
+          nameFi: "Unit 1",
+        },
+      },
+    },
+    ...overrides,
+  } as AllocatedSectionsTableElementFragment;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("AllocatedSectionsTable", () => {
+  it("renders table rows with all columns", () => {
+    const mockSortChanged = vi.fn();
+    render(<AllocatedSectionsTable sort={null} sortChanged={mockSortChanged} schedules={[createAllocatedSection()]} />);
+
+    expect(screen.getByText("1-10")).toBeInTheDocument();
+    expect(screen.getByText("Test Section")).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+    expect(screen.getByText("Reservation Unit")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no schedules", () => {
+    const mockSortChanged = vi.fn();
+    render(<AllocatedSectionsTable sort={null} sortChanged={mockSortChanged} schedules={[]} />);
+
+    expect(screen.getByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("renders applicant link with correct href", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <AllocatedSectionsTable sort={null} sortChanged={mockSortChanged} schedules={[createAllocatedSection()]} />
+    );
+
+    const link = container.querySelector("a[href*='/applications/1']");
+    expect(link).toBeTruthy();
+  });
+
+  it("handles access code alert tooltip when access code is pending", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <AllocatedSectionsTable
+        sort={null}
+        sortChanged={mockSortChanged}
+        schedules={[
+          createAllocatedSection({
+            reservationSeries: {
+              id: "series-1",
+              pk: 100,
+              shouldHaveActiveAccessCode: true,
+              isAccessCodeIsActiveCorrect: false,
+              reservations: [{ id: "res-1", pk: 1000 }],
+            },
+          }),
+        ]}
+      />
+    );
+
+    // Tooltip is rendered when access code is pending
+    expect(container.querySelector("table")).toBeTruthy();
+  });
+
+  it("handles multiple allocated sections", () => {
+    const mockSortChanged = vi.fn();
+    const schedules = [
+      createAllocatedSection({ pk: 1 }),
+      createAllocatedSection({ pk: 2 }),
+      createAllocatedSection({ pk: 3 }),
+    ];
+    const { container } = render(
+      <AllocatedSectionsTable sort={null} sortChanged={mockSortChanged} schedules={schedules} />
+    );
+
+    const rows = container.querySelectorAll("tbody tr");
+    expect(rows.length).toBe(3);
+    expect(screen.getAllByText("1-10").length).toBe(3);
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationDataLoader.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApplicationsDocument } from "@gql/gql-types";
+import type { ApplicationsTableElementFragment } from "@gql/gql-types";
+import { ApplicationDataLoader } from "./ApplicationDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), asPath: "/" }),
+}));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+function listMock(totalCount: number = 0, hasNextPage = false): MockedResponse {
+  const applications: ApplicationsTableElementFragment[] = Array.from({ length: totalCount }, (_, i) => ({
+    __typename: "ApplicationNode",
+    pk: 100 + i,
+  })) as unknown as ApplicationsTableElementFragment[];
+
+  return {
+    request: { query: ApplicationsDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        applications: {
+          __typename: "ApplicationNodeConnection",
+          edges: applications.map((node) => ({
+            __typename: "ApplicationNodeEdge",
+            node,
+          })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: ApplicationsDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ApplicationDataLoader applicationRoundPk={1} />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+});
+
+describe("ApplicationDataLoader", () => {
+  it("shows the empty state when there are no applications", async () => {
+    renderLoader([listMock(0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationSectionDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationSectionDataLoader.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApplicationSectionsDocument } from "@gql/gql-types";
+import type { ApplicationSectionTableElementFragment } from "@gql/gql-types";
+import { ApplicationSectionDataLoader } from "./ApplicationSectionDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), asPath: "/" }),
+}));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+function listMock(totalCount: number = 0, hasNextPage = false): MockedResponse {
+  const applicationSections: ApplicationSectionTableElementFragment[] = Array.from({ length: totalCount }, (_, i) => ({
+    __typename: "ApplicationSectionNode",
+    pk: i + 1,
+  })) as unknown as ApplicationSectionTableElementFragment[];
+
+  return {
+    request: { query: ApplicationSectionsDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        applicationSections: {
+          __typename: "ApplicationSectionNodeConnection",
+          edges: applicationSections.map((node) => ({
+            __typename: "ApplicationSectionNodeEdge",
+            node,
+          })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: ApplicationSectionsDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ApplicationSectionDataLoader applicationRoundPk={1} />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+});
+
+describe("ApplicationSectionDataLoader", () => {
+  it("shows the empty state when there are no application sections", async () => {
+    renderLoader([listMock(0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationSectionsTable.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationSectionsTable.test.tsx
@@ -1,0 +1,107 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationSectionTableElementFragment } from "@gql/gql-types";
+import { ApplicationSectionsTable } from "./ApplicationSectionsTable";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  ApplicationSectionStatusLabel: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+function createApplicationSection(
+  overrides: Partial<ApplicationSectionTableElementFragment> = {}
+): ApplicationSectionTableElementFragment {
+  return {
+    id: "section-1",
+    pk: 10,
+    name: "Section 1",
+    status: "APPROVED",
+    allocations: 0,
+    reservationsBeginDate: "2024-01-01",
+    reservationsEndDate: "2024-12-31",
+    reservationMinDuration: 3600,
+    reservationMaxDuration: 28_800,
+    appliedReservationsPerWeek: 2,
+    application: {
+      pk: 1,
+      id: "app-1",
+    },
+    reservationUnitOptions: [
+      {
+        id: "opt-1",
+        preferredOrder: 1,
+        reservationUnit: {
+          id: "ru-1",
+          unit: {
+            id: "unit-1",
+            pk: 100,
+            nameFi: "Unit 1",
+          },
+        },
+      },
+    ],
+    ...overrides,
+  } as ApplicationSectionTableElementFragment;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ApplicationSectionsTable", () => {
+  it("renders table rows with all columns", () => {
+    const mockSortChanged = vi.fn();
+    render(
+      <ApplicationSectionsTable
+        sort={null}
+        sortChanged={mockSortChanged}
+        applicationSections={[createApplicationSection()]}
+      />
+    );
+
+    expect(screen.getByText("1-10")).toBeInTheDocument();
+    expect(screen.getByText("Section 1")).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no application sections", () => {
+    const mockSortChanged = vi.fn();
+    render(<ApplicationSectionsTable sort={null} sortChanged={mockSortChanged} applicationSections={[]} />);
+
+    expect(screen.getByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("renders applicant link with correct href", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ApplicationSectionsTable
+        sort={null}
+        sortChanged={mockSortChanged}
+        applicationSections={[createApplicationSection()]}
+      />
+    );
+
+    const link = container.querySelector("a[href*='/applications/1']");
+    expect(link).toBeTruthy();
+  });
+
+  it("handles multiple sections", () => {
+    const mockSortChanged = vi.fn();
+    const sections = [
+      createApplicationSection({ pk: 10 }),
+      createApplicationSection({ pk: 11 }),
+      createApplicationSection({ pk: 12 }),
+    ];
+    render(<ApplicationSectionsTable sort={null} sortChanged={mockSortChanged} applicationSections={sections} />);
+
+    expect(screen.getByText("1-10")).toBeInTheDocument();
+    expect(screen.getByText("1-11")).toBeInTheDocument();
+    expect(screen.getByText("1-12")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationsTable.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/ApplicationsTable.test.tsx
@@ -1,0 +1,96 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApplicationsTableElementFragment } from "@gql/gql-types";
+import { ApplicationsTable } from "./ApplicationsTable";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  ApplicationStatusLabel: ({ status }: { status: string }) => <span>{status}</span>,
+}));
+
+function createApplication(
+  overrides: Partial<ApplicationsTableElementFragment> = {}
+): ApplicationsTableElementFragment {
+  return {
+    id: "app-1",
+    pk: 1,
+    status: "IN_HANDLING",
+    organisationIdentifier: "",
+    applicantType: "INDIVIDUAL",
+    applicationSections: [
+      {
+        id: "section-1",
+        pk: 10,
+        name: "Section 1",
+        reservationsBeginDate: "2024-01-01",
+        reservationsEndDate: "2024-12-31",
+        appliedReservationsPerWeek: 2,
+        reservationMinDuration: 3600,
+        reservationUnitOptions: [
+          {
+            id: "opt-1",
+            preferredOrder: 1,
+            reservationUnit: {
+              id: "ru-1",
+              unit: {
+                id: "unit-1",
+                pk: 100,
+                nameFi: "Unit 1",
+              },
+            },
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  } as ApplicationsTableElementFragment;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ApplicationsTable", () => {
+  it("renders table with application data", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ApplicationsTable sort={null} sortChanged={mockSortChanged} applications={[createApplication()]} />
+    );
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(container.querySelector("a[href*='/applications/1']")).toBeTruthy();
+  });
+
+  it("shows empty state when no applications", () => {
+    const mockSortChanged = vi.fn();
+    render(<ApplicationsTable sort={null} sortChanged={mockSortChanged} applications={[]} />);
+
+    expect(screen.getByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("renders application link with correct href", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ApplicationsTable sort={null} sortChanged={mockSortChanged} applications={[createApplication()]} />
+    );
+
+    const link = container.querySelector("a[href*='/applications/1']");
+    expect(link).toBeTruthy();
+  });
+
+  it("handles multiple applications", () => {
+    const mockSortChanged = vi.fn();
+    const applications = [createApplication({ pk: 1 }), createApplication({ pk: 2 }), createApplication({ pk: 3 })];
+    render(<ApplicationsTable sort={null} sortChanged={mockSortChanged} applications={applications} />);
+
+    expect(screen.getByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/Filters.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/Filters.test.tsx
@@ -1,0 +1,97 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TagOptionsList } from "@/modules/search";
+import { Filters } from "./Filters";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({ mockUseSearchParams: vi.fn() }));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({ mockUseSetSearchParams: vi.fn() }));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const OPTIONS: TagOptionsList = {
+  units: [{ label: "Unit 1", value: 1 }],
+  equipments: [],
+  intendedUses: [],
+  reservationPurposes: [],
+  reservationUnitTypes: [],
+  ageGroups: [],
+  municipalities: [],
+  stateChoices: [],
+  reservationUnits: [{ label: "Reservation unit 1", value: 1 }],
+  unitGroups: [{ label: "Group 1", value: 1 }],
+  reservationUnitStates: [],
+  priorityChoices: [],
+  orderChoices: [],
+  orderStatus: [],
+  reservationTypeChoices: [],
+  recurringChoices: [],
+  reserveeTypes: [],
+};
+
+describe("application-rounds/[id] Filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+  });
+
+  it("renders the application status filter by default", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters options={OPTIONS} />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+    expect(screen.getByTestId("searchButton")).toBeInTheDocument();
+  });
+
+  it("renders the section status filter instead of application status when statusOption is 'section'", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters options={OPTIONS} statusOption="section" />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+  });
+
+  it("only renders the applicant, weekday, reservationUnit and accessCodeState filters when their enable flags are set", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    const { rerender } = render(<Filters options={OPTIONS} />);
+    // AutoGrid children count without the optional filters
+    const baseCount = screen.getAllByRole("combobox").length + screen.getAllByRole("textbox").length;
+
+    rerender(<Filters options={OPTIONS} enableApplicant enableWeekday enableReservationUnit enableAccessCodeState />);
+    const expandedCount = screen.getAllByRole("combobox").length + screen.getAllByRole("textbox").length;
+
+    expect(expandedCount).toBeGreaterThan(baseCount);
+  });
+
+  it("submits the search text as a search param", async () => {
+    const user = userEvent.setup();
+    const setSearchParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+    mockUseSetSearchParams.mockReturnValue(setSearchParams);
+
+    render(<Filters options={OPTIONS} />);
+
+    await user.type(screen.getByLabelText("filters:label.search"), "hall");
+    await user.click(screen.getByTestId("searchButton"));
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1);
+    const params = setSearchParams.mock.calls[0]?.[0] as URLSearchParams;
+    expect(params.get("search")).toBe("hall");
+  });
+
+  it("maps the weekday search param through convertWeekday", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("weekday=0&weekday=3"));
+
+    render(<Filters options={OPTIONS} enableWeekday />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/RejectedOccurrencesDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/RejectedOccurrencesDataLoader.test.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RejectedOccurrencesDocument } from "@gql/gql-types";
+import type { RejectedOccurrencesTableElementFragment } from "@gql/gql-types";
+import { RejectedOccurrencesDataLoader } from "./RejectedOccurrencesDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn(), asPath: "/" }),
+}));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+vi.mock("@ui/modules/apollo/helpers", () => ({
+  getPermissionErrors: () => [],
+}));
+
+function createRejectedOccurrence(
+  overrides: Partial<RejectedOccurrencesTableElementFragment> = {}
+): RejectedOccurrencesTableElementFragment {
+  return {
+    __typename: "RejectedOccurrenceNode",
+    pk: 1,
+    applicationId: 100,
+    applicationSectionId: 10,
+    applicant: "Applicant Name",
+    applicationSectionNameFi: "Section Name",
+    unitNameFi: "Unit Name",
+    reservationUnitNameFi: "Reservation Unit Name",
+    beginDatetime: "2024-06-15T09:00:00Z",
+    rejectionReason: "RESERVATION_UNIT_NOT_AVAILABLE",
+    ...overrides,
+  } as RejectedOccurrencesTableElementFragment;
+}
+
+function listMock(
+  rejectedOccurrences: RejectedOccurrencesTableElementFragment[],
+  totalCount: number,
+  hasNextPage = false
+): MockedResponse {
+  return {
+    request: { query: RejectedOccurrencesDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        rejectedOccurrences: {
+          __typename: "RejectedOccurrenceNodeConnection",
+          edges: rejectedOccurrences.map((node) => ({
+            __typename: "RejectedOccurrenceNodeEdge",
+            node,
+          })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: RejectedOccurrencesDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <RejectedOccurrencesDataLoader applicationRoundPk={1} unitOptions={[]} />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+});
+
+describe("RejectedOccurrencesDataLoader", () => {
+  it("shows the loading spinner until the query resolves", () => {
+    renderLoader([listMock([createRejectedOccurrence()], 1)]);
+    expect(screen.queryByTestId("hds-table-sorting-header-applicant")).not.toBeInTheDocument();
+  });
+
+  it("renders the rejected occurrences table once the query resolves", async () => {
+    renderLoader([listMock([createRejectedOccurrence()], 1)]);
+    expect(await screen.findByTestId("hds-table-sorting-header-applicant")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no rejected occurrences", async () => {
+    renderLoader([listMock([], 0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+
+  it("shows the More button when there are more results, and fetches the next page on click", async () => {
+    const user = userEvent.setup();
+    renderLoader([
+      listMock([createRejectedOccurrence()], 2, true),
+      listMock([createRejectedOccurrence(), createRejectedOccurrence({ pk: 2 })], 2),
+    ]);
+
+    expect(await screen.findByRole("button", { name: "common:showMore" })).toBeInTheDocument();
+    const moreButton = screen.getByRole("button", { name: "common:showMore" });
+
+    await user.click(moreButton);
+
+    await waitFor(() => expect(moreButton).not.toBeDisabled());
+  });
+
+  it("shows the all-results message when every rejected occurrence has been loaded", async () => {
+    renderLoader([listMock([createRejectedOccurrence()], 1, false)]);
+    expect(await screen.findByText("translation:paging.allResults")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/Filters.test.tsx
+++ b/frontend/apps/staff/src/lib/application-rounds/[id]/allocation/Filters.test.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ApplicationRoundFilterUnitFragment } from "@gql/gql-types";
+import { Filters } from "./Filters";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({ mockUseSearchParams: vi.fn() }));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({ mockUseSetSearchParams: vi.fn() }));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+const { mockUseFilterOptions } = vi.hoisted(() => ({ mockUseFilterOptions: vi.fn() }));
+vi.mock("@/hooks/useFilterOptions", () => ({ useFilterOptions: mockUseFilterOptions }));
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const UNITS: ApplicationRoundFilterUnitFragment[] = [
+  { id: "1", pk: 1, nameFi: "Unit 1" },
+  { id: "2", pk: 2, nameFi: "Unit 2" },
+];
+
+describe("application-rounds/[id]/allocation Filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+    mockUseFilterOptions.mockReturnValue({
+      reservationUnitTypes: [],
+      units: [{ label: "Other unit", value: 99 }],
+      reservationUnits: [],
+      stateChoices: [],
+      orderStatus: [],
+      reservationTypeChoices: [],
+      recurringChoices: [],
+      reservationUnitStates: [],
+      unitGroups: [],
+      municipalities: [],
+      reserveeTypes: [],
+      orderChoices: [],
+      priorityChoices: [],
+      intendedUses: [],
+      reservationPurposes: [],
+      ageGroups: [],
+      equipments: [],
+    });
+  });
+
+  it("renders and defaults the unit form field to the first passed-in unit", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters hideSearchTags={[]} units={UNITS} />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+    expect(screen.getByTestId("searchButton")).toBeInTheDocument();
+  });
+
+  it("shows a loading spinner on the search button when isLoading is true", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters hideSearchTags={[]} units={UNITS} isLoading />);
+
+    expect(screen.getByTestId("searchButton")).toBeDisabled();
+  });
+
+  it("overrides the queried unit options with the units passed in as props", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters hideSearchTags={[]} units={UNITS} />);
+
+    // useFilterOptions() returns "Other unit" (pk 99), but the component always
+    // overrides `options.units` with the `units` prop it was given.
+    expect(screen.queryByText("Other unit")).not.toBeInTheDocument();
+  });
+
+  it("submits the search text and the selected unit as search params", async () => {
+    const user = userEvent.setup();
+    const setSearchParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+    mockUseSetSearchParams.mockReturnValue(setSearchParams);
+
+    render(<Filters hideSearchTags={[]} units={UNITS} />);
+
+    await user.type(screen.getByLabelText("filters:label.search"), "gym");
+    await user.click(screen.getByTestId("searchButton"));
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1);
+    const params = setSearchParams.mock.calls[0]?.[0] as URLSearchParams;
+    expect(params.get("search")).toBe("gym");
+    expect(params.get("unit")).toBe("1");
+  });
+
+  it("falls back to unit pk 0 when there are no units to select from", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters hideSearchTags={[]} units={[]} />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+  });
+
+  it("re-reads the unit from search params when a unit filter is already set", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("unit=2"));
+
+    render(<Filters hideSearchTags={[]} units={UNITS} />);
+
+    expect(screen.getByLabelText("filters:label.search")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/Filters.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/Filters.test.tsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { TagOptionsList } from "@/modules/search";
+import { Filters } from "./Filters";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({ mockUseSearchParams: vi.fn() }));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({ mockUseSetSearchParams: vi.fn() }));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+const EMPTY_OPTIONS: TagOptionsList = {
+  units: [],
+  equipments: [],
+  intendedUses: [],
+  reservationPurposes: [],
+  reservationUnitTypes: [{ label: "Type A", value: 1 }],
+  ageGroups: [],
+  municipalities: [],
+  stateChoices: [],
+  reservationUnits: [],
+  unitGroups: [{ label: "Group A", value: 1 }],
+  reservationUnitStates: [],
+  priorityChoices: [],
+  orderChoices: [],
+  orderStatus: [],
+  reservationTypeChoices: [],
+  recurringChoices: [],
+  reserveeTypes: [],
+};
+
+describe("reservation-units Filters", () => {
+  const onChangedCriteria = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+  });
+
+  it("renders the filter fields and calls onChangedCriteria on mount", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters options={EMPTY_OPTIONS} onChangedCriteria={onChangedCriteria} />);
+
+    expect(screen.getByLabelText("filters:label.reservationUnit")).toBeInTheDocument();
+    expect(onChangedCriteria).toHaveBeenCalled();
+  });
+
+  it("populates the search field from the search param", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("search=pool"));
+
+    render(<Filters options={EMPTY_OPTIONS} onChangedCriteria={onChangedCriteria} />);
+
+    expect(screen.getByLabelText("filters:label.reservationUnit")).toHaveValue("pool");
+  });
+
+  it("submits the search text as a search param", async () => {
+    const user = userEvent.setup();
+    const setSearchParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+    mockUseSetSearchParams.mockReturnValue(setSearchParams);
+
+    render(<Filters options={EMPTY_OPTIONS} onChangedCriteria={onChangedCriteria} />);
+
+    await user.type(screen.getByLabelText("filters:label.reservationUnit"), "sauna");
+    await user.click(screen.getByTestId("searchButton"));
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1);
+    const params = setSearchParams.mock.calls[0]?.[0] as URLSearchParams;
+    expect(params.get("search")).toBe("sauna");
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/ReservationUnitsDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/ReservationUnitsDataLoader.test.tsx
@@ -1,0 +1,168 @@
+import React, { useState } from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SearchReservationUnitsDocument } from "@gql/gql-types";
+import type { ReservationUnitTableElementFragment } from "@gql/gql-types";
+import { ReservationUnitsDataReader } from "./ReservationUnitsDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/context/EnvContext", () => ({
+  useEnvContext: () => ({
+    env: {
+      apiBaseUrl: "http://api.example.com",
+    },
+  }),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  ReservationUnitPublishingStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+  ReservationUnitReservationStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+}));
+
+const { mockedSearchParams, useSearchParams } = vi.hoisted(() => {
+  const params = vi.fn();
+  return { useSearchParams: params, mockedSearchParams: params };
+});
+vi.mock("next/navigation", () => ({ useSearchParams }));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+function createReservationUnit(
+  overrides: Partial<ReservationUnitTableElementFragment> = {}
+): ReservationUnitTableElementFragment {
+  return {
+    __typename: "ReservationUnitNode",
+    id: "ru-1",
+    pk: 1,
+    nameFi: "Reservation Unit 1",
+    publishingState: "PUBLISHED",
+    reservationState: "RESERVABLE",
+    maxPersons: 10,
+    surfaceArea: 25.5,
+    unit: {
+      __typename: "UnitNode",
+      id: "unit-1",
+      nameFi: "Unit 1",
+    },
+    reservationUnitType: {
+      __typename: "ReservationUnitTypeNode",
+      id: "type-1",
+      nameFi: "Meeting Room",
+    },
+    ...overrides,
+  } as ReservationUnitTableElementFragment;
+}
+
+function listMock(
+  reservationUnits: ReservationUnitTableElementFragment[],
+  totalCount: number,
+  hasNextPage = false
+): MockedResponse {
+  return {
+    request: { query: SearchReservationUnitsDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        reservationUnits: {
+          __typename: "ReservationUnitNodeConnection",
+          edges: reservationUnits.map((node) => ({ __typename: "ReservationUnitNodeEdge", node })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: SearchReservationUnitsDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function Wrapper() {
+  const [selectedRows, setSelectedRows] = useState<Array<number | string>>([]);
+  return <ReservationUnitsDataReader selectedRows={selectedRows} setSelectedRows={setSelectedRows} />;
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <Wrapper />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockedSearchParams.mockReturnValue(new URLSearchParams());
+  mockErrorToast.mockReset();
+});
+
+describe("ReservationUnitsDataReader", () => {
+  it("shows nothing from the table until the query resolves", () => {
+    renderLoader([listMock([createReservationUnit()], 1)]);
+    expect(screen.queryByText("Reservation Unit 1")).not.toBeInTheDocument();
+  });
+
+  it("renders the reservation units table once the query resolves", async () => {
+    renderLoader([listMock([createReservationUnit()], 1)]);
+    expect(await screen.findByText("Reservation Unit 1")).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no reservation units", async () => {
+    renderLoader([listMock([], 0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+
+  it("shows the More button when there are more results, and fetches the next page on click", async () => {
+    const user = userEvent.setup();
+    renderLoader([listMock([createReservationUnit()], 2, true), listMock([createReservationUnit()], 2)]);
+
+    expect(await screen.findByText("Reservation Unit 1")).toBeInTheDocument();
+    const moreButton = screen.getByRole("button", { name: "common:showMore" });
+
+    await user.click(moreButton);
+
+    await waitFor(() => expect(moreButton).not.toBeDisabled());
+  });
+
+  it("shows the all-results message when every reservation unit has been loaded", async () => {
+    renderLoader([listMock([createReservationUnit()], 1, false)]);
+    expect(await screen.findByText("translation:paging.allResults")).toBeInTheDocument();
+  });
+
+  it("toggles the sort field for every sortable column when its header is clicked", async () => {
+    const user = userEvent.setup();
+    const sortKeys = ["nameFi", "unitNameFi", "typeFi", "maxPersons", "surfaceArea"];
+    renderLoader(Array.from({ length: sortKeys.length + 1 }, () => listMock([createReservationUnit()], 1)));
+
+    expect(await screen.findByText("Reservation Unit 1")).toBeInTheDocument();
+
+    for (const key of sortKeys) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(screen.getByTestId(`hds-table-sorting-header-${key}`));
+    }
+
+    expect(screen.getByText("Reservation Unit 1")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/ReservationUnitsTable.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/ReservationUnitsTable.test.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReservationUnitTableElementFragment } from "@gql/gql-types";
+import { ReservationUnitsTable } from "./ReservationUnitsTable";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("@/context/EnvContext", () => ({
+  useEnvContext: () => ({
+    env: {
+      apiBaseUrl: "http://api.example.com",
+    },
+  }),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  ReservationUnitPublishingStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+  ReservationUnitReservationStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+}));
+
+function createReservationUnit(
+  overrides: Partial<ReservationUnitTableElementFragment> = {}
+): ReservationUnitTableElementFragment {
+  return {
+    id: "ru-1",
+    pk: 1,
+    nameFi: "Reservation Unit 1",
+    publishingState: "PUBLISHED",
+    reservationState: "RESERVABLE",
+    maxPersons: 10,
+    surfaceArea: 25.5,
+    unit: {
+      id: "unit-1",
+      nameFi: "Unit 1",
+    },
+    reservationUnitType: {
+      id: "type-1",
+      nameFi: "Meeting Room",
+    },
+    ...overrides,
+  } as ReservationUnitTableElementFragment;
+}
+
+function ReservationUnitsTableWrapper({
+  reservationUnits,
+}: {
+  reservationUnits: ReservationUnitTableElementFragment[];
+}) {
+  const [selectedRows, setSelectedRows] = useState<Array<number | string>>([]);
+  const mockSortChanged = vi.fn();
+
+  return (
+    <ReservationUnitsTable
+      sort=""
+      sortChanged={mockSortChanged}
+      reservationUnits={reservationUnits}
+      selectedRows={selectedRows}
+      setSelectedRows={setSelectedRows}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ReservationUnitsTable", () => {
+  it("renders table rows with all columns", () => {
+    render(<ReservationUnitsTableWrapper reservationUnits={[createReservationUnit()]} />);
+
+    expect(screen.getByRole("link", { name: "Reservation Unit 1" })).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+    expect(screen.getByText("Meeting Room")).toBeInTheDocument();
+    expect(screen.getByText("10")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no reservation units", () => {
+    render(<ReservationUnitsTableWrapper reservationUnits={[]} />);
+
+    expect(screen.getByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("renders reservation unit name link with correct href", () => {
+    render(<ReservationUnitsTableWrapper reservationUnits={[createReservationUnit()]} />);
+
+    const link = screen.getByRole("link", { name: "Reservation Unit 1" });
+    expect(link).toHaveAttribute("href", expect.stringContaining("/1"));
+  });
+
+  it("displays surface area with locale formatting", () => {
+    render(<ReservationUnitsTableWrapper reservationUnits={[createReservationUnit()]} />);
+
+    const cells = screen.getAllByRole("cell");
+    const surfaceAreaCell = cells.find((c) => c.textContent?.includes("25") || c.textContent?.includes("m²"));
+    expect(surfaceAreaCell).toBeTruthy();
+  });
+
+  it("handles missing optional fields", () => {
+    render(
+      <ReservationUnitsTableWrapper
+        reservationUnits={[
+          createReservationUnit({
+            maxPersons: null,
+            surfaceArea: null,
+            reservationUnitType: null,
+          }),
+        ]}
+      />
+    );
+
+    const cells = screen.getAllByText("-");
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it("handles multiple reservation units with different states", () => {
+    const units = [
+      createReservationUnit({ pk: 1 }),
+      createReservationUnit({ pk: 2 }),
+      createReservationUnit({ pk: 3 }),
+    ];
+    render(<ReservationUnitsTableWrapper reservationUnits={units} />);
+
+    expect(screen.getAllByRole("link", { name: /Reservation Unit/ })).toHaveLength(3);
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/AccessTypeSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/AccessTypeSection.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import type { ReservationUnitEditQuery } from "@gql/gql-types";
+import { AccessType } from "@gql/gql-types";
+import { AccessTypeSection } from "./AccessTypeSection";
+import { convertReservationUnit } from "./form";
+import type { ReservationUnitEditFormValues } from "./form";
+
+type AccessTypes = NonNullable<ReservationUnitEditQuery["reservationUnit"]>["accessTypes"];
+
+function Harness({ accessTypes }: { accessTypes: AccessTypes }) {
+  const form = useForm<ReservationUnitEditFormValues>({
+    defaultValues: convertReservationUnit(undefined),
+  });
+  return <AccessTypeSection form={form} accessTypes={accessTypes} />;
+}
+
+async function openAccordion() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /accessType:accessTypeLabel/ }));
+  return user;
+}
+
+describe("AccessTypeSection", () => {
+  it("shows an inactive placeholder when there is no currently active access type", async () => {
+    render(<Harness accessTypes={[]} />);
+    await openAccordion();
+
+    expect(screen.getByText("accessType:status.inactive")).toBeInTheDocument();
+    expect(screen.getAllByText("-")).toHaveLength(2);
+  });
+
+  it("shows the currently active access type and its start date", async () => {
+    render(
+      <Harness accessTypes={[{ id: "at-1", pk: 1, accessType: AccessType.PhysicalKey, beginDate: "2020-01-15" }]} />
+    );
+    await openAccordion();
+
+    expect(screen.getByText("accessType:type.PHYSICAL_KEY")).toBeInTheDocument();
+    expect(screen.getByText("15.1.2020")).toBeInTheDocument();
+    expect(screen.getByText("accessType:status.active")).toBeInTheDocument();
+  });
+
+  it("adds a new access type, excluding ACCESS_CODE for a new (pk 0) reservation unit", async () => {
+    render(<Harness accessTypes={[]} />);
+    const user = await openAccordion();
+
+    await user.click(screen.getByRole("button", { name: "accessType:actions.addNewAccessType" }));
+
+    const combobox = screen.getByRole("combobox", { name: /accessType:accessTypeLabel/ });
+    await user.click(combobox);
+    const listbox = await screen.findByRole("listbox");
+    const options = within(listbox).getAllByRole("option");
+    expect(options.map((o) => o.textContent)).toEqual([
+      "accessType:type.OPENED_BY_STAFF",
+      "accessType:type.PHYSICAL_KEY",
+      "accessType:type.UNRESTRICTED",
+    ]);
+  });
+
+  it("removes a newly-added access type via its remove button", async () => {
+    render(<Harness accessTypes={[]} />);
+    const user = await openAccordion();
+
+    await user.click(screen.getByRole("button", { name: "accessType:actions.addNewAccessType" }));
+    expect(screen.getByRole("combobox", { name: /accessType:accessTypeLabel/ })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "common:remove" }));
+
+    expect(screen.queryByRole("combobox", { name: /accessType:accessTypeLabel/ })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/BasicSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/BasicSection.test.tsx
@@ -1,0 +1,121 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { ReservationUnitEditUnitFragment } from "@gql/gql-types";
+import { ResourceLocationType } from "@gql/gql-types";
+import { BasicSection } from "./BasicSection";
+import { convertReservationUnit } from "./form";
+import type { ReservationUnitEditFormValues } from "./form";
+
+type Spaces = ReservationUnitEditUnitFragment["spaces"];
+
+const SPACE_WITH_RESOURCES: Spaces[number] = {
+  id: "space-1",
+  pk: 1,
+  nameFi: "Space 1",
+  maxPersons: 15,
+  surfaceArea: 30,
+  resources: [{ id: "resource-1", pk: 1, nameFi: "Resource 1", locationType: ResourceLocationType.Fixed }],
+};
+
+const SPACE_WITHOUT_RESOURCES: Spaces[number] = {
+  id: "space-2",
+  pk: 2,
+  nameFi: "Space 2",
+  maxPersons: 5,
+  surfaceArea: 10,
+  resources: [],
+};
+
+// HDS appends a trailing " *" to the accessible name of required fields.
+function nameLike(base: string): RegExp {
+  const escaped = base.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}(\\s\\*)?$`);
+}
+
+// HDS multiselect buttons compose their accessible name from label + placeholder + selection count.
+function selectButtonNameLike(base: string): RegExp {
+  const escaped = base.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}`);
+}
+
+function Harness({
+  spaces,
+  overrideSpaces,
+}: {
+  spaces: Spaces;
+  overrideSpaces?: ReservationUnitEditFormValues["spaces"];
+}) {
+  const base = convertReservationUnit(undefined);
+  const form = useForm<ReservationUnitEditFormValues>({
+    defaultValues: {
+      ...base,
+      ...(overrideSpaces ? { spaces: overrideSpaces } : {}),
+    },
+  });
+  return <BasicSection form={form} spaces={spaces} />;
+}
+
+describe("BasicSection", () => {
+  it("is open by default and renders the required fields", () => {
+    render(<Harness spaces={[SPACE_WITHOUT_RESOURCES]} />);
+
+    expect(screen.getByRole("textbox", { name: nameLike("reservationUnitEditor:label.nameFi") })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: nameLike("reservationUnitEditor:label.nameEn") })).toBeInTheDocument();
+    expect(screen.getByRole("textbox", { name: nameLike("reservationUnitEditor:label.nameSv") })).toBeInTheDocument();
+    expect(
+      screen.getByRole("radio", { name: "reservationUnitEditor:label.options.reservationKind.DIRECT" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.surfaceArea") })
+    ).toBeInTheDocument();
+  });
+
+  it("defaults min surface area to 1 and max persons to 20 when no spaces are selected", () => {
+    render(<Harness spaces={[SPACE_WITH_RESOURCES, SPACE_WITHOUT_RESOURCES]} overrideSpaces={[]} />);
+
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.surfaceArea") })
+    ).toHaveAttribute("min", "1");
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.maxPersons") })
+    ).toHaveAttribute("max", "20");
+  });
+
+  it("derives min surface area and max persons from the currently selected spaces", () => {
+    render(<Harness spaces={[SPACE_WITH_RESOURCES, SPACE_WITHOUT_RESOURCES]} overrideSpaces={[1, 2]} />);
+
+    // 30 + 10 surface area, 15 + 5 max persons, summed across selected spaces.
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.surfaceArea") })
+    ).toHaveAttribute("min", "40");
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.maxPersons") })
+    ).toHaveAttribute("max", "20");
+  });
+
+  it("disables the resources select when no space has any resources", () => {
+    render(<Harness spaces={[SPACE_WITHOUT_RESOURCES]} />);
+
+    expect(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.resources") })
+    ).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("enables the resources select when a space has resources", () => {
+    render(<Harness spaces={[SPACE_WITH_RESOURCES]} />);
+
+    expect(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.resources") })
+    ).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("caps minPersons at the current maxPersons form value, defaulting to 1", () => {
+    render(<Harness spaces={[SPACE_WITHOUT_RESOURCES]} />);
+
+    expect(
+      screen.getByRole("spinbutton", { name: nameLike("reservationUnitEditor:label.minPersons") })
+    ).toHaveAttribute("max", "1");
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/ImageEditor.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/ImageEditor.test.tsx
@@ -1,0 +1,91 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { ReservationUnitImageType } from "@gql/gql-types";
+import { ImageEditor } from "./ImageEditor";
+import type { ImageFormType } from "./form";
+
+const MAIN_IMAGE: ImageFormType = {
+  pk: 1,
+  imageUrl: "https://example.com/main.jpg",
+  mediumUrl: "https://example.com/main-medium.jpg",
+  imageType: ReservationUnitImageType.Main,
+};
+
+const OTHER_IMAGE: ImageFormType = {
+  pk: 2,
+  imageUrl: "https://example.com/other.jpg",
+  mediumUrl: "https://example.com/other-medium.jpg",
+  imageType: ReservationUnitImageType.Other,
+};
+
+const DELETED_IMAGE: ImageFormType = {
+  pk: 3,
+  imageUrl: "https://example.com/deleted.jpg",
+  imageType: ReservationUnitImageType.Other,
+  deleted: true,
+};
+
+function Harness({ images, setImages }: { images: ImageFormType[]; setImages: (images: ImageFormType[]) => void }) {
+  return <ImageEditor images={images} setImages={setImages} />;
+}
+
+describe("ImageEditor", () => {
+  it("renders the file input and one image per non-deleted image", () => {
+    render(<Harness images={[MAIN_IMAGE, OTHER_IMAGE, DELETED_IMAGE]} setImages={vi.fn()} />);
+
+    expect(screen.getByLabelText("reservationUnitEditor:ImageEditor.label")).toBeInTheDocument();
+    expect(screen.getAllByRole("img")).toHaveLength(2);
+  });
+
+  it("shows the main-image label for the main image and a promote button for others", () => {
+    render(<Harness images={[MAIN_IMAGE, OTHER_IMAGE]} setImages={vi.fn()} />);
+
+    expect(screen.getByText("reservationUnitEditor:ImageEditor.mainImage")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "reservationUnitEditor:ImageEditor.useAsMainImage" })
+    ).toBeInTheDocument();
+  });
+
+  it("promotes another image to be the main image", async () => {
+    const setImages = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness images={[MAIN_IMAGE, OTHER_IMAGE]} setImages={setImages} />);
+
+    await user.click(screen.getByRole("button", { name: "reservationUnitEditor:ImageEditor.useAsMainImage" }));
+
+    expect(setImages).toHaveBeenCalledWith([
+      { ...MAIN_IMAGE, imageType: ReservationUnitImageType.Other },
+      { ...OTHER_IMAGE, imageType: ReservationUnitImageType.Main },
+    ]);
+  });
+
+  it("marks a saved image (positive pk) as deleted instead of removing it", async () => {
+    const setImages = vi.fn();
+    const user = userEvent.setup();
+    render(<Harness images={[MAIN_IMAGE, OTHER_IMAGE]} setImages={setImages} />);
+
+    const [, secondRemoveButton] = screen.getAllByRole("button", { name: "common:remove" });
+    if (!secondRemoveButton) throw new Error("expected a second remove button");
+    await user.click(secondRemoveButton);
+
+    expect(setImages).toHaveBeenCalledWith([
+      { ...MAIN_IMAGE, deleted: undefined },
+      { ...OTHER_IMAGE, deleted: true },
+    ]);
+  });
+
+  it("removes an unsaved image (non-positive pk) outright", async () => {
+    const setImages = vi.fn();
+    const user = userEvent.setup();
+    const unsavedImage: ImageFormType = { ...OTHER_IMAGE, pk: -1 };
+    render(<Harness images={[MAIN_IMAGE, unsavedImage]} setImages={setImages} />);
+
+    const [, secondRemoveButton] = screen.getAllByRole("button", { name: "common:remove" });
+    if (!secondRemoveButton) throw new Error("expected a second remove button");
+    await user.click(secondRemoveButton);
+
+    expect(setImages).toHaveBeenCalledWith([MAIN_IMAGE]);
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/ReservationUnitSettingsSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/ReservationUnitSettingsSection.test.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ReservationKind } from "@gql/gql-types";
+import { ReservationUnitSettingsSection } from "./ReservationUnitSettingsSection";
+import { convertReservationUnit } from "./form";
+import type { ReservationUnitEditFormValues } from "./form";
+
+const CANCELLATION_RULE_OPTIONS = [{ value: 1, label: "Rule 1" }];
+
+function Harness({ overrides }: { overrides?: Partial<ReservationUnitEditFormValues> }) {
+  const base = convertReservationUnit(undefined);
+  const form = useForm<ReservationUnitEditFormValues>({
+    defaultValues: { ...base, ...overrides },
+  });
+  return <ReservationUnitSettingsSection form={form} cancellationRuleOptions={CANCELLATION_RULE_OPTIONS} />;
+}
+
+async function openAccordion() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /reservationUnitEditor:settings/ }));
+  return user;
+}
+
+describe("ReservationUnitSettingsSection", () => {
+  it("hides direct-only reservation settings when reservationKind is Season", async () => {
+    render(<Harness overrides={{ reservationKind: ReservationKind.Season }} />);
+    await openAccordion();
+
+    expect(screen.queryByText("reservationUnitEditor:scheduledPublishing")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("checkbox", { name: "reservationUnitEditor:requireAdultReserveeLabel" })
+    ).not.toBeInTheDocument();
+    // The start interval select isn't direct-only and should always be present.
+    expect(
+      screen.getByRole("combobox", { name: /^reservationUnitEditor:label\.reservationStartInterval/ })
+    ).toBeInTheDocument();
+  });
+
+  it("shows direct-only reservation settings when reservationKind is Direct", async () => {
+    render(<Harness overrides={{ reservationKind: ReservationKind.Direct }} />);
+    await openAccordion();
+
+    expect(screen.getByText("reservationUnitEditor:scheduledPublishing")).toBeInTheDocument();
+    expect(screen.getByText("reservationUnitEditor:scheduledReservation")).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /^reservationUnitEditor:label\.minReservationDuration/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox", { name: /^reservationUnitEditor:label\.maxReservationDuration/ })
+    ).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /^reservationUnitEditor:label\.reservationForm/ })).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "reservationUnitEditor:requireAdultReserveeLabel" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "reservationUnitEditor:requireReservationHandling" })
+    ).toBeInTheDocument();
+  });
+
+  it("reveals begin/end date-time inputs as scheduled publishing sub-toggles are enabled", async () => {
+    render(
+      <Harness
+        overrides={{
+          reservationKind: ReservationKind.Direct,
+          hasScheduledPublish: true,
+          hasPublishBegins: true,
+        }}
+      />
+    );
+    const user = await openAccordion();
+
+    expect(screen.getAllByRole("textbox", { name: "common:date" })).toHaveLength(1);
+
+    await user.click(screen.getByRole("checkbox", { name: "reservationUnitEditor:publishEndsAt" }));
+
+    expect(screen.getAllByRole("textbox", { name: "common:date" })).toHaveLength(2);
+  });
+
+  it("reveals buffer-time selects once bufferTimesSet and a direction toggle are enabled", async () => {
+    render(<Harness />);
+    const user = await openAccordion();
+
+    expect(screen.queryByText("reservationUnitEditor:bufferTimeBefore")).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("radio", { name: "reservationUnitEditor:label.options.bufferType.bufferTimesSet" })
+    );
+
+    expect(screen.getByText("reservationUnitEditor:bufferTimeBefore")).toBeInTheDocument();
+    expect(screen.getByText("reservationUnitEditor:bufferTimeAfter")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "reservationUnitEditor:bufferTimeBefore" }));
+
+    expect(
+      screen.getByRole("combobox", { name: /^reservationUnitEditor:bufferTimeBeforeDuration/ })
+    ).toBeInTheDocument();
+  });
+
+  it("reveals the cancellation rule options once hasCancellationRule is enabled", async () => {
+    render(<Harness />);
+    const user = await openAccordion();
+
+    expect(screen.queryByRole("radio", { name: "Rule 1" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "reservationUnitEditor:cancellationIsPossible" }));
+
+    expect(screen.getByRole("radio", { name: "Rule 1" })).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/ReservationUnitSettingsSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/ReservationUnitSettingsSection.test.tsx
@@ -60,6 +60,7 @@ describe("ReservationUnitSettingsSection", () => {
     ).toBeInTheDocument();
   });
 
+  // Accordion open + HDS interactions; give it headroom over the 5s default under parallel test load.
   it("reveals begin/end date-time inputs as scheduled publishing sub-toggles are enabled", async () => {
     render(
       <Harness
@@ -77,8 +78,9 @@ describe("ReservationUnitSettingsSection", () => {
     await user.click(screen.getByRole("checkbox", { name: "reservationUnitEditor:publishEndsAt" }));
 
     expect(screen.getAllByRole("textbox", { name: "common:date" })).toHaveLength(2);
-  });
+  }, 10_000);
 
+  // Accordion open + HDS interactions; give it headroom over the 5s default under parallel test load.
   it("reveals buffer-time selects once bufferTimesSet and a direction toggle are enabled", async () => {
     render(<Harness />);
     const user = await openAccordion();
@@ -97,8 +99,9 @@ describe("ReservationUnitSettingsSection", () => {
     expect(
       screen.getByRole("combobox", { name: /^reservationUnitEditor:bufferTimeBeforeDuration/ })
     ).toBeInTheDocument();
-  });
+  }, 10_000);
 
+  // Accordion open + HDS interactions; give it headroom over the 5s default under parallel test load.
   it("reveals the cancellation rule options once hasCancellationRule is enabled", async () => {
     render(<Harness />);
     const user = await openAccordion();
@@ -108,5 +111,5 @@ describe("ReservationUnitSettingsSection", () => {
     await user.click(screen.getByRole("checkbox", { name: "reservationUnitEditor:cancellationIsPossible" }));
 
     expect(screen.getByRole("radio", { name: "Rule 1" })).toBeInTheDocument();
-  });
+  }, 10_000);
 });

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/SeasonalSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/SeasonalSection.test.tsx
@@ -92,7 +92,7 @@ describe("SeasonalSection", () => {
 
     expect(screen.getAllByPlaceholderText("tt:mm")).toHaveLength(14);
     expect(screen.getAllByRole("button", { name: "reservationUnitEditor:addSeasonalTime" })).toHaveLength(7);
-  }, 10_000);
+  }, 20_000);
 
   // Several sequential HDS interactions; give it headroom over the 5s default under parallel test load.
   it("resets all days to default when Clear is clicked", async () => {

--- a/frontend/apps/staff/src/lib/reservation-units/[pk]/TermsSection.test.tsx
+++ b/frontend/apps/staff/src/lib/reservation-units/[pk]/TermsSection.test.tsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { useForm } from "react-hook-form";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { TermsSection } from "./TermsSection";
+import { convertReservationUnit } from "./form";
+import type { ReservationUnitEditFormValues } from "./form";
+
+const OPTIONS = {
+  service: [{ value: "service-1", label: "Service terms 1" }],
+  payment: [{ value: "payment-1", label: "Payment terms 1" }],
+  cancellation: [{ value: "cancellation-1", label: "Cancellation terms 1" }],
+};
+
+function Harness() {
+  const form = useForm<ReservationUnitEditFormValues>({
+    defaultValues: convertReservationUnit(undefined),
+  });
+  return <TermsSection form={form} options={OPTIONS} />;
+}
+
+async function openAccordion() {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: /reservationUnitEditor:termsInstructions/ }));
+  return user;
+}
+
+// The terms selects use enableSearch, which makes HDS render them as a "button"
+// that opens a picker dialog rather than a native "combobox".
+function selectButtonNameLike(base: string): RegExp {
+  const escaped = base.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`^${escaped}`);
+}
+
+describe("TermsSection", () => {
+  it("is closed by default and renders the three term selects and rich text fields once opened", async () => {
+    render(<Harness />);
+    expect(
+      screen.queryByRole("button", { name: /reservationUnitEditor:label\.serviceSpecificTerms/ })
+    ).not.toBeInTheDocument();
+
+    await openAccordion();
+
+    expect(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.serviceSpecificTerms") })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.paymentTerms") })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.cancellationTerms") })
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("reservationUnitEditor:label.notesWhenApplyingFi", { exact: false, selector: "label" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("reservationUnitEditor:label.notesWhenApplyingEn", { exact: false, selector: "label" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("reservationUnitEditor:label.notesWhenApplyingSv", { exact: false, selector: "label" })
+    ).toBeInTheDocument();
+  });
+
+  it("lists the given options for each terms select", async () => {
+    render(<Harness />);
+    const user = await openAccordion();
+
+    await user.click(
+      screen.getByRole("button", { name: selectButtonNameLike("reservationUnitEditor:label.serviceSpecificTerms") })
+    );
+    const listbox = await screen.findByRole("listbox");
+    expect(within(listbox).getByRole("option", { name: "Service terms 1" })).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/Filters.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/Filters.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Filters } from "./Filters";
+
+const { mockUseSearchParams } = vi.hoisted(() => ({ mockUseSearchParams: vi.fn() }));
+vi.mock("next/navigation", () => ({ useSearchParams: mockUseSearchParams }));
+
+const { mockUseSetSearchParams } = vi.hoisted(() => ({ mockUseSetSearchParams: vi.fn() }));
+vi.mock("@/hooks/useSetSearchParams", () => ({ useSetSearchParams: mockUseSetSearchParams }));
+
+const { mockUseFilterOptions } = vi.hoisted(() => ({ mockUseFilterOptions: vi.fn() }));
+vi.mock("@/hooks/useFilterOptions", () => ({ useFilterOptions: mockUseFilterOptions }));
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: "fi" } }),
+}));
+
+describe("reservations Filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSetSearchParams.mockReturnValue(vi.fn());
+    mockUseFilterOptions.mockReturnValue({
+      reservationUnitTypes: [{ label: "Type A", value: 1 }],
+      units: [{ label: "Unit A", value: 1 }],
+      reservationUnits: [{ label: "Reservation unit A", value: 1 }],
+      stateChoices: [{ label: "Confirmed", value: "CONFIRMED" }],
+      orderStatus: [{ label: "Paid", value: "PAID" }],
+      reservationTypeChoices: [{ label: "Normal", value: "NORMAL" }],
+      recurringChoices: [
+        { label: "Only recurring", value: "only" },
+        { label: "Only not recurring", value: "onlyNot" },
+      ],
+      reservationUnitStates: [],
+      unitGroups: [],
+      municipalities: [],
+      reserveeTypes: [],
+      orderChoices: [],
+      priorityChoices: [],
+      intendedUses: [],
+      reservationPurposes: [],
+      ageGroups: [],
+      equipments: [],
+    });
+  });
+
+  it("renders the always-visible search field and search button", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(<Filters />);
+
+    expect(screen.getByLabelText("filters:label.searchReservation")).toBeInTheDocument();
+    expect(screen.getByTestId("searchButton")).toBeInTheDocument();
+  });
+
+  it("passes the unit search param through to useFilterOptions", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("unit=1&unit=2"));
+
+    render(<Filters />);
+
+    expect(mockUseFilterOptions).toHaveBeenCalledWith([1, 2]);
+  });
+
+  it("populates the search field from the search param", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("search=badminton"));
+
+    render(<Filters />);
+
+    expect(screen.getByLabelText("filters:label.searchReservation")).toHaveValue("badminton");
+  });
+
+  it("submits the search text as a search param", async () => {
+    const user = userEvent.setup();
+    const setSearchParams = vi.fn();
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+    mockUseSetSearchParams.mockReturnValue(setSearchParams);
+
+    render(<Filters />);
+
+    await user.type(screen.getByLabelText("filters:label.searchReservation"), "badminton");
+    await user.click(screen.getByTestId("searchButton"));
+
+    expect(setSearchParams).toHaveBeenCalledTimes(1);
+    const params = setSearchParams.mock.calls[0]?.[0] as URLSearchParams;
+    expect(params.get("search")).toBe("badminton");
+  });
+
+  it("renders default tags and the clear-button labels passed in as props", () => {
+    mockUseSearchParams.mockReturnValue(new URLSearchParams(""));
+
+    render(
+      <Filters
+        defaultFilters={[{ key: "state", value: "CONFIRMED" }]}
+        clearButtonLabel="Clear all"
+        clearButtonAriaLabel="Clear all filters"
+      />
+    );
+
+    expect(screen.getByLabelText("filters:label.searchReservation")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/ReservationsDataLoader.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/ReservationsDataLoader.test.tsx
@@ -1,0 +1,195 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReservationListDocument, ReservationStateChoice } from "@gql/gql-types";
+import type { ReservationTableElementFragment } from "@gql/gql-types";
+import { ReservationsDataLoader } from "./ReservationsDataLoader";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("ui/src/modules/date-utils", () => ({
+  formatDateTime: (date: Date) => date.toISOString(),
+  formatDateTimeRange: (start: Date, end: Date) => `${start.toISOString()} - ${end.toISOString()}`,
+  parseValidDateObject: (dateStr: string) => new Date(dateStr),
+  parseUIDate: (value: string) => new Date(value),
+  formatApiDate: (date: Date) => date.toISOString().slice(0, 10),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  OrderStatusLabel: ({ status }: { status: string }) => <span>{status}</span>,
+  ReservationStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+}));
+
+const { mockedSearchParams, useSearchParams } = vi.hoisted(() => {
+  const params = vi.fn();
+  return { useSearchParams: params, mockedSearchParams: params };
+});
+vi.mock("next/navigation", () => ({ useSearchParams }));
+
+const mockErrorToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+}));
+
+function createReservation(overrides: Partial<ReservationTableElementFragment> = {}): ReservationTableElementFragment {
+  return {
+    __typename: "ReservationNode",
+    id: "res-1",
+    pk: 1000,
+    name: "John Doe",
+    state: ReservationStateChoice.Confirmed,
+    beginsAt: "2024-06-15T09:00:00Z",
+    endsAt: "2024-06-15T11:00:00Z",
+    createdAt: "2024-06-01T10:00:00Z",
+    type: null,
+    isBlocked: false,
+    workingMemo: null,
+    reserveeName: "John Doe",
+    bufferTimeBefore: 0,
+    bufferTimeAfter: 0,
+    reservationUnit: {
+      __typename: "ReservationUnitNode",
+      id: "ru-1",
+      nameFi: "Meeting Room A",
+      unit: {
+        __typename: "UnitNode",
+        id: "unit-1",
+        nameFi: "Unit 1",
+      },
+    },
+    paymentOrder: null,
+    user: null,
+    ...overrides,
+  } as ReservationTableElementFragment;
+}
+
+function listMock(
+  reservations: ReservationTableElementFragment[],
+  totalCount: number,
+  hasNextPage = false
+): MockedResponse {
+  return {
+    request: { query: ReservationListDocument },
+    variableMatcher: () => true,
+    result: {
+      data: {
+        reservations: {
+          __typename: "ReservationNodeConnection",
+          edges: reservations.map((node) => ({ __typename: "ReservationNodeEdge", node })),
+          pageInfo: { __typename: "PageInfo", endCursor: "cursor-1", hasNextPage },
+          totalCount,
+        },
+      },
+    },
+  };
+}
+
+function errorMock(): MockedResponse {
+  return {
+    request: { query: ReservationListDocument },
+    variableMatcher: () => true,
+    result: { errors: [new GraphQLError("Error")] },
+  };
+}
+
+function renderLoader(mocks: MockedResponse[]) {
+  return render(
+    <MockedProvider mocks={mocks}>
+      <ReservationsDataLoader />
+    </MockedProvider>
+  );
+}
+
+beforeEach(() => {
+  mockedSearchParams.mockReturnValue(new URLSearchParams());
+  mockErrorToast.mockReset();
+});
+
+describe("ReservationsDataLoader", () => {
+  it("shows nothing from the table until the query resolves", () => {
+    renderLoader([listMock([createReservation()], 1)]);
+    expect(screen.queryByText("1000")).not.toBeInTheDocument();
+  });
+
+  it("renders the reservations table once the query resolves", async () => {
+    renderLoader([listMock([createReservation()], 1)]);
+    expect(await screen.findByText("1000")).toBeInTheDocument();
+    expect(screen.getByText("Meeting Room A")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no reservations", async () => {
+    renderLoader([listMock([], 0)]);
+    expect(await screen.findByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("shows an error toast when the query returns a GraphQL error", async () => {
+    renderLoader([errorMock()]);
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalledWith({ text: "errors:errorFetchingData" }));
+  });
+
+  it("shows the More button when there are more results, and fetches the next page on click", async () => {
+    const user = userEvent.setup();
+    renderLoader([
+      listMock([createReservation()], 2, true),
+      listMock([createReservation(), createReservation({ id: "res-2", pk: 1001 })], 2),
+    ]);
+
+    expect(await screen.findByText("1000")).toBeInTheDocument();
+    const moreButton = screen.getByRole("button", { name: "common:showMore" });
+
+    await user.click(moreButton);
+
+    await waitFor(() => expect(moreButton).not.toBeDisabled());
+  });
+
+  it("shows the all-results message when every reservation has been loaded", async () => {
+    renderLoader([listMock([createReservation()], 1, false)]);
+    expect(await screen.findByText("translation:paging.allResults")).toBeInTheDocument();
+  });
+
+  it("toggles the sort field for every sortable column when its header is clicked", async () => {
+    const user = userEvent.setup();
+    const sortKeys = [
+      "pk",
+      "reservee_name",
+      "reservation_unit_name_fi",
+      "unit_name_fi",
+      "begin",
+      "created_at",
+      "orderStatus",
+      "state",
+    ];
+    renderLoader(Array.from({ length: sortKeys.length + 2 }, () => listMock([createReservation()], 1)));
+
+    expect(await screen.findByText("1000")).toBeInTheDocument();
+
+    for (const key of sortKeys) {
+      // eslint-disable-next-line no-await-in-loop
+      await user.click(screen.getByTestId(`hds-table-sorting-header-${key}`));
+    }
+    // click "begin" again to also exercise the descending branch
+    await user.click(screen.getByTestId("hds-table-sorting-header-begin"));
+
+    expect(screen.getByText("1000")).toBeInTheDocument();
+  });
+
+  it("sends the recurring filter when the recurring search param is set", async () => {
+    mockedSearchParams.mockReturnValue(new URLSearchParams({ recurring: "only" }));
+    renderLoader([listMock([createReservation()], 1)]);
+    expect(await screen.findByText("1000")).toBeInTheDocument();
+  });
+
+  it("sends the non-recurring filter when the recurring search param is 'onlyNot'", async () => {
+    mockedSearchParams.mockReturnValue(new URLSearchParams({ recurring: "onlyNot" }));
+    renderLoader([listMock([createReservation()], 1)]);
+    expect(await screen.findByText("1000")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/ReservationsTable.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/ReservationsTable.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReservationStateChoice } from "@gql/gql-types";
+import type { ReservationTableElementFragment } from "@gql/gql-types";
+import { ReservationsTable } from "./ReservationsTable";
+
+vi.mock("next-i18next", () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+vi.mock("ui/src/modules/date-utils", () => ({
+  formatDateTime: (date: Date) => date.toISOString(),
+  formatDateTimeRange: (start: Date, end: Date) => `${start.toISOString()} - ${end.toISOString()}`,
+  parseValidDateObject: (dateStr: string) => new Date(dateStr),
+}));
+
+vi.mock("ui/src/components/statuses", () => ({
+  OrderStatusLabel: ({ status }: { status: string }) => <span>{status}</span>,
+  ReservationStatusLabel: ({ state }: { state: string }) => <span>{state}</span>,
+}));
+
+function createReservation(overrides: Partial<ReservationTableElementFragment> = {}): ReservationTableElementFragment {
+  return {
+    id: "res-1",
+    pk: 1000,
+    name: "John Doe",
+    state: ReservationStateChoice.Confirmed,
+    beginsAt: "2024-06-15T09:00:00Z",
+    endsAt: "2024-06-15T11:00:00Z",
+    createdAt: "2024-06-01T10:00:00Z",
+    reservationUnit: {
+      id: "ru-1",
+      nameFi: "Meeting Room A",
+      unit: {
+        id: "unit-1",
+        nameFi: "Unit 1",
+      },
+    },
+    paymentOrder: null,
+    ...overrides,
+  } as ReservationTableElementFragment;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ReservationsTable", () => {
+  it("renders table rows with all columns", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ReservationsTable
+        sort="pk"
+        sortChanged={mockSortChanged}
+        isLoading={false}
+        reservations={[createReservation()]}
+      />
+    );
+
+    expect(screen.getByText("1000")).toBeInTheDocument();
+    expect(screen.getByText("Meeting Room A")).toBeInTheDocument();
+    expect(screen.getByText("Unit 1")).toBeInTheDocument();
+    expect(container.querySelector("table tbody tr")).toBeTruthy();
+  });
+
+  it("shows empty state when no reservations", () => {
+    const mockSortChanged = vi.fn();
+    render(<ReservationsTable sort="pk" sortChanged={mockSortChanged} isLoading={false} reservations={[]} />);
+
+    expect(screen.getByText("common:noFilteredResults")).toBeInTheDocument();
+  });
+
+  it("renders reservation link with correct href", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ReservationsTable
+        sort="pk"
+        sortChanged={mockSortChanged}
+        isLoading={false}
+        reservations={[createReservation()]}
+      />
+    );
+
+    const link = container.querySelector("a[href*='/reservations/1000']");
+    expect(link).toBeTruthy();
+  });
+
+  it("handles reservations without names", () => {
+    const mockSortChanged = vi.fn();
+    const { container } = render(
+      <ReservationsTable
+        sort="pk"
+        sortChanged={mockSortChanged}
+        isLoading={false}
+        reservations={[createReservation({ name: null })]}
+      />
+    );
+
+    expect(screen.getByText("1000")).toBeInTheDocument();
+    expect(container.querySelector("table")).toBeTruthy();
+  });
+
+  it("handles multiple reservations with different states", () => {
+    const mockSortChanged = vi.fn();
+    const reservations = [
+      createReservation({ pk: 1000, state: ReservationStateChoice.Confirmed }),
+      createReservation({ pk: 1001, state: ReservationStateChoice.Cancelled }),
+      createReservation({ pk: 1002, state: ReservationStateChoice.RequiresHandling }),
+    ];
+    render(<ReservationsTable sort="pk" sortChanged={mockSortChanged} isLoading={false} reservations={reservations} />);
+
+    expect(screen.getByText("1000")).toBeInTheDocument();
+    expect(screen.getByText("1001")).toBeInTheDocument();
+    expect(screen.getByText("1002")).toBeInTheDocument();
+  });
+
+  it("handles reservations without payment orders", () => {
+    const mockSortChanged = vi.fn();
+    render(
+      <ReservationsTable
+        sort="pk"
+        sortChanged={mockSortChanged}
+        isLoading={false}
+        reservations={[createReservation({ paymentOrder: null })]}
+      />
+    );
+
+    const dashCells = screen.getAllByText("-");
+    expect(dashCells.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/[id]/ApprovalButtonsRecurring.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/[id]/ApprovalButtonsRecurring.test.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReservationStateChoice } from "@gql/gql-types";
+import { ApprovalButtonsRecurring } from "./ApprovalButtonsRecurring";
+
+const mockSetModalContent = vi.fn();
+vi.mock("@/context/ModalContext", () => ({
+  useModal: () => ({ isOpen: true, setModalContent: mockSetModalContent, modalContent: { content: null } }),
+}));
+
+const mockUseReservationSeries = vi.fn();
+vi.mock("@/hooks", () => ({
+  useReservationSeries: (pk: number | undefined) => mockUseReservationSeries(pk),
+}));
+
+function reservation(overrides: Partial<{ pk: number; state: ReservationStateChoice; beginsAt: string }> = {}) {
+  return {
+    pk: 1,
+    state: ReservationStateChoice.RequiresHandling,
+    beginsAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    handlingDetails: "",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockSetModalContent.mockReset();
+  mockUseReservationSeries.mockReset();
+});
+
+describe("ApprovalButtonsRecurring", () => {
+  it("renders nothing while loading", () => {
+    mockUseReservationSeries.mockReturnValue({ loading: true, reservations: [], refetch: vi.fn() });
+    const { container } = render(
+      <ApprovalButtonsRecurring reservationSeries={{ pk: 1 }} handleClose={vi.fn()} handleAccept={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when no reservation in the series can be denied", () => {
+    mockUseReservationSeries.mockReturnValue({
+      loading: false,
+      reservations: [reservation({ state: ReservationStateChoice.Denied })],
+      refetch: vi.fn(),
+    });
+    const { container } = render(
+      <ApprovalButtonsRecurring reservationSeries={{ pk: 1 }} handleClose={vi.fn()} handleAccept={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the reject button and edit links, opening the deny dialog on click", async () => {
+    const user = userEvent.setup();
+    mockUseReservationSeries.mockReturnValue({
+      loading: false,
+      reservations: [reservation({ pk: 7 })],
+      refetch: vi.fn(),
+    });
+
+    render(<ApprovalButtonsRecurring reservationSeries={{ pk: 1 }} handleClose={vi.fn()} handleAccept={vi.fn()} />);
+
+    expect(screen.getByTestId("approval-buttons-recurring__edit-link")).toHaveAttribute("href", "/reservations/7/edit");
+    expect(screen.getByText("reservation:ApprovalButtons.editSeriesTime")).toHaveAttribute(
+      "href",
+      "/reservations/7/series"
+    );
+
+    await user.click(screen.getByTestId("approval-buttons-recurring__reject-button"));
+    expect(mockSetModalContent).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides the non-essential edit links when disableNonEssentialButtons is set", () => {
+    mockUseReservationSeries.mockReturnValue({
+      loading: false,
+      reservations: [reservation()],
+      refetch: vi.fn(),
+    });
+
+    render(
+      <ApprovalButtonsRecurring
+        reservationSeries={{ pk: 1 }}
+        handleClose={vi.fn()}
+        handleAccept={vi.fn()}
+        disableNonEssentialButtons
+      />
+    );
+
+    expect(screen.getByTestId("approval-buttons-recurring__reject-button")).toBeInTheDocument();
+    expect(screen.queryByTestId("approval-buttons-recurring__edit-link")).not.toBeInTheDocument();
+  });
+
+  it("only considers reservations that are still possible to deny", () => {
+    mockUseReservationSeries.mockReturnValue({
+      loading: false,
+      reservations: [
+        reservation({ pk: 1, state: ReservationStateChoice.Denied }),
+        reservation({ pk: 9, state: ReservationStateChoice.RequiresHandling }),
+      ],
+      refetch: vi.fn(),
+    });
+
+    render(<ApprovalButtonsRecurring reservationSeries={{ pk: 1 }} handleClose={vi.fn()} handleAccept={vi.fn()} />);
+
+    expect(screen.getByTestId("approval-buttons-recurring__edit-link")).toHaveAttribute("href", "/reservations/9/edit");
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/[id]/ApproveDialog.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/[id]/ApproveDialog.test.tsx
@@ -1,0 +1,142 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApproveReservationDocument } from "@gql/gql-types";
+import type { ApprovalDialogFieldsFragment } from "@gql/gql-types";
+import { ApproveDialog } from "./ApproveDialog";
+
+vi.mock("@/context/ModalContext", () => ({
+  useModal: () => ({ isOpen: true, setModalContent: vi.fn(), modalContent: { content: null } }),
+}));
+
+vi.mock("@/modules/reservation", () => ({
+  getReservationPriceDetails: () => "price details",
+}));
+
+const mockErrorToast = vi.fn();
+const mockSuccessToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+  successToast: (...args: unknown[]) => mockSuccessToast(...args),
+}));
+
+function createReservation(overrides: Partial<ApprovalDialogFieldsFragment> = {}): ApprovalDialogFieldsFragment {
+  return {
+    pk: 1,
+    price: "0",
+    handlingDetails: "",
+    applyingForFreeOfCharge: false,
+    freeOfChargeReason: null,
+    ...overrides,
+  } as ApprovalDialogFieldsFragment;
+}
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+  mockSuccessToast.mockReset();
+});
+
+describe("ApproveDialog", () => {
+  it("renders handling details and accepts with the default price", async () => {
+    const onAccept = vi.fn();
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: {
+          query: ApproveReservationDocument,
+          variables: { input: { pk: 1, price: "0", handlingDetails: "" } },
+        },
+        result: { data: { approveReservation: { pk: 1, state: "CONFIRMED" } } },
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <ApproveDialog reservation={createReservation()} onClose={vi.fn()} onAccept={onAccept} />
+      </MockedProvider>
+    );
+
+    expect(screen.queryByText("price details")).not.toBeInTheDocument();
+    await user.click(screen.getByTestId("approval-dialog__accept-button"));
+
+    await waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+    expect(mockSuccessToast).toHaveBeenCalledWith({ text: "reservation:ApproveDialog.approved" });
+  });
+
+  it("closes on cancel", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <MockedProvider mocks={[]}>
+        <ApproveDialog reservation={createReservation()} onClose={onClose} onAccept={vi.fn()} />
+      </MockedProvider>
+    );
+
+    await user.click(screen.getByTestId("approval-dialog__cancel-button"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the subvention section, zeroes the price via the clear-price checkbox, and submits", async () => {
+    const onAccept = vi.fn();
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: {
+          query: ApproveReservationDocument,
+          variables: { input: { pk: 1, price: "0", handlingDetails: "" } },
+        },
+        result: { data: { approveReservation: { pk: 1, state: "CONFIRMED" } } },
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <ApproveDialog
+          reservation={createReservation({
+            price: "10",
+            applyingForFreeOfCharge: true,
+            freeOfChargeReason: "reason",
+          })}
+          onClose={vi.fn()}
+          onAccept={onAccept}
+        />
+      </MockedProvider>
+    );
+
+    expect(screen.getByText("price details")).toBeInTheDocument();
+    expect(screen.getByText("reason")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("checkbox", { name: "reservation:ApproveDialog.clearPrice" }));
+    await user.click(screen.getByTestId("approval-dialog__accept-button"));
+
+    await waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+  });
+
+  it("displays an error and does not call onAccept when the mutation fails", async () => {
+    const onAccept = vi.fn();
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: {
+          query: ApproveReservationDocument,
+          variables: { input: { pk: 1, price: "0", handlingDetails: "" } },
+        },
+        result: { errors: [new GraphQLError("Error")] },
+      },
+    ];
+
+    render(
+      <MockedProvider mocks={mocks}>
+        <ApproveDialog reservation={createReservation()} onClose={vi.fn()} onAccept={onAccept} />
+      </MockedProvider>
+    );
+
+    await user.click(screen.getByTestId("approval-dialog__accept-button"));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/staff/src/lib/reservations/[id]/ReturnToRequiresHandlingDialog.test.tsx
+++ b/frontend/apps/staff/src/lib/reservations/[id]/ReturnToRequiresHandlingDialog.test.tsx
@@ -1,0 +1,96 @@
+import React, { createRef } from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RequireHandlingDocument } from "@gql/gql-types";
+import { ReturnToRequiresHandlingDialog } from "./ReturnToRequiresHandlingDialog";
+
+vi.mock("@/context/ModalContext", () => ({
+  useModal: () => ({ isOpen: true, setModalContent: vi.fn(), modalContent: { content: null } }),
+}));
+
+const mockErrorToast = vi.fn();
+const mockSuccessToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+  successToast: (...args: unknown[]) => mockSuccessToast(...args),
+}));
+
+beforeEach(() => {
+  mockErrorToast.mockReset();
+  mockSuccessToast.mockReset();
+});
+
+function renderDialog(mocks: ReadonlyArray<MockedResponse>, reservation: { pk: number | null } = { pk: 1 }) {
+  const onClose = vi.fn();
+  const onAccept = vi.fn();
+  const focusAfterCloseRef = createRef<HTMLElement>();
+  render(
+    <MockedProvider mocks={mocks}>
+      <ReturnToRequiresHandlingDialog
+        reservation={reservation}
+        onClose={onClose}
+        onAccept={onAccept}
+        focusAfterCloseRef={focusAfterCloseRef as React.RefObject<HTMLElement>}
+      />
+    </MockedProvider>
+  );
+  return { onClose, onAccept };
+}
+
+describe("ReturnToRequiresHandlingDialog", () => {
+  it("returns the reservation to handling and calls onAccept", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: { query: RequireHandlingDocument, variables: { input: { pk: 1 } } },
+        result: { data: { requireHandlingForReservation: { pk: 1, state: "REQUIRES_HANDLING" } } },
+      },
+    ];
+    const { onAccept } = renderDialog(mocks);
+
+    await user.click(screen.getByText("reservation:ReturnToRequiresHandlingDialog.accept"));
+
+    await waitFor(() => expect(onAccept).toHaveBeenCalledTimes(1));
+    expect(mockSuccessToast).toHaveBeenCalledWith({ text: "reservation:ReturnToRequiresHandlingDialog.returned" });
+  });
+
+  it("closes on cancel without calling the mutation", async () => {
+    const user = userEvent.setup();
+    const { onClose, onAccept } = renderDialog([]);
+
+    await user.click(screen.getByText("common:prev"));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+
+  it("displays an error when the reservation pk is missing", async () => {
+    const user = userEvent.setup();
+    const { onAccept } = renderDialog([], { pk: null });
+
+    await user.click(screen.getByText("reservation:ReturnToRequiresHandlingDialog.accept"));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+
+  it("displays an error when the mutation fails", async () => {
+    const user = userEvent.setup();
+    const mocks = [
+      {
+        request: { query: RequireHandlingDocument, variables: { input: { pk: 1 } } },
+        result: { errors: [new GraphQLError("Error")] },
+      },
+    ];
+    const { onAccept } = renderDialog(mocks);
+
+    await user.click(screen.getByText("reservation:ReturnToRequiresHandlingDialog.accept"));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(onAccept).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/apps/staff/src/lib/units/[id]/ParentSelector.test.tsx
+++ b/frontend/apps/staff/src/lib/units/[id]/ParentSelector.test.tsx
@@ -1,0 +1,246 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useUnitSpacesQuery } from "@gql/gql-types";
+import { ParentSelector } from "./ParentSelector";
+
+vi.mock("@gql/gql-types", () => ({
+  useUnitSpacesQuery: vi.fn(),
+}));
+
+describe("ParentSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders disabled when unitPk is not provided and parentless option excluded", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: undefined,
+    } as never);
+
+    render(<ParentSelector unitPk={0} onChange={vi.fn()} value={null} label="Parent" noParentless />);
+
+    expect(screen.getByRole("combobox", { name: /parent/i })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("renders disabled when no spaces available and parentless option excluded", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" noParentless />);
+
+    expect(screen.getByRole("combobox", { name: /parent/i })).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("renders enabled when no spaces but parentless option included", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox", { name: /parent/i })).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("renders enabled when spaces are available", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox", { name: /parent/i })).toHaveAttribute("aria-disabled", "false");
+  });
+
+  it("renders space hierarchy with padding", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [
+            { pk: 1, nameFi: "Root", parent: null },
+            { pk: 2, nameFi: "Child", parent: { pk: 1 } },
+          ],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("includes parentless option by default", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("excludes parentless option when noParentless is true", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" noParentless />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("filters out self and direct children of self", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [
+            { pk: 1, nameFi: "Root", parent: null },
+            { pk: 2, nameFi: "Self", parent: { pk: 1 } },
+            { pk: 3, nameFi: "Child of Self", parent: { pk: 2 } },
+            { pk: 4, nameFi: "Other", parent: { pk: 1 } },
+          ],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" selfPk={2} />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("displays placeholder text", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" placeholder="Select a parent" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("displays helper text", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" helperText="Help text" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("displays error text and marks as invalid", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [{ pk: 1, nameFi: "Space 1", parent: null }],
+        },
+      },
+    } as never);
+
+    render(
+      <ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" errorText="This field is required" />
+    );
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("calls onChange when selection changes", async () => {
+    const user = userEvent.setup();
+    const mockOnChange = vi.fn();
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [
+            { pk: 1, nameFi: "Space 1", parent: null },
+            { pk: 2, nameFi: "Space 2", parent: null },
+          ],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={mockOnChange} value={null} label="Parent" />);
+
+    const button = screen.getByRole("combobox");
+    await user.click(button);
+
+    expect(button).toBeInTheDocument();
+  });
+
+  it("skips query when unitPk is 0", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: undefined,
+    } as never);
+
+    render(<ParentSelector unitPk={0} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(useUnitSpacesQuery).toHaveBeenCalledWith({
+      fetchPolicy: "no-cache",
+      variables: expect.any(Object),
+      skip: true,
+    });
+  });
+
+  it("handles spaces with null nameFi", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [
+            { pk: 1, nameFi: null, parent: null },
+            { pk: 2, nameFi: "Space 2", parent: null },
+          ],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+
+  it("handles spaces with empty nameFi", () => {
+    vi.mocked(useUnitSpacesQuery).mockReturnValue({
+      data: {
+        unit: {
+          spaces: [
+            { pk: 1, nameFi: "", parent: null },
+            { pk: 2, nameFi: "Space 2", parent: null },
+          ],
+        },
+      },
+    } as never);
+
+    render(<ParentSelector unitPk={1} onChange={vi.fn()} value={null} label="Parent" />);
+
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+  });
+});

--- a/frontend/apps/staff/src/lib/units/[id]/resources/[pk]/ResourceEditor.test.tsx
+++ b/frontend/apps/staff/src/lib/units/[id]/resources/[pk]/ResourceEditor.test.tsx
@@ -1,0 +1,223 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNodeId } from "ui/src/modules/helpers";
+import { ResourceDocument, ResourceLocationType, UnitSpacesDocument, UpdateResourceDocument } from "@gql/gql-types";
+import { ResourceEditor } from "./ResourceEditor";
+
+const mockRouterReplace = vi.fn();
+vi.mock("next/router", () => ({
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
+
+const mockErrorToast = vi.fn();
+const mockSuccessToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+  successToast: (...args: unknown[]) => mockSuccessToast(...args),
+}));
+
+const RESOURCE_PK = 5;
+const UNIT_PK = 1;
+
+function unitFragment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: createNodeId("UnitNode", UNIT_PK),
+    pk: UNIT_PK,
+    nameFi: "Unit A",
+    addressStreetFi: "Street 1",
+    addressCityFi: "City",
+    addressZip: "00100",
+    ...overrides,
+  };
+}
+
+function resourceFragment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: createNodeId("ResourceNode", RESOURCE_PK),
+    pk: RESOURCE_PK,
+    nameFi: "Resource A",
+    nameSv: "Resurssi A",
+    nameEn: "Resource EN",
+    space: { id: createNodeId("SpaceNode", 2), pk: 2 },
+    ...overrides,
+  };
+}
+
+function resourceQueryMock({
+  resourcePk = RESOURCE_PK,
+  unitPk = UNIT_PK,
+  resource = resourceFragment(),
+  unit = unitFragment(),
+}: {
+  resourcePk?: number;
+  unitPk?: number;
+  resource?: ReturnType<typeof resourceFragment> | null;
+  unit?: ReturnType<typeof unitFragment> | null;
+} = {}) {
+  return {
+    request: {
+      query: ResourceDocument,
+      variables: { id: createNodeId("ResourceNode", resourcePk), unitId: createNodeId("UnitNode", unitPk) },
+    },
+    result: { data: { resource, unit } },
+  };
+}
+
+function unitSpacesMock(unitPk = UNIT_PK) {
+  return {
+    request: { query: UnitSpacesDocument, variables: { id: createNodeId("UnitNode", unitPk) } },
+    result: {
+      data: {
+        unit: {
+          id: createNodeId("UnitNode", unitPk),
+          spaces: [{ id: createNodeId("SpaceNode", 2), pk: 2, nameFi: "Space A", parent: null }],
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockRouterReplace.mockReset();
+  mockErrorToast.mockReset();
+  mockSuccessToast.mockReset();
+});
+
+function renderEditor(mocks: ReadonlyArray<MockedResponse>, props: { resourcePk?: number; unitPk?: number } = {}) {
+  return render(
+    <MockedProvider
+      mocks={mocks}
+      defaultOptions={{
+        watchQuery: { fetchPolicy: "no-cache" },
+        query: { fetchPolicy: "no-cache" },
+        mutate: { fetchPolicy: "no-cache" },
+      }}
+    >
+      <ResourceEditor resourcePk={RESOURCE_PK} unitPk={UNIT_PK} {...props} />
+    </MockedProvider>
+  );
+}
+
+describe("ResourceEditor", () => {
+  it("shows a spinner while the resource query is loading", () => {
+    renderEditor([resourceQueryMock(), unitSpacesMock()]);
+    expect(screen.queryByRole("heading", { name: "Resource A" })).not.toBeInTheDocument();
+  });
+
+  it("renders Error404 when the resource is not found", async () => {
+    renderEditor([resourceQueryMock({ resource: null })]);
+    expect(await screen.findByTestId("error__404--title")).toBeInTheDocument();
+  });
+
+  it("renders Error404 when the unit is not found", async () => {
+    renderEditor([resourceQueryMock({ unit: null })]);
+    expect(await screen.findByTestId("error__404--title")).toBeInTheDocument();
+  });
+
+  it("renders Error404 when resourcePk is not provided (query skipped)", async () => {
+    renderEditor([], { resourcePk: undefined });
+    expect(await screen.findByTestId("error__404--title")).toBeInTheDocument();
+  });
+
+  it("renders the editor once the query resolves", async () => {
+    renderEditor([resourceQueryMock(), unitSpacesMock()]);
+    expect(await screen.findByRole("heading", { name: "Resource A" })).toBeInTheDocument();
+    expect(screen.getByText("Unit A")).toBeInTheDocument();
+  });
+
+  it("navigates back to the unit's spaces-resources page on cancel", async () => {
+    renderEditor([resourceQueryMock(), unitSpacesMock()]);
+    await screen.findByRole("heading", { name: "Resource A" });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "common:cancel" }));
+
+    expect(mockRouterReplace).toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+
+  it("disables the save button while the form is pristine", async () => {
+    renderEditor([resourceQueryMock(), unitSpacesMock()]);
+    await screen.findByRole("heading", { name: "Resource A" });
+
+    expect(screen.getByRole("button", { name: "common:save" })).toBeDisabled();
+  });
+
+  it("submits the update and shows a success toast", async () => {
+    const mocks = [
+      resourceQueryMock(),
+      unitSpacesMock(),
+      // updateResource() refetches once, then onSubmit refetches again
+      resourceQueryMock(),
+      resourceQueryMock(),
+      {
+        request: {
+          query: UpdateResourceDocument,
+          variables: {
+            input: {
+              nameFi: "Resource B",
+              nameSv: "Resurssi A",
+              nameEn: "Resource EN",
+              space: 2,
+              pk: RESOURCE_PK,
+              locationType: ResourceLocationType.Fixed,
+            },
+          },
+        },
+        result: { data: { updateResource: { pk: RESOURCE_PK } } },
+      },
+    ];
+    renderEditor(mocks);
+    await screen.findByRole("heading", { name: "Resource A" });
+
+    const user = userEvent.setup();
+    const nameFiInput = screen.getByLabelText(/spaces:ResourceEditor\.label\.nameFi/);
+    await user.clear(nameFiInput);
+    await user.type(nameFiInput, "Resource B");
+
+    await user.click(screen.getByRole("button", { name: "common:save" }));
+
+    await waitFor(() => expect(mockSuccessToast).toHaveBeenCalledWith({ text: "spaces:resourceUpdatedNotification" }));
+    expect(mockRouterReplace).toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+
+  it("shows an error toast when the mutation fails", async () => {
+    const mocks = [
+      resourceQueryMock(),
+      unitSpacesMock(),
+      {
+        request: {
+          query: UpdateResourceDocument,
+          variables: {
+            input: {
+              nameFi: "Resource B",
+              nameSv: "Resurssi A",
+              nameEn: "Resource EN",
+              space: 2,
+              pk: RESOURCE_PK,
+              locationType: ResourceLocationType.Fixed,
+            },
+          },
+        },
+        result: { errors: [new GraphQLError("Error")] },
+      },
+    ];
+    renderEditor(mocks);
+    await screen.findByRole("heading", { name: "Resource A" });
+
+    const user = userEvent.setup();
+    const nameFiInput = screen.getByLabelText(/spaces:ResourceEditor\.label\.nameFi/);
+    await user.clear(nameFiInput);
+    await user.type(nameFiInput, "Resource B");
+
+    await user.click(screen.getByRole("button", { name: "common:save" }));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(mockSuccessToast).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+});

--- a/frontend/apps/staff/src/lib/units/[id]/spaces/[pk]/SpaceEditor.test.tsx
+++ b/frontend/apps/staff/src/lib/units/[id]/spaces/[pk]/SpaceEditor.test.tsx
@@ -1,0 +1,212 @@
+import React from "react";
+import { MockedProvider } from "@apollo/client/testing";
+import type { MockedResponse } from "@apollo/client/testing";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GraphQLError } from "graphql";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createNodeId } from "ui/src/modules/helpers";
+import { SpaceDocument, UnitSpacesDocument, UpdateSpaceDocument } from "@gql/gql-types";
+import { SpaceEditor } from "./SpaceEditor";
+
+const mockRouterReplace = vi.fn();
+vi.mock("next/router", () => ({
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
+
+const mockErrorToast = vi.fn();
+const mockSuccessToast = vi.fn();
+vi.mock("ui/src/components/toast", () => ({
+  errorToast: (...args: unknown[]) => mockErrorToast(...args),
+  successToast: (...args: unknown[]) => mockSuccessToast(...args),
+}));
+
+const SPACE_PK = 10;
+const UNIT_PK = 1;
+
+function unitFragment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: createNodeId("UnitNode", UNIT_PK),
+    pk: UNIT_PK,
+    nameFi: "Unit A",
+    addressStreetFi: "Street 1",
+    addressCityFi: "City",
+    addressZip: "00100",
+    descriptionFi: "desc",
+    spaces: [{ id: createNodeId("SpaceNode", SPACE_PK), pk: SPACE_PK, nameFi: "Space A" }],
+    ...overrides,
+  };
+}
+
+function spaceFragment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: createNodeId("SpaceNode", SPACE_PK),
+    pk: SPACE_PK,
+    nameFi: "Space A",
+    nameSv: "Utrymme A",
+    nameEn: "Space EN",
+    code: "A1",
+    surfaceArea: 20,
+    maxPersons: 10,
+    unit: unitFragment(),
+    parent: null,
+    ...overrides,
+  };
+}
+
+function spaceQueryMock({
+  spacePk = SPACE_PK,
+  space = spaceFragment(),
+}: { spacePk?: number; space?: ReturnType<typeof spaceFragment> | null } = {}) {
+  return {
+    request: { query: SpaceDocument, variables: { id: createNodeId("SpaceNode", spacePk) } },
+    result: { data: { space } },
+  };
+}
+
+function unitSpacesMock(unitPk = UNIT_PK) {
+  return {
+    request: { query: UnitSpacesDocument, variables: { id: createNodeId("UnitNode", unitPk) } },
+    result: {
+      data: {
+        unit: {
+          id: createNodeId("UnitNode", unitPk),
+          spaces: [{ id: createNodeId("SpaceNode", SPACE_PK), pk: SPACE_PK, nameFi: "Space A", parent: null }],
+        },
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  mockRouterReplace.mockReset();
+  mockErrorToast.mockReset();
+  mockSuccessToast.mockReset();
+});
+
+function renderEditor(mocks: ReadonlyArray<MockedResponse>, props: { space?: number; unit?: number } = {}) {
+  return render(
+    <MockedProvider
+      mocks={mocks}
+      defaultOptions={{
+        watchQuery: { fetchPolicy: "no-cache" },
+        query: { fetchPolicy: "no-cache" },
+        mutate: { fetchPolicy: "no-cache" },
+      }}
+    >
+      <SpaceEditor space={SPACE_PK} unit={UNIT_PK} {...props} />
+    </MockedProvider>
+  );
+}
+
+describe("SpaceEditor", () => {
+  it("shows a spinner while the space query is loading", () => {
+    renderEditor([spaceQueryMock(), unitSpacesMock()]);
+    expect(screen.queryByRole("heading", { name: "spaces:SpaceEditor.details" })).not.toBeInTheDocument();
+  });
+
+  it("renders the editor once the query resolves", async () => {
+    renderEditor([spaceQueryMock(), unitSpacesMock()]);
+    expect(await screen.findByRole("heading", { name: "spaces:SpaceEditor.details" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "spaces:noParent" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Unit A" })).toBeInTheDocument();
+  });
+
+  it("navigates back to the unit's spaces-resources page on cancel", async () => {
+    renderEditor([spaceQueryMock(), unitSpacesMock()]);
+    await screen.findByRole("heading", { name: "spaces:SpaceEditor.details" });
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: "common:cancel" }));
+
+    expect(mockRouterReplace).toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+
+  it("disables the save button while the form is pristine", async () => {
+    renderEditor([spaceQueryMock(), unitSpacesMock()]);
+    await screen.findByRole("heading", { name: "spaces:SpaceEditor.details" });
+
+    expect(screen.getByRole("button", { name: "common:save" })).toBeDisabled();
+  });
+
+  it("submits the update and shows a success toast", async () => {
+    const mocks = [
+      spaceQueryMock(),
+      unitSpacesMock(),
+      // refetch after a successful submit
+      spaceQueryMock(),
+      {
+        request: {
+          query: UpdateSpaceDocument,
+          variables: {
+            input: {
+              nameFi: "Space B",
+              nameSv: "Utrymme A",
+              nameEn: "Space EN",
+              maxPersons: 10,
+              unit: UNIT_PK,
+              code: "A1",
+              pk: SPACE_PK,
+              parent: null,
+              surfaceArea: 20,
+            },
+          },
+        },
+        result: { data: { updateSpace: { pk: SPACE_PK } } },
+      },
+    ];
+    renderEditor(mocks);
+    await screen.findByRole("heading", { name: "spaces:SpaceEditor.details" });
+
+    const user = userEvent.setup();
+    const nameFiInput = screen.getByLabelText(/spaces:SpaceEditor\.label\.nameFi/);
+    await user.clear(nameFiInput);
+    await user.type(nameFiInput, "Space B");
+
+    await user.click(screen.getByRole("button", { name: "common:save" }));
+
+    await waitFor(() =>
+      expect(mockSuccessToast).toHaveBeenCalledWith({ text: "spaces:SpaceEditor.spaceUpdatedNotification" })
+    );
+    expect(mockRouterReplace).toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+
+  it("shows an error toast when the mutation fails", async () => {
+    const mocks = [
+      spaceQueryMock(),
+      unitSpacesMock(),
+      {
+        request: {
+          query: UpdateSpaceDocument,
+          variables: {
+            input: {
+              nameFi: "Space B",
+              nameSv: "Utrymme A",
+              nameEn: "Space EN",
+              maxPersons: 10,
+              unit: UNIT_PK,
+              code: "A1",
+              pk: SPACE_PK,
+              parent: null,
+              surfaceArea: 20,
+            },
+          },
+        },
+        result: { errors: [new GraphQLError("Error")] },
+      },
+    ];
+    renderEditor(mocks);
+    await screen.findByRole("heading", { name: "spaces:SpaceEditor.details" });
+
+    const user = userEvent.setup();
+    const nameFiInput = screen.getByLabelText(/spaces:SpaceEditor\.label\.nameFi/);
+    await user.clear(nameFiInput);
+    await user.type(nameFiInput, "Space B");
+
+    await user.click(screen.getByRole("button", { name: "common:save" }));
+
+    await waitFor(() => expect(mockErrorToast).toHaveBeenCalled());
+    expect(mockSuccessToast).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalledWith(`/units/${UNIT_PK}/spaces-resources`);
+  });
+});

--- a/frontend/apps/staff/vitest.config.mts
+++ b/frontend/apps/staff/vitest.config.mts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: "happy-dom",
     setupFiles: ["./vitest.setup.ts"],
     reporters: ["verbose"],
+    testTimeout: 10_000,
     coverage: {
       reporter: ["clover", "json", "lcov", "text"],
       include: ["src/**/*"],


### PR DESCRIPTION
## 🛠️ Changelog
[//]: # "Describe the changes in this pull request here."

Should push Sonar code coverage to ~65% for both applications.

## 🧪 Test plan
[//]: # "Help your fellow reviewer and write a short description of the fastest way to test your changes."

- Automated tests

## 🚧 Dependencies
[//]: # "Is this PR dependent on other changes outside this repository? Describe the changes, or add links to them."
[//]: # "e.g. This PR breaks X and is waiting for frontend changes before merging."

- None

## 🎫 Tickets
[//]: # "This pull request resolves all or part of the following ticket(s)."

- [TILA-](https://helsinkisolutionoffice.atlassian.net/browse/TILA-)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded automated coverage across customer and staff applications for search, filters, tables, loaders, forms, dialogs, editors, navigation, and data handling.
  - Added checks for loading, empty, error, pagination, sorting, validation, responsive, localized-link, image-fallback, and interaction states.
  - Added coverage for reservation workflows and editor behavior.
  - Increased selected test timeouts and configured a standard staff-app test timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->